### PR TITLE
only display '[Read More]' link if post is truncated

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -48,8 +48,12 @@
               </p>
             
               <div class="post-entry">
+              {{ if .Truncated }}
                 {{ .Summary }}
           	  <a href="{{ .Permalink }}" class="post-read-more">[Read&nbsp;More]</a>
+              {{ else }}
+                {{ .Content }}
+              {{ end }}	
               </div>
             
              </article>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -318,6 +318,7 @@ footer .theme-by {
 }
 .post-preview .post-read-more {
   font-weight: 800;
+  float: right;
 }
 
 @media only screen and (min-width: 768px) {


### PR DESCRIPTION
The beautifulhugo theme includes a '[Read More]' link, even on short posts that are not truncated. For example, both 'Soccer' and 'Pirates arrrr' display the '[Read More]' link; however, 'Pirates arrrr' is displayed in its entirety and therefore doesn't need to display the link: 

<img width="1280" alt="screenshot 2016-09-25 08 41 34" src="https://cloud.githubusercontent.com/assets/159040/18816419/35041bae-830f-11e6-9ba2-b2766547a967.png">

This pull request modifies the theme to exclude the '[Read More]' link when the post is short enough to be displayed in its entirely (i.e. not truncated):

<img width="1280" alt="screenshot 2016-09-25 08 51 33 2" src="https://cloud.githubusercontent.com/assets/159040/18816432/7c8d8c44-830f-11e6-9587-2fc98024fb6b.png">
