### PR TITLE
only display '[Read More]' link if post is truncated

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -48,8 +48,12 @@
               </p>
             
               <div class="post-entry">
+              {{ if .Truncated }}
                 {{ .Summary }}
-          	  <a href="{{ .Permalink }}" class="post-read-more">[Read&nbsp;More]</a>
+                <a href="{{ .Permalink }}" class="post-read-more">[Read&nbsp;More]</a>
+              {{ else }}
+                {{ .Content }}
+              {{ end }}
               </div>
             
              </article>


### PR DESCRIPTION
The beautifulhugo theme includes a '[Read More]' link, even on short posts that are not truncated. For example, both 'Code Sample' and 'First Post!' display the '[Read More]' link; however, 'First Post!' is displayed in its entirety and therefore doesn't need to display the link: 

![screenshot 2017-02-18 12 34 38](https://cloud.githubusercontent.com/assets/159040/23095936/69c5acd6-f5d8-11e6-9216-4d31dae1c2ea.png)

This pull request modifies the theme to exclude the '[Read More]' link when the post is short enough to be displayed in its entirely (i.e. not truncated):

![screenshot 2017-02-18 12 46 49](https://cloud.githubusercontent.com/assets/159040/23095939/722f67d6-f5d8-11e6-96d1-5dbb336eef15.png)
