### PR TITLE
User header_wp.html partial in index.html

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -6,47 +6,7 @@
   <body>
 
     {{ partial "nav.html" . }}
-
-    {{ if isset .Site.Params.bigimg 0 }}
-      <div id="header-big-imgs" data-num-img={{len .Site.Params.bigimg}} {{range $i, $img := .Site.Params.bigimg}}data-img-src-{{add $i 1}}="{{$img.src}}" data-img-desc-{{add $i 1}}="{{$img.desc}}"{{end}}></div>
-    {{ end }}
-
-   <header class="header-section {{ if isset .Site.Params.bigimg 0 }}has-img{{ end }}">
-      {{ if isset .Site.Params.bigimg 0 }}
-        <div class="intro-header big-img">
-          <div class="container">
-            <div class="row">
-              <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
-                <div class="page-heading">
-                  <h1>{{.Site.Title}}</h1>
-                  {{if .Site.Params.subtitle}}
-                    <hr class="small">
-                    <span class="page-subheading">{{.Site.Params.subtitle}}</span>
-                  {{end}}
-                </div>
-              </div>
-            </div>
-          </div>
-          <span class="img-desc" style="display: inline;"></span>
-        </div>
-      {{end}}
-      <div class="intro-header no-img">
-        <div class="container">
-          <div class="row">
-            <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
-              <div class="page-heading">
-                <h1>{{.Site.Title}}</h1>
-                {{if .Site.Params.subtitle}}
-                  <hr class="small">
-                  <span class="page-subheading">{{.Site.Params.subtitle}}</span>
-                {{end}}
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </header>
-
+    {{ partial "header_wp.html" . }}
 
     <div role="main" class="container">
       <div class="row">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,17 +1,18 @@
+{{ $subtitle := $.Scratch.Get "subtitle" }}
+
   <div class="container">
     <div class="row">
       <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
         <div class="{{ .Type }}-heading">
-          <h1>{{ if .Title }}{{ .Title }}{{ else }}<br/>{{ end }}</h1>
-            {{ if .Params.subtitle }}
+          <h1>{{ with $.Scratch.Get "title" }}{{.}}{{ else }}<br/>{{ end }}</h1>
+            {{ if $subtitle }}
               {{ if eq .Type "page" }}
                 <hr class="small">
-                <span class="{{ .Type }}-subheading">{{ .Params.subtitle }}</span>
+                <span class="{{ .Type }}-subheading">{{ $subtitle }}</span>
               {{ else }}
-                <h2 class="{{ .Type }}-subheading">{{ .Params.subtitle }}</h2>
+                <h2 class="{{ .Type }}-subheading">{{ $subtitle }}</h2>
               {{ end }}
             {{ end }}
-
             {{ if eq .Type "post" }}
               <span class="post-meta">Posted on {{ .Date.Format .Site.Params.dateFormat }}</span>
             {{ end }}

--- a/layouts/partials/header_wp.html
+++ b/layouts/partials/header_wp.html
@@ -1,14 +1,25 @@
-{{ if or .Params.bigimg .Title }}
-  {{ if isset .Params.bigimg 0 }}
-    <div id="header-big-imgs" data-num-img={{len .Params.bigimg}} {{range $i, $img := .Params.bigimg}}data-img-src-{{add $i 1}}="{{$img.src}}" {{ if $img.desc}}data-img-desc-{{add $i 1}}="{{$img.desc}}"{{end}}{{end}}></div>
+{{ if .IsHome }}
+  {{ $.Scratch.Add "bigimg" .Site.Params.bigimg }}
+  {{ $.Scratch.Add "title" .Site.Title }}
+  {{ $.Scratch.Add "subtitle" .Site.Params.subtitle }}
+{{ else }}
+  {{ $.Scratch.Add "bigimg" .Params.bigimg }}
+  {{ $.Scratch.Add "title" .Title }}
+  {{ $.Scratch.Add "subtitle" .Params.subtitle }}
+{{ end }}
+{{ $bigimg := $.Scratch.Get "bigimg" }}
+
+{{ if or $bigimg ($.Scratch.Get "title") }}
+  {{ if isset $bigimg 0 }}
+    <div id="header-big-imgs" data-num-img={{len $bigimg}} {{range $i, $img := $bigimg}}data-img-src-{{add $i 1}}="{{$img.src}}" {{ if $img.desc}}data-img-desc-{{add $i 1}}="{{$img.desc}}"{{end}}{{end}}></div>
   {{ end }}
 
-  <header class="header-section {{ if isset .Params.bigimg 0 }}has-img{{ end }}">
-    {{ if isset .Params.bigimg 0 }}
-      <div class="intro-header big-img">
-        {{ partial "header.html" . }}
-        <span class="img-desc" style="display: inline;"></span>
-      </div>
+  <header class="header-section {{ if isset $bigimg 0 }}has-img{{ end }}">
+    {{ if isset $bigimg 0 }}
+    <div class="intro-header big-img">
+      {{ partial "header.html" . }}
+      <span class="img-desc" style="display: inline;"></span>
+    </div>
     {{end}}
     <div class="intro-header no-img">
       {{ partial "header.html" . }}


### PR DESCRIPTION
The purpose of this change is to reduce duplicated code, and ensure that the header (bigimg/title/subtitle) is handled exactly the same way on the homepage as on content pages. There should be no change in functionality or performance.
- Changed header_wp.html and header.html so that they will also work on
the homepage (if the current page is the homepage then use the site
bigimg/title/subtitle, otherwise use the page bigimg/title/subtitle;
need to add them to the scratchpad so that they are accessible outside
the scope of the if/else statement).
- Change index.html to use the header_wp.html partial instead of
duplicating the same code.