### PR TITLE
Ignore vim swap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
+# Vim swap files
+*.swp
+
 # =========================
 # Operating System Files
 # =========================


### PR DESCRIPTION
Add vim's .swp files to .gitignore. These files are created by vim
whenever you open a file, so if you have a file open while running
"git status", the .swp file will show up as untracked, which is
kind of annoying.