### PR TITLE
Use .Summary instead of .Content for og:description and twitter:description

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -38,7 +38,7 @@
   {{ else if .Params.subtitle }}
     <meta property="og:description" content="{{ .Params.subtitle }}">
   {{ else }}
-    <meta property="og:description" content="{{ .Content | plainify | htmlEscape | truncate 200 }}">
+    <meta property="og:description" content="{{ .Summary }}">
   {{ end }}
 
   <meta property="og:type" content="website" />
@@ -77,7 +77,7 @@
   {{ else if .Params.subtitle }}
     <meta name="twitter:description" content="{{ .Params.subtitle }}">
   {{ else }}
-    <meta name="twitter:description" content="{{ .Content | plainify | htmlEscape | truncate 200 }}">
+    <meta name="twitter:description" content="{{ .Summary }}">
   {{ end }}
 
   {{ if .Params.share_img }}


### PR DESCRIPTION
`.Summary` is much simpler than `.Content | plainify | htmlEscape | truncate 200` and it also automatically cuts off the content after `<!--more-->`