### PR TITLE
Added support for Google Custom Search Engine

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -16,6 +16,7 @@ pygmentCodeFences = true
   commit = false
   rss = true
   comments = true
+#  gcse = "012345678901234567890:abcdefghijk" # Get your code from google.com/cse. Make sure to go to "Look and Feel" and change Layout to "Full Width" and Theme to "Classic"
 
 #[[Params.bigimg]]
 #  src = "img/triangle.jpg"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -205,5 +205,17 @@
 <script src="{{ .Site.BaseURL }}/js/highlight.min.js"></script>
 <script> hljs.initHighlightingOnLoad(); </script>
 <script> renderMathInElement(document.body); </script>
+<!-- Google Custom Search Engine -->
+<script>
+  (function() {
+    var cx = '{{ .Site.Params.gcse }}';
+    var gcse = document.createElement('script');
+    gcse.type = 'text/javascript';
+    gcse.async = true;
+    gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(gcse, s);
+  })();
+</script>
 
 {{ template "_internal/google_analytics.html" . }}

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -28,6 +28,13 @@
             </li>
           {{ end }}
         {{ end }}
+        {{ if isset .Site.Params "gcse" }}
+          <li>
+            <a href="#modalSearch" data-toggle="modal" data-target="#modalSearch" style="outline: none;">
+              <span class="hidden-sm hidden-md hidden-lg">Search</span> <span id="searchGlyph" class="glyphicon glyphicon-search"></span>
+            </a>
+          </li>
+        {{ end }}
       </ul>
     </div>
 
@@ -43,3 +50,23 @@
 
   </div>
 </nav>
+
+<!-- Search Modal -->
+{{ if isset .Site.Params "gcse" }}
+  <div id="modalSearch" class="modal fade" role="dialog">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal">&times;</button>
+          <h4 class="modal-title">Search {{ .Site.Title }}</h4>
+        </div>
+        <div class="modal-body">
+          <gcse:search></gcse:search>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+{{ end }}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -681,3 +681,17 @@ td.gutter {
 #social-share-section {
   margin-bottom: 30px;
 }
+
+/* --- Google Custom Search Engine Popup --- */
+#modalSearch table tr, #modalSearch table tr td, #modalSearch table tr th {
+  border:none;
+}
+.reset-box-sizing, .reset-box-sizing *, .reset-box-sizing *:before, .reset-box-sizing *:after,  .gsc-inline-block {
+  -webkit-box-sizing: content-box;
+  -moz-box-sizing: content-box;
+  box-sizing: content-box;
+}
+input.gsc-input, .gsc-input-box, .gsc-input-box-hover, .gsc-input-box-focus, .gsc-search-button {
+  box-sizing: content-box;
+  line-height: normal;
+}


### PR DESCRIPTION
Added support for Google Custom Search Engine using instructions at  https://www.cambiaresearch.com/articles/84/how-to-integrate-a-google-custom-search-popup-in-a-bootstrap-navbar

Live demo at https://www.liwen.id.au/

NB to make sure everything behaves properly, it's very important to set Layout to "Full Width":

![image](https://cloud.githubusercontent.com/assets/16456010/24324071/718a3594-1177-11e7-803d-d85738b6eb7f.png)

And set theme to "Classic":

![image](https://cloud.githubusercontent.com/assets/16456010/24324075/887c2da2-1177-11e7-9458-2afcda9fcf7e.png)
