### PR TITLE
Add default "posted on" text in a new partial template

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -39,7 +39,7 @@
                 </a>
       
                 <p class="post-meta">
-                  Posted on {{ .Date.Format .Site.Params.dateFormat }}
+                  {{ partial "posted-on-date.html" . }}
                 </p>
                 <div class="post-entry">
                   {{ if .Truncated }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -31,7 +31,7 @@
               </a>
 
               <p class="post-meta">
-                Posted on {{ .Date.Format .Site.Params.dateFormat }}
+                {{ partial "posted-on-date.html" . }}
               </p>
               <div class="post-entry">
                 {{ if .Truncated }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -32,7 +32,7 @@
                     {{ end }}
                   {{ end }}
                   {{ if eq .Type "post" }}
-                    <span class="post-meta">Posted on {{ .Date.Format .Site.Params.dateFormat }}</span>
+                    <span class="post-meta">{{ partial "posted-on-date.html" . }}</span>
                   {{ end }}
               </div>
             </div>
@@ -57,7 +57,7 @@
                   {{ end }}
                 {{ end }}
                 {{ if eq .Type "post" }}
-                  <span class="post-meta">Posted on {{ .Date.Format .Site.Params.dateFormat }}</span>
+                  <span class="post-meta">{{ partial "posted-on-date.html" . }}</span>
                 {{ end }}
             </div>
           </div>

--- a/layouts/partials/posted-on-date.html
+++ b/layouts/partials/posted-on-date.html
@@ -1,0 +1,1 @@
+Posted on {{ .Date.Format (default "January 2, 2006" .Site.Params.dateFormat) }}


### PR DESCRIPTION
If sites don't have `.Site.Params.dateFormat` set, then Hugo aborts
when trying to render `{{ .Date.Format .Site.Params.dateFormat }}`,
leading to the index page missing post previews and the footer,
and post pages having all the content styled with the "post-meta"
class.

To fix this, specify a default value, and put it in a new partial
template so that there is only one place we have to change it if
we need to.