### PR TITLE
Fix issues with title, subtitle, and bigimg on page 2

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,17 +1,17 @@
 {{ if .IsHome }}
-  {{ $.Scratch.Add "title" .Site.Title }}
-  {{ if .Site.Params.subtitle }}{{ $.Scratch.Add "subtitle" .Site.Params.subtitle }}{{ end }}
-  {{ if .Site.Params.bigimg }}{{ $.Scratch.Add "bigimg" .Site.Params.bigimg }}{{ end }}
+  {{ $.Scratch.Set "title" .Site.Title }}
+  {{ if .Site.Params.subtitle }}{{ $.Scratch.Set "subtitle" .Site.Params.subtitle }}{{ end }}
+  {{ if .Site.Params.bigimg }}{{ $.Scratch.Set "bigimg" .Site.Params.bigimg }}{{ end }}
 {{ else }}
-  {{ $.Scratch.Add "title" .Title }}
-  {{ if .Params.subtitle }}{{ $.Scratch.Add "subtitle" .Params.subtitle }}{{ end }}
-  {{ if .Params.bigimg }}{{ $.Scratch.Add "bigimg" .Params.bigimg }}{{ end }}
+  {{ $.Scratch.Set "title" .Title }}
+  {{ if .Params.subtitle }}{{ $.Scratch.Set "subtitle" .Params.subtitle }}{{ end }}
+  {{ if .Params.bigimg }}{{ $.Scratch.Set "bigimg" .Params.bigimg }}{{ end }}
 {{ end }}
 {{ $bigimg := $.Scratch.Get "bigimg" }}
 
 {{ if or $bigimg ($.Scratch.Get "title") }}
   {{ if isset $bigimg 0 }}
-    <div id="header-big-imgs" data-num-img={{len $bigimg}} {{range $i, $img := $bigimg}}data-img-src-{{add $i 1}}="{{$img.src}}" {{ if $img.desc}}data-img-desc-{{add $i 1}}="{{$img.desc}}"{{end}}{{end}}></div>
+    <div id="header-big-imgs" data-num-img={{len $bigimg}} {{range $i, $img := $bigimg}}data-img-src-{{add $i 1}}="{{$img.src | absURL }}" {{ if $img.desc}}data-img-desc-{{add $i 1}}="{{$img.desc}}"{{end}}{{end}}></div>
   {{ end }}
 
   <header class="header-section {{ if isset $bigimg 0 }}has-img{{ end }}">


### PR DESCRIPTION
For some reason these statements in `header.html` are being evaluated twice if you're on page 2 of the homepage:
```
  {{ $.Scratch.Add "title" .Site.Title }}
  {{ if .Site.Params.subtitle }}{{ $.Scratch.Add "subtitle" .Site.Params.subtitle }}{{ end }}
  {{ if .Site.Params.bigimg }}{{ $.Scratch.Add "bigimg" .Site.Params.bigimg }}{{ end }}
```
No idea why this is, but changing `Add` to `Set` solves the symptoms.

Also changed the `bigimg` images to be an absolute URL so they work from paths other than `/`

# Before:
![2017-03-26 13_53_23-localhost_1313_page_2_](https://cloud.githubusercontent.com/assets/16456010/24331452/bfa25f30-122c-11e7-9f28-7b3df9377157.png)

# After:
![2017-03-26 13_52_54-localhost_1313_page_2_](https://cloud.githubusercontent.com/assets/16456010/24331454/c9e9ffa2-122c-11e7-8cf5-06fe0695cdd5.png)

