### PR TITLE
Split the social icon data out from the footer template

### DIFF
--- a/data/social.toml
+++ b/data/social.toml
@@ -1,0 +1,96 @@
+[[social_icons]]
+id = "email"
+url = "mailto:%s"
+title = "Email me"
+icon = "fa-envelope"
+
+[[social_icons]]
+id = "facebook"
+url = "https://www.facebook.com/%s"
+title = "Facebook"
+icon = "fa-facebook"
+
+[[social_icons]]
+id = "googleplus"
+url = "https://www.plus.google.com/%s"
+title = "Google+"
+icon = "fa-google-plus"
+
+[[social_icons]]
+id = "github"
+url = "https://github.com/%s"
+title = "GitHub"
+icon = "fa-github"
+
+[[social_icons]]
+id = "twitter"
+url = "https://twitter.com/%s"
+title = "Twitter"
+icon = "fa-twitter"
+
+[[social_icons]]
+id = "reddit"
+url = "https://reddit.com/u/%s"
+title = "Reddit"
+icon = "fa-reddit-alien"
+
+[[social_icons]]
+id = "linkedin"
+url = "https://linkedin.com/in/%s"
+title = "LinkedIn"
+icon = "fa-linkedin"
+
+[[social_icons]]
+id = "xing"
+url = "https://www.xing.com/profile/%s"
+title = "Xing"
+icon = "fa-xing"
+
+[[social_icons]]
+id = "stackoverflow"
+url = "https://stackoverflow.com/%s"
+title = "StackOverflow"
+icon = "fa-stack-overflow"
+
+[[social_icons]]
+id = "snapchat"
+url = "https://www.snapchat.com/add/%s"
+title = "Snapchat"
+icon = "fa-snapchat-ghost"
+
+[[social_icons]]
+id = "instagram"
+url = "https://www.instagram.com/%s"
+title = "Instagram"
+icon = "fa-instagram"
+
+[[social_icons]]
+id = "youtube"
+url = "https://www.youtube.com/%s"
+title = "Youtube"
+icon = "fa-youtube"
+
+[[social_icons]]
+id = "soundcloud"
+url = "https://soundcloud.com/%s"
+title = "SoundCloud"
+icon = "fa-soundcloud"
+
+[[social_icons]]
+id = "spotify"
+url = "https://open.spotify.com/user/%s"
+title = "Spotify"
+icon = "fa-spotify"
+
+[[social_icons]]
+id = "bandcamp"
+url = "https://%s.bandcamp.com/"
+title = "Bandcamp"
+icon = "fa-bandcamp"
+
+[[social_icons]]
+id = "itchio"
+url = "https://itch.io/profile/%s"
+title = "Itch.io"
+icon = "fa-gamepad"
+

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -3,165 +3,17 @@
     <div class="row">
       <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
         <ul class="list-inline text-center footer-links">
-          {{ if .Site.Author.email }}
-          <li>
-            <a href="mailto:{{ .Site.Author.email }}" title="Email me">
-              <span class="fa-stack fa-lg">
-                <i class="fa fa-circle fa-stack-2x"></i>
-                <i class="fa fa-envelope fa-stack-1x fa-inverse"></i>
-              </span>
-            </a>
-          </li>
-          {{ end }}
-          {{ if .Site.Author.facebook }}
-          <li>
-            <a href="https://www.facebook.com/{{ .Site.Author.facebook }}" title="Facebook">
-              <span class="fa-stack fa-lg">
-                <i class="fa fa-circle fa-stack-2x"></i>
-                <i class="fa fa-facebook fa-stack-1x fa-inverse"></i>
-              </span>
-            </a>
-          </li>
-          {{ end }}
-          {{ if .Site.Author.googleplus }}
-          <li>
-            <a href="https://www.plus.google.com/{{ .Site.Author.googleplus }}" title="Google+">
-              <span class="fa-stack fa-lg">
-                <i class="fa fa-circle fa-stack-2x"></i>
-                <i class="fa fa-google-plus fa-stack-1x fa-inverse"></i>
-              </span>
-            </a>
-          </li>
-          {{ end }}
-          {{ if .Site.Author.github }}
-          <li>
-            <a href="https://github.com/{{ .Site.Author.github }}" title="GitHub">
-              <span class="fa-stack fa-lg">
-                <i class="fa fa-circle fa-stack-2x"></i>
-                <i class="fa fa-github fa-stack-1x fa-inverse"></i>
-              </span>
-            </a>
-          </li>
-          {{ end }}
-          {{ if .Site.Author.twitter }}
-          <li>
-            <a href="https://twitter.com/{{ .Site.Author.twitter }}" title="Twitter">
-              <span class="fa-stack fa-lg">
-                <i class="fa fa-circle fa-stack-2x"></i>
-                <i class="fa fa-twitter fa-stack-1x fa-inverse"></i>
-              </span>
-            </a>
-          </li>
-          {{ end }}
-          {{ if .Site.Author.reddit }}
-          <li>
-            <a href="https://reddit.com/u/{{ .Site.Author.reddit }}" title="Reddit">
-              <span class="fa-stack fa-lg">
-                <i class="fa fa-circle fa-stack-2x"></i>
-                <i class="fa fa-reddit-alien fa-stack-1x fa-inverse"></i>
-              </span>
-            </a>
-          </li>
-          {{ end }}
-          {{ if .Site.Author.linkedin }}
-          <li>
-            <a href="https://linkedin.com/in/{{ .Site.Author.linkedin }}" title="LinkedIn">
-              <span class="fa-stack fa-lg">
-                <i class="fa fa-circle fa-stack-2x"></i>
-                <i class="fa fa-linkedin fa-stack-1x fa-inverse"></i>
-              </span>
-            </a>
-          </li>
-          {{ end }}
-          {{ if .Site.Author.xing }}
-          <li>
-            <a href="https://www.xing.com/profile/{{ .Site.Author.xing }}" title="Xing">
-              <span class="fa-stack fa-lg">
-                <i class="fa fa-circle fa-stack-2x"></i>
-                <i class="fa fa-xing fa-stack-1x fa-inverse"></i>
-              </span>
-            </a>
-          </li>
-          {{ end }}
-          {{ if .Site.Author.stackoverflow }}
-          <li>
-            <a href="https://stackoverflow.com/{{ .Site.Author.stackoverflow }}" title="StackOverflow">
-              <span class="fa-stack fa-lg">
-                <i class="fa fa-circle fa-stack-2x"></i>
-                <i class="fa fa-stack-overflow fa-stack-1x fa-inverse"></i>
-              </span>
-            </a>
-          </li>
-          {{ end }}
-          {{ if .Site.Author.snapchat }}
-          <li>
-            <a href="https://www.snapchat.com/add/{{ .Site.Author.snapchat }}" title="Snapchat">
-              <span class="fa-stack fa-lg">
-                <i class="fa fa-circle fa-stack-2x"></i>
-                <i class="fa fa-snapchat-ghost fa-stack-1x fa-inverse"></i>
-              </span>
-            </a>
-          </li>
-          {{ end }}
-          {{ if .Site.Author.instagram }}
-          <li>
-            <a href="https://www.instagram.com/{{ .Site.Author.instagram }}" title="Instagram">
-              <span class="fa-stack fa-lg">
-                <i class="fa fa-circle fa-stack-2x"></i>
-                <i class="fa fa-instagram fa-stack-1x fa-inverse"></i>
-              </span>
-            </a>
-          </li>
-          {{ end }}
-          {{ if .Site.Author.youtube }}
-          <li>
-            <a href="https://www.youtube.com/{{ .Site.Author.youtube }}" title="Youtube">
-              <span class="fa-stack fa-lg">
-                <i class="fa fa-circle fa-stack-2x"></i>
-                <i class="fa fa-youtube fa-stack-1x fa-inverse"></i>
-              </span>
-            </a>
-          </li>
-          {{ end }}
-          {{ if .Site.Author.soundcloud }}
-          <li>
-            <a href="https://soundcloud.com/{{ .Site.Author.soundcloud }}" title="SoundCloud">
-              <span class="fa-stack fa-lg">
-                <i class="fa fa-circle fa-stack-2x"></i>
-                <i class="fa fa-soundcloud fa-stack-1x fa-inverse"></i>
-              </span>
-            </a>
-          </li>
-          {{ end }}
-          {{ if .Site.Author.spotify }}
-          <li>
-            <a href="https://open.spotify.com/user/{{ .Site.Author.spotify }}" title="Spotify">
-              <span class="fa-stack fa-lg">
-                <i class="fa fa-circle fa-stack-2x"></i>
-                <i class="fa fa-spotify fa-stack-1x fa-inverse"></i>
-              </span>
-            </a>
-          </li>
-          {{ end }}
-          {{ if .Site.Author.bandcamp }}
-          <li>
-            <a href="https://{{ .Site.Author.bandcamp }}.bandcamp.com/" title="Bandcamp">
-              <span class="fa-stack fa-lg">
-                <i class="fa fa-circle fa-stack-2x"></i>
-                <i class="fa fa-bandcamp fa-stack-1x fa-inverse"></i>
-              </span>
-            </a>
-          </li>
-          {{ end }}
-          {{ if .Site.Author.itchio }}
-          <li>
-            <a href="https://itch.io/profile/{{ .Site.Author.itchio }}" title="Itch.io">
-              <span class="fa-stack fa-lg">
-                <i class="fa fa-circle fa-stack-2x"></i>
-                <i class="fa fa-gamepad fa-stack-1x fa-inverse"></i>
-              </span>
-            </a>
-          </li>
+          {{ range .Site.Data.social.social_icons }}
+            {{- if isset $.Site.Author .id }}
+              <li>
+                <a href="{{ printf .url (index $.Site.Author .id) }}" title="{{ .title }}">
+                  <span class="fa-stack fa-lg">
+                    <i class="fa fa-circle fa-stack-2x"></i>
+                    <i class="fa {{ .icon }} fa-stack-1x fa-inverse"></i>
+                  </span>
+                </a>
+              </li>
+            {{- end -}}
           {{ end }}
           {{ if .Site.Params.rss }}
           <li>


### PR DESCRIPTION
Add a "social.toml" data file to hold the data for all the social
icons in the footer template. This reduces repetition in the
template code and makes it easier to reuse the data in other
parts of the theme, should that be desired in the future.

It also makes it easier for end users to add new icons by just
overriding the data file, instead of having to override the whole
footer template.