### PR TITLE
Add empty partials for custom html in head and footer

### DIFF
--- a/exampleSite/layouts/partials/footer_custom.html
+++ b/exampleSite/layouts/partials/footer_custom.html
@@ -1,0 +1,7 @@
+<!--
+If you want to include any custom html just before </body>, put it in this file.
+Or you can delete these file if you don't need it.
+-->
+<!-- for example, you could include some js libraries:
+<script src="https://cdnjs.cloudflare.com/ajax/libs/vis/4.19.1/vis.js" integrity="sha256-HdIuWBZj4eftihsoDCJoMYjZi6aNVaw7YlUpzKT3ZxI=" crossorigin="anonymous"></script>
+-->

--- a/exampleSite/layouts/partials/head_custom.html
+++ b/exampleSite/layouts/partials/head_custom.html
@@ -1,0 +1,18 @@
+<!--
+If you want to include any custom html just before </head>, put it in this file.
+Or you can delete these file if you don't need it.
+-->
+<!-- for example, you could insert this custom css, which makes the bigimg not stretch:
+<style>
+.intro-header.big-img, .intro-header.big-img  .big-img-transition {
+  -webkit-background-size: contain !important;
+  -moz-background-size: contain !important;
+  background-size: contain !important;
+  -o-background-size: contain !important;
+  background-color: lightgrey;
+}
+</style>
+-->
+<!-- or you could include some additional css libraries:
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/vis/4.19.1/vis.css" integrity="sha256-I1UoFd33KHIydu88R9owFaQWzwkiZV4hXXug5aYaM28=" crossorigin="anonymous" />
+-->

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -76,3 +76,4 @@
 {{ end }}
 
 {{ template "_internal/google_analytics.html" . }}
+{{- partial "footer_custom.html" . }}

--- a/layouts/partials/footer_custom.html
+++ b/layouts/partials/footer_custom.html
@@ -1,0 +1,4 @@
+<!--
+If you want to include any custom html just before </body>, put it in /layouts/footer_custom.html
+Do not put anything in this file - it's only here so that hugo won't throw an error if /layouts/footer_custom.html doesn't exist.
+-->

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -46,4 +46,5 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800" />
   <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/pygment_highlights.css" />
   <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/highlight.min.css" />
+{{- partial "head_custom.html" . }}
 </head>

--- a/layouts/partials/head_custom.html
+++ b/layouts/partials/head_custom.html
@@ -1,0 +1,4 @@
+<!--
+If you want to include any custom html just before </head>, put it in /layouts/head_custom.html
+Do not put anything in this file - it's only here so that hugo won't throw an error if /layouts/head_custom.html doesn't exist.
+-->


### PR DESCRIPTION
As per https://gohugo.io/templates/partials/:

> Theme developers may want to include a few partials with empty HTML files in the theme just so end users have an easy place to inject their customized content.

Resolves #42