### PR TITLE
Removed duplicated main div, because it is included in single

### DIFF
--- a/layouts/partials/page.html
+++ b/layouts/partials/page.html
@@ -1,14 +1,12 @@
-<div class="container" role="main">
-  <div class="row">
-    <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
-      {{ .Content }}
-      {{ if (.Params.comments) | or (and (or (not (isset .Params "comments")) (eq .Params.comments nil)) (.Site.Params.comments)) }}
-        {{ if .Site.DisqusShortname }}
-          <div class="disqus-comments">
-            {{ template "_internal/disqus.html" . }}
-          </div>
-        {{ end }}
+<div class="row">
+  <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
+    {{ .Content }}
+    {{ if (.Params.comments) | or (and (or (not (isset .Params "comments")) (eq .Params.comments nil)) (.Site.Params.comments)) }}
+      {{ if .Site.DisqusShortname }}
+        <div class="disqus-comments">
+          {{ template "_internal/disqus.html" . }}
+        </div>
       {{ end }}
-    </div>
+    {{ end }}
   </div>
 </div>

--- a/layouts/partials/post.html
+++ b/layouts/partials/post.html
@@ -1,31 +1,29 @@
-<div class="container">
-  <div class="row">
-    <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
-      <article role="main" class="blog-post">
-        {{ .Content }}
-      </article>
+<div class="row">
+  <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
+    <article role="main" class="blog-post">
+      {{ .Content }}
+    </article>
 
-      <ul class="pager blog-pager">
-        {{ if .PrevInSection }}
-          <li class="previous">
-            <a href="{{ .PrevInSection.Permalink }}" data-toggle="tooltip" data-placement="top" title="{{ .PrevInSection.Title }}">&larr; Previous Post</a>
-          </li>
-        {{ end }}
-        {{ if .NextInSection }}
-          <li class="next">
-            <a href="{{ .NextInSection.Permalink }}" data-toggle="tooltip" data-placement="top" title="{{ .NextInSection.Title }}">Next Post &rarr;</a>
-          </li>
-        {{ end }}
-      </ul>
-
-      {{ if (.Params.comments) | or (and (or (not (isset .Params "comments")) (eq .Params.comments nil)) (.Site.Params.comments)) }}
-        {{ if .Site.DisqusShortname }}
-          <div class="disqus-comments">
-            {{ template "_internal/disqus.html" . }}
-          </div>
-        {{ end }}
+     <ul class="pager blog-pager">
+      {{ if .PrevInSection }}
+        <li class="previous">
+          <a href="{{ .PrevInSection.Permalink }}" data-toggle="tooltip" data-placement="top" title="{{ .PrevInSection.Title }}">&larr; Previous Post</a>
+        </li>
       {{ end }}
+      {{ if .NextInSection }}
+        <li class="next">
+          <a href="{{ .NextInSection.Permalink }}" data-toggle="tooltip" data-placement="top" title="{{ .NextInSection.Title }}">Next Post &rarr;</a>
+        </li>
+      {{ end }}
+    </ul>
 
-    </div>
+    {{ if (.Params.comments) | or (and (or (not (isset .Params "comments")) (eq .Params.comments nil)) (.Site.Params.comments)) }}
+      {{ if .Site.DisqusShortname }}
+        <div class="disqus-comments">
+          {{ template "_internal/disqus.html" . }}
+        </div>
+      {{ end }}
+    {{ end }}
+
   </div>
 </div>


### PR DESCRIPTION
It is defined once in single, and once more in page/post, which causes the main body to have larger left-padding that expected. I remove `-<div class="container">` from `page.html` and `post.html`. So many changes are shown because I removed a level of indentation.