### PR TITLE
Update the required Hugo version in theme.toml

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -4,7 +4,7 @@ licenselink = "https://github.com/halogenica/Hugo-BeautifulHugo/blob/master/LICE
 description = "A port of Beautiful Jekyll theme"
 tags = ["blog", "company", "portfolio", "projects", "minimal", "responsive"]
 features = ["blog", "themes", "disqus", "minimal", "responsive"]
-min_version = 0.15
+min_version = 0.17
 
 [author]
     name = "halogenica"
@@ -15,3 +15,4 @@ min_version = 0.15
     author =  "dattali"
     homepage = "http://deanattali.com/beautiful-jekyll/"
     repo = "https://github.com/daattali/beautiful-jekyll"
+


### PR DESCRIPTION
The i18n changes introduced in 5cf80fe require Hugo 0.17, so
update theme.toml accordingly.