### PR TITLE
Fix links to static content

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -50,8 +50,8 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.7.1/contrib/auto-render.min.js" integrity="sha384-dq1/gEHSxPZQ7DdrM82ID4YVol9BYyU7GbWlIwnwyPzotpoc57wDw/guX8EaYGPx" crossorigin="anonymous"></script>
 <script src="https://code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ=" crossorigin="anonymous"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
-<script src="{{ .Site.BaseURL }}/js/main.js"></script>
-<script src="{{ .Site.BaseURL }}/js/highlight.min.js"></script>
+<script src="{{ "/js/main.js" | absURL }}"></script>
+<script src="{{ "/js/highlight.min.js" | absURL }}"></script>
 <script> hljs.initHighlightingOnLoad(); </script>
 <script> renderMathInElement(document.body); </script>
 <!-- Load PhotoSwipe js if the load-photoswipe shortcode has been used -->

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -41,10 +41,10 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.7.1/katex.min.css" integrity="sha384-wITovz90syo1dJWVh32uuETPVEtGigN07tkttEqPv+uR2SE/mbQcG7ATL28aI9H0" crossorigin="anonymous">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" />
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-  <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/main.css" />
+  <link rel="stylesheet" href="{{ "/css/main.css" | absURL }}" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800" />
-  <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/pygment_highlights.css" />
-  <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/highlight.min.css" />
+  <link rel="stylesheet" href="{{ "/css/pygment_highlights.css" | absURL }}" />
+  <link rel="stylesheet" href="{{ "/css/highlight.min.css" | absURL }}" />
 {{- partial "head_custom.html" . }}
 </head>

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -66,7 +66,7 @@
       <div class="avatar-img-border">
         {{ if isset .Site.Params "logo" }}
           <a title="{{ .Site.Title }}" href="{{ "/" | absLangURL }}">
-            <img class="avatar-img" src="{{ .Site.BaseURL }}/{{ .Site.Params.logo }}" alt="{{ .Site.Title }}" />
+            <img class="avatar-img" src="{{ .Site.Params.logo | absURL }}" alt="{{ .Site.Title }}" />
           </a>
         {{ end }}
       </div>


### PR DESCRIPTION
Use absURL to find the URL for static content such as images,
CSS and JavaScript. The previous approach sometimes led to an
extra slash between the domain name and the path, breaking the
links. (In particular, it works when tested with hugo server, but
breaks in production.)