### PR TITLE
Fix og:url meta tag for multilingual sites

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -30,7 +30,7 @@
 {{- with .Site.Params.fb_app_id }}
   <meta property="fb:app_id" content="{{ . }}" />
 {{- end }}
-  <meta property="og:url" content="{{ .URL | absURL }}" />
+  <meta property="og:url" content="{{ .URL | absLangURL }}" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="{{ .Site.Title }}" />
 <!-- Hugo Version number -->


### PR DESCRIPTION
We need to use absLangURL instead of absURL, otherwise we
generate URLs that are wrong or don't exist for pages which aren't
in the default language.