### PR TITLE
Fix URLs for sites where baseURL is not the domain root

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -50,12 +50,12 @@ pygmentCodeFences = true
 
 [[menu.main]]
     name = "Blog"
-    url = "/"
+    url = ""
     weight = 1
 
 [[menu.main]]
     name = "About"
-    url = "/page/about/"
+    url = "page/about/"
     weight = 3
 
 [[menu.main]]
@@ -66,22 +66,23 @@ pygmentCodeFences = true
 [[menu.main]]
     parent = "samples"
     name = "Big Image Sample"
-    url = "/post/2017-03-07-bigimg-sample"
+    url = "post/2017-03-07-bigimg-sample"
     weight = 1
 
 [[menu.main]]
     parent = "samples"
     name = "Math Sample"
-    url = "/post/2017-03-05-math-sample"
+    url = "post/2017-03-05-math-sample"
     weight = 2
 
 [[menu.main]]
     parent = "samples"
     name = "Code Sample"
-    url = "/post/2016-03-08-code-sample"
+    url = "post/2016-03-08-code-sample"
     weight = 3
 
 [[menu.main]]
     name = "Tags"
-    url = "/tags"
+    url = "tags"
     weight = 3
+

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -17,7 +17,7 @@
           {{ end }}
           {{ if .Site.Params.rss }}
           <li>
-            <a href="{{ "/index.xml" | absLangURL }}" title="RSS">
+            <a href="{{ "index.xml" | absLangURL }}" title="RSS">
               <span class="fa-stack fa-lg">
                 <i class="fa fa-circle fa-stack-2x"></i>
                 <i class="fa fa-rss fa-stack-1x fa-inverse"></i>
@@ -33,7 +33,7 @@
 
           {{ if .Site.Title }}
             &nbsp;&bull;&nbsp;
-            <a href="{{ "/" | absLangURL }}">{{ .Site.Title }}</a>
+            <a href="{{ "" | absLangURL }}">{{ .Site.Title }}</a>
           {{ end }}
         </p>
         <!-- Please don't remove this, keep my open source work credited :) -->
@@ -50,8 +50,8 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.7.1/contrib/auto-render.min.js" integrity="sha384-dq1/gEHSxPZQ7DdrM82ID4YVol9BYyU7GbWlIwnwyPzotpoc57wDw/guX8EaYGPx" crossorigin="anonymous"></script>
 <script src="https://code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ=" crossorigin="anonymous"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
-<script src="{{ "/js/main.js" | absURL }}"></script>
-<script src="{{ "/js/highlight.min.js" | absURL }}"></script>
+<script src="{{ "js/main.js" | absURL }}"></script>
+<script src="{{ "js/highlight.min.js" | absURL }}"></script>
 <script> hljs.initHighlightingOnLoad(); </script>
 <script> renderMathInElement(document.body); </script>
 <!-- Load PhotoSwipe js if the load-photoswipe shortcode has been used -->

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -37,14 +37,14 @@
   {{ .Hugo.Generator -}}
 <!-- Links and stylesheets -->
   <link rel="canonical" href="{{ .URL | absLangURL }}" />
-  <link rel="alternate" href="{{ "/index.xml" | absLangURL }}" type="application/rss+xml" title="{{ .Site.Title }}">
+  <link rel="alternate" href="{{ "index.xml" | absLangURL }}" type="application/rss+xml" title="{{ .Site.Title }}">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.7.1/katex.min.css" integrity="sha384-wITovz90syo1dJWVh32uuETPVEtGigN07tkttEqPv+uR2SE/mbQcG7ATL28aI9H0" crossorigin="anonymous">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" />
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-  <link rel="stylesheet" href="{{ "/css/main.css" | absURL }}" />
+  <link rel="stylesheet" href="{{ "css/main.css" | absURL }}" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800" />
-  <link rel="stylesheet" href="{{ "/css/pygment_highlights.css" | absURL }}" />
-  <link rel="stylesheet" href="{{ "/css/highlight.min.css" | absURL }}" />
+  <link rel="stylesheet" href="{{ "css/pygment_highlights.css" | absURL }}" />
+  <link rel="stylesheet" href="{{ "css/highlight.min.css" | absURL }}" />
 {{- partial "head_custom.html" . }}
 </head>

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -7,7 +7,7 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a class="navbar-brand" href="{{ "/" | absLangURL }}">{{ .Site.Title }}</a>
+      <a class="navbar-brand" href="{{ "" | absLangURL }}">{{ .Site.Title }}</a>
     </div>
 
     <div class="collapse navbar-collapse" id="main-navbar">
@@ -65,7 +65,7 @@
     <div class="avatar-container">
       <div class="avatar-img-border">
         {{ if isset .Site.Params "logo" }}
-          <a title="{{ .Site.Title }}" href="{{ "/" | absLangURL }}">
+          <a title="{{ .Site.Title }}" href="{{ "" | absLangURL }}">
             <img class="avatar-img" src="{{ .Site.Params.logo | absURL }}" alt="{{ .Site.Title }}" />
           </a>
         {{ end }}


### PR DESCRIPTION
It turns out that the fix for static links in 6528985ed breaks
sites where baseURL is not at the domain root, (i.e. the Hugo site
is at http://www.example.com/foo/, not http://www.example.com/).
This is because the link strings passed to absURL and absLangURL
have a leading slash, which Hugo resolves to the domain root. This
commit fixes the problem by removing removing the leading slash
from these strings.

Fixes #57