### PR TITLE
Fixed Google search console verification with Google Analytics.

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -75,5 +75,4 @@
 </script>
 {{ end }}
 
-{{ template "_internal/google_analytics.html" . }}
 {{- partial "footer_custom.html" . }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -47,4 +47,5 @@
   <link rel="stylesheet" href="{{ "css/pygment_highlights.css" | absURL }}" />
   <link rel="stylesheet" href="{{ "css/highlight.min.css" | absURL }}" />
 {{- partial "head_custom.html" . }}
+{{ template "_internal/google_analytics_async.html" . }}
 </head>


### PR DESCRIPTION
Google analytics method for Google search console verification requires **async** snippet to be in `<head>`.


https://support.google.com/webmasters/answer/35179?hl=en#google_analytics_verification