### PR TITLE
Add exampleSite/themes to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Themes directory of example site; ignored so that we can clone the repo
+# inside the themes directory and test the example site with "hugo server".
+exampleSite/themes/
+
 # Windows image file caches
 Thumbs.db
 ehthumbs.db


### PR DESCRIPTION
This is so that we can clone the repo in the example site's themes
directory and test the example site using `hugo server`.