### PR TITLE
Avoid using css import

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1,5 +1,3 @@
-<link rel="style.css" href="pygment_highlights.css" type="text/css">
-
 /* --- General --- */
 
 body {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1,4 +1,4 @@
-@import url("pygment_highlights.css");
+<link rel="style.css" href="pygment_highlights.css" type="text/css">
 
 /* --- General --- */
 


### PR DESCRIPTION
Avoid using css `@import` in main.css file 
Some context: https://varvy.com/pagespeed/avoid-css-import.html