### PR TITLE
Add keybase to social config

### DIFF
--- a/data/beautifulhugo/social.toml
+++ b/data/beautifulhugo/social.toml
@@ -94,3 +94,9 @@ url = "https://itch.io/profile/%s"
 title = "Itch.io"
 icon = "fa-gamepad"
 
+[[social_icons]]
+id = "keybase"
+url = "https://keybase.io/%s"
+title = "Keybase"
+icon = "fa-key"
+


### PR DESCRIPTION
Add keybase social icon. Notice that keybase does not have a specific icon in font-awesome (https://github.com/FortAwesome/Font-Awesome/issues/4095). Other themes in Hugo are using this icon`fa-key` as well. 