### PR TITLE
fix google plus social link. It doesn't work with `www`

### DIFF
--- a/data/beautifulhugo/social.toml
+++ b/data/beautifulhugo/social.toml
@@ -12,7 +12,7 @@ icon = "fa-facebook"
 
 [[social_icons]]
 id = "googleplus"
-url = "https://www.plus.google.com/%s"
+url = "https://plus.google.com/%s"
 title = "Google+"
 icon = "fa-google-plus"
 


### PR DESCRIPTION
The next urls lead to a redirect to the main page:

- https://www.plus.google.com/+AlexanderIvanov
- https://www.plus.google.com/114173154718145483119

It's fine without `www`

- https://plus.google.com/+AlexanderIvanov
- https://plus.google.com/114173154718145483119