### PR TITLE
added authors website to site parameters. link to authors website can…

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -31,6 +31,7 @@ pygmentCodeFences = true
 
 [Author]
   name = "Some Person"
+  website = "yourwebsite.com"
   email = "youremail@domain.com"
   facebook = "username"
   googleplus = "+username" # or xxxxxxxxxxxxxxxxxxxxx
@@ -89,4 +90,3 @@ pygmentCodeFences = true
     name = "Tags"
     url = "tags"
     weight = 3
-

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -27,10 +27,12 @@
           {{ end }}
         </ul>
         <p class="credits copyright text-muted">
-          {{ if .Site.Author.web }}
-            <a href="{{ .Site.Author.website }}">{{ .Site.Author.name }}</a>
-          {{ else }}
-            {{ .Site.Author.name }}
+          {{ if .Site.Author.name }}
+            {{ if .Site.Author.web }}
+              <a href="{{ .Site.Author.website }}">{{ .Site.Author.name }}</a>
+            {{ else }}
+              {{ .Site.Author.name }}
+            {{ end }}          
           {{ end }}
           
           &nbsp;&bull;&nbsp;

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -27,7 +27,12 @@
           {{ end }}
         </ul>
         <p class="credits copyright text-muted">
-          {{ .Site.Author.name }}
+          {{ if .Site.Author.web }}
+            <a href="{{ .Site.Author.website }}">{{ .Site.Author.name }}</a>
+          {{ else }}
+            {{ .Site.Author.name }}
+          {{ end }}
+          
           &nbsp;&bull;&nbsp;
           {{ .Site.LastChange.Format "2006" }}
 


### PR DESCRIPTION
… be included in the footer now.

We are a students club and use this theme for a website of one of our projects. We set the author-name parameter to the name of our club and want to add the link of the clubs website ot the name in the footer. So we added an additional parameter author-website and changed a few lines in the footer.html. The author-website paramter is optional and can be ignored if not needed. 