### PR TITLE
generate tag links with trailing slash

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -28,14 +28,14 @@
             <article class="post-preview">
               <a href="{{ .Permalink }}">
                 <h2 class="post-title">{{ .Title }}</h2>
-    
+
                 {{ if .Params.subtitle }}
                   <h3 class="post-subtitle">
                     {{ .Params.subtitle }}
                   </h3>
                 {{ end }}
               </a>
-    
+
               <p class="post-meta">
                 {{ default (i18n "dateFormat") .Site.Params.dateformat | .Date.Format | i18n "postedOnDate" }}
               </p>
@@ -47,15 +47,15 @@
                   {{ .Content }}
                 {{ end }}
               </div>
-    
+
               {{ if .Params.tags }}
                 <span class="post-meta">
                   {{ range .Params.tags }}
-                    #<a href="{{ $.Site.LanguagePrefix }}/tags/{{ . | urlize }}">{{ . }}</a>&nbsp;
+                    #<a href="{{ $.Site.LanguagePrefix }}/tags/{{ . | urlize }}/">{{ . }}</a>&nbsp;
                   {{ end }}
                 </span>
               {{ end }}
-    
+
             </article>
           {{ end }}
         </div>

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -4,7 +4,7 @@
     <article class="post-preview">
       <div class="list-group col-lg-4 col-lg-offset-4 col-md-6 col-md-offset-3">
       {{ range $key, $value := .Data.Terms.ByCount }}
-      <a href="{{ $.Site.LanguagePrefix }}/{{ $data.Plural }}/{{ $value.Name | urlize }}" class="list-group-item">
+      <a href="{{ $.Site.LanguagePrefix }}/{{ $data.Plural }}/{{ $value.Name | urlize }}/" class="list-group-item">
           {{ $value.Name }}<span class="badge">{{ $value.Count }}</span></a>
       {{ end }}
       </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -34,7 +34,7 @@
               {{ if .Params.tags }}
                 <span class="post-meta">
                 {{ range .Params.tags }}
-                  #<a href="{{ $.Site.LanguagePrefix }}/tags/{{ . | urlize }}">{{ . }}</a>&nbsp;
+                  #<a href="{{ $.Site.LanguagePrefix }}/tags/{{ . | urlize }}/">{{ . }}</a>&nbsp;
                 {{ end }}
                 </span>
               {{ end }}


### PR DESCRIPTION
Since all post URIs are generated with a trailing slash, I thought
it would be a good idea to do the same for tag links. This can
save a few I/O operations here and there (or, depending on your
webhoster, even get rid of redirects).