### PR TITLE
some URL related fixes, mainly tags

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -28,14 +28,14 @@
             <article class="post-preview">
               <a href="{{ .Permalink }}">
                 <h2 class="post-title">{{ .Title }}</h2>
-    
+
                 {{ if .Params.subtitle }}
                   <h3 class="post-subtitle">
                     {{ .Params.subtitle }}
                   </h3>
                 {{ end }}
               </a>
-    
+
               <p class="post-meta">
                 {{ default (i18n "dateFormat") .Site.Params.dateformat | .Date.Format | i18n "postedOnDate" }}
               </p>
@@ -47,15 +47,15 @@
                   {{ .Content }}
                 {{ end }}
               </div>
-    
+
               {{ if .Params.tags }}
                 <span class="post-meta">
                   {{ range .Params.tags }}
-                    #<a href="{{ $.Site.LanguagePrefix }}/tags/{{ . | urlize }}">{{ . }}</a>&nbsp;
+                    #<a href="{{ $.Site.LanguagePrefix }}/tags/{{ . | urlize }}/">{{ . }}</a>&nbsp;
                   {{ end }}
                 </span>
               {{ end }}
-    
+
             </article>
           {{ end }}
         </div>

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -4,7 +4,7 @@
     <article class="post-preview">
       <div class="list-group col-lg-4 col-lg-offset-4 col-md-6 col-md-offset-3">
       {{ range $key, $value := .Data.Terms.ByCount }}
-      <a href="{{ $.Site.LanguagePrefix }}/{{ $data.Plural }}/{{ $value.Name | urlize }}" class="list-group-item">
+      <a href="{{ $.Site.LanguagePrefix }}/{{ $data.Plural }}/{{ $value.Name | urlize }}/" class="list-group-item">
           {{ $value.Name }}<span class="badge">{{ $value.Count }}</span></a>
       {{ end }}
       </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -34,7 +34,7 @@
               {{ if .Params.tags }}
                 <span class="post-meta">
                 {{ range .Params.tags }}
-                  #<a href="{{ $.Site.LanguagePrefix }}/tags/{{ . | urlize }}">{{ . }}</a>&nbsp;
+                  #<a href="{{ $.Site.LanguagePrefix }}/tags/{{ . | urlize }}/">{{ . }}</a>&nbsp;
                 {{ end }}
                 </span>
               {{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -56,7 +56,7 @@
 <script> renderMathInElement(document.body); </script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/photoswipe/4.1.1/photoswipe.min.js" integrity="sha256-UplRCs9v4KXVJvVY+p+RSo5Q4ilAUXh7kpjyIP5odyc=" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/photoswipe/4.1.1/photoswipe-ui-default.min.js" integrity="sha256-PWHOlUzc96pMc8ThwRIXPn8yH4NOLu42RQ0b9SpnpFk=" crossorigin="anonymous"></script>
-<script src="/js/load-photoswipe.js"></script>
+<script src="{{ "js/load-photoswipe.js" | absURL }}"></script>
 <!-- Google Custom Search Engine -->
 {{ if .Site.Params.gcse }}
 <script>


### PR DESCRIPTION
* generate all links to tags with trailing slash (saves I/O on webserver)
* generate all links to tags with complete URL (for when website doesn't live in domain root)
* include load-photoswipe.js from absolute URL (for when website doesn't live in domain root)