### PR TITLE
include complete URL in tags

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -51,7 +51,7 @@
               {{ if .Params.tags }}
                 <span class="post-meta">
                   {{ range .Params.tags }}
-                    #<a href="{{ $.Site.LanguagePrefix }}/tags/{{ . | urlize }}/">{{ . }}</a>&nbsp;
+                    #<a href="{{ $.Site.LanguagePrefix | absURL }}tags/{{ . | urlize }}/">{{ . }}</a>&nbsp;
                   {{ end }}
                 </span>
               {{ end }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -4,7 +4,7 @@
     <article class="post-preview">
       <div class="list-group col-lg-4 col-lg-offset-4 col-md-6 col-md-offset-3">
       {{ range $key, $value := .Data.Terms.ByCount }}
-      <a href="{{ $.Site.LanguagePrefix }}/{{ $data.Plural }}/{{ $value.Name | urlize }}/" class="list-group-item">
+      <a href="{{ $.Site.LanguagePrefix | absURL }}{{ $data.Plural }}/{{ $value.Name | urlize }}/" class="list-group-item">
           {{ $value.Name }}<span class="badge">{{ $value.Count }}</span></a>
       {{ end }}
       </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -34,7 +34,7 @@
               {{ if .Params.tags }}
                 <span class="post-meta">
                 {{ range .Params.tags }}
-                  #<a href="{{ $.Site.LanguagePrefix }}/tags/{{ . | urlize }}/">{{ . }}</a>&nbsp;
+                  #<a href="{{ $.Site.LanguagePrefix | absURL }}tags/{{ . | urlize }}/">{{ . }}</a>&nbsp;
                 {{ end }}
                 </span>
               {{ end }}


### PR DESCRIPTION
I want to resolve #71 with this - links to tags should now also
work when the site is not living in a domain's root.