### PR TITLE
corrected variable name for authors website in footer layout

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -28,7 +28,7 @@
         </ul>
         <p class="credits copyright text-muted">
           {{ if .Site.Author.name }}
-            {{ if .Site.Author.web }}
+            {{ if .Site.Author.website }}
               <a href="{{ .Site.Author.website }}">{{ .Site.Author.name }}</a>
             {{ else }}
               {{ .Site.Author.name }}


### PR DESCRIPTION
Found a mistake in the footer layout file. The if that checks for the authors website used a wrong variable name (.Site.Author.web instead of .Site.Author.website).