### PR TITLE
Add modified time, fix translations, make reading time optional

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -17,6 +17,7 @@ pygmentCodeFences = true
   commit = false
   rss = true
   comments = true
+  readingTime = true
 #  gcse = "012345678901234567890:abcdefghijk" # Get your code from google.com/cse. Make sure to go to "Look and Feel" and change Layout to "Full Width" and Theme to "Classic"
 
 #[[Params.bigimg]]

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -24,7 +24,7 @@
 - id: readTime
   translation: "min"
 - id: words
-  translation: "wörter"
+  translation: "Wörter"
 
 
 # 404 page

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -5,6 +5,8 @@
   translation: "2 Jan, 2006 15:04:05"
 - id: postedOnDate
   translation: "Gepostet am {{ .Count }}"
+- id: lastModified
+  translation: "(Zuletzt geändert am {{ .Count }})"
 - id: translationsLabel
   translation: "Andere Sprachen: "
 - id: translationsSeparator
@@ -22,7 +24,7 @@
 - id: readTime
   translation: "min"
 - id: words
-  translation: "mots"
+  translation: "wörter"
 
 
 # 404 page

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -5,6 +5,8 @@
   translation: "Jan 2, 2006 15:04:05"
 - id: postedOnDate
   translation: "Posted on {{ .Count }}"
+- id: lastModified
+  translation: "(Last modified on {{ .Count }})"
 - id: translationsLabel
   translation: "Other languages: "
 - id: translationsSeparator
@@ -22,7 +24,7 @@
 - id: readTime
   translation: "min"
 - id: words
-  translation: "mots"
+  translation: "words"
 
 
 # 404 page

--- a/i18n/es-ES.yaml
+++ b/i18n/es-ES.yaml
@@ -5,6 +5,8 @@
   translation: "2 Jan, 2006 15:04:05"
 - id: postedOnDate
   translation: "Publicado el {{ .Count }}"
+- id: lastModified
+  translation: "(Última modificación en {{ .Count }})"
 - id: translationsLabel
   translation: "Otros idiomas: "
 - id: translationsSeparator
@@ -22,7 +24,7 @@
 - id: readTime
   translation: "min"
 - id: words
-  translation: "mots"
+  translation: "palabras"
 
 
 # 404 page

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -5,6 +5,8 @@
   translation: "2 Jan, 2006 15:04:05"
 - id: postedOnDate
   translation: "Posté le {{ .Count }}"
+- id: lastModified
+  translation: "(Dernière modification le {{ .Count }})"
 - id: translationsLabel
   translation: "Autres langues: "
 - id: translationsSeparator

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -5,6 +5,8 @@
   translation: "2 Jan, 2006 15:04:05"
 - id: postedOnDate
   translation: "{{ .Count }}に投稿"
+- id: lastModified
+  translation: "(最終更新日時{{ .Count }})"
 - id: translationsLabel
   translation: "翻訳："
 - id: translationsSeparator
@@ -20,9 +22,9 @@
 - id: nextPost
   translation: "次ページ"
 - id: readTime
-  translation: "min"
+  translation: "分"
 - id: words
-  translation: "mots"
+  translation: "言葉"
 
 
 # 404 page

--- a/i18n/pl.yaml
+++ b/i18n/pl.yaml
@@ -5,6 +5,8 @@
   translation: "2 Jan, 2006 15:04:05"
 - id: postedOnDate
   translation: "Opublikowany {{ .Count }}"
+- id: lastModified
+  translation: "(Ostatnia modyfikacja {{ .Count }})"
 - id: translationsLabel
   translation: "Inne języki: "
 - id: translationsSeparator
@@ -22,7 +24,7 @@
 - id: readTime
   translation: "min"
 - id: words
-  translation: "mots"
+  translation: "słowa"
 
 
 # 404 page

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -5,6 +5,8 @@
   translation: "2 Jan, 2006 15:04:05"
 - id: postedOnDate
   translation: "Опубликовано {{ .Count }}"
+- id: lastModified
+  translation: "(Последнее изменение {{ .Count }})"
 - id: translationsLabel
   translation: "Другие языки: "
 - id: translationsSeparator
@@ -22,7 +24,7 @@
 - id: readTime
   translation: "min"
 - id: words
-  translation: "mots"
+  translation: "слова"
 
 
 # 404 page

--- a/i18n/zh.yaml
+++ b/i18n/zh.yaml
@@ -5,6 +5,8 @@
   translation: "2 Jan, 2006 15:04:05"
 - id: postedOnDate
   translation: "发表于 {{ .Count }}"
+- id: lastModified
+  translation: "(上次修改时间 {{ .Count }})"
 - id: translationsLabel
   translation: "其它语言: "
 - id: translationsSeparator
@@ -22,7 +24,7 @@
 - id: readTime
   translation: "min"
 - id: words
-  translation: "mots"
+  translation: "字"
 
 
 # 404 page

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -1,6 +1,14 @@
 <span class="post-meta">
-  <i class="fa fa-calendar-o"></i>&nbsp;{{ default (i18n "dateFormat") .Site.Params.dateformat | .Date.Format | i18n "postedOnDate" }}
-  &nbsp;|&nbsp; <i class="fa fa-clock-o"></i>{{ i18n "readingTime"}} {{ .ReadingTime }} {{ i18n "readTime" }} ({{ .WordCount }} {{ i18n "words" }})
+  {{ $lastmodstr := default (i18n "dateFormat") .Site.Params.dateformat | .Lastmod.Format }}
+  {{ $datestr := default (i18n "dateFormat") .Site.Params.dateformat | .Date.Format }}
+  <i class="fa fa-calendar-o"></i>&nbsp;{{ $datestr | i18n "postedOnDate"}}
+  {{ if ne $datestr $lastmodstr }}
+    &nbsp;{{ $lastmodstr | i18n "lastModified"  }}
+  {{ end }}
+  {{ if .Params.readingTime }}
+  &nbsp;|&nbsp;
+  <i class="fa fa-clock-o"></i>{{ i18n "readingTime"}} {{ .ReadingTime }} {{ i18n "readTime" }} ({{ .WordCount }} {{ i18n "words" }})
+  {{ end }}
   {{- if .Site.Params.staticman -}}
     &nbsp;|&nbsp;  <i class="fa fa-comment-o"></i>
     {{ $slug := replace .URL "/" "" }}


### PR DESCRIPTION
The recent changes to the master branch have introduced a few issues, this should fix those.

The fairly newly added reading time is now optional via `readingTime=true` parameter, and is correctly translated (English version does not have French in it now, and other translations added via Google Translate).

The modification date has also been added, and is only shown if different from the creation date (so it will not clutter a site unless the author is using modification times)