### PR TITLE
.Site.Params.UseChroma, .readingTime, SRI for font-awesome

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ To enable Chroma, add the following to your site parameters:
 ```
 pygmentsCodeFences = true
 pygmentsUseClasses = true
-[params]
-    useChroma = true
+[Params]
+    UseChroma = true
 ```
 
 Then, you can use a different style by running:

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -43,7 +43,7 @@
   <link rel="alternate" href="{{ .Site.RSSLink }}" type="application/rss+xml" title="{{ .Site.Title }}">
   {{- end }}
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.7.1/katex.min.css" integrity="sha384-wITovz90syo1dJWVh32uuETPVEtGigN07tkttEqPv+uR2SE/mbQcG7ATL28aI9H0" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" />
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
   <link rel="stylesheet" href="{{ "css/main.css" | absURL }}" />
   {{- if .Site.Params.staticman -}}

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -5,7 +5,7 @@
   {{ if ne $datestr $lastmodstr }}
     &nbsp;{{ $lastmodstr | i18n "lastModified"  }}
   {{ end }}
-  {{ if .Params.readingTime }}
+  {{ if .Site.Params.readingTime }}
   &nbsp;|&nbsp;
   <i class="fa fa-clock-o"></i>{{ i18n "readingTime"}} {{ .ReadingTime }} {{ i18n "readTime" }} ({{ .WordCount }} {{ i18n "words" }})
   {{ end }}


### PR DESCRIPTION
Recreated:

The optional readingTime was broken due to a missing `.Site` in `{{ if .Site.Params.readingTime }}` in `post_meta.html`.

The Chroma usage in README.md seem to have inconsistent capitalizations from `layouts/partials`:
```
 layouts/partials/head.html:  {{- if (not ( .Site.Params.UseChroma )) }}
 layouts/partials/footer.html:{{- if (not ( .Site.Params.UseChroma )) }}
```
Capitalization was changed to match.

Added the [SRI SHA384 hash](https://www.bootstrapcdn.com/fontawesome/) for `font-awesome` - this was the only missing SRI in all included CDN resources in the theme.