### PR TITLE
Fix missing slash in tags URL is also in layouts/_default/list.html.

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -51,7 +51,7 @@
               {{ if .Params.tags }}
                 <span class="post-meta">
                   {{ range .Params.tags }}
-                    #<a href="{{ $.Site.LanguagePrefix | absURL }}tags/{{ . | urlize }}/">{{ . }}</a>&nbsp;
+                    #<a href="{{ $.Site.LanguagePrefix | absURL }}/tags/{{ . | urlize }}/">{{ . }}</a>&nbsp;
                   {{ end }}
                 </span>
               {{ end }}


### PR DESCRIPTION
Fix missing slash in tags URL is also in layouts/_default/list.html.