### PR TITLE
Add `post_meta.html` reference to `_default/list.html`

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -37,7 +37,7 @@
               </a>
 
               <p class="post-meta">
-                {{ default (i18n "dateFormat") .Site.Params.dateformat | .Date.Format | i18n "postedOnDate" }}
+                {{ partial "post_meta.html" . }}
               </p>
               <div class="post-entry">
                 {{ if .Truncated }}


### PR DESCRIPTION
It looked like the `layouts/_default/list.html` was missing a reference to `post_meta.html` to match what was already in `index.html` and `layouts/partials/header.html`. Otherwise list pages won't use the same formatting as many others.