### PR TITLE
Allow title in _index.md

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,5 @@
 {{ if .IsHome }}
-  {{ $.Scratch.Set "title" .Site.Title }}
+  {{ if isset .Params "title" }}{{ $.Scratch.Set "title" .Title }}{{ else }}{{ $.Scratch.Set "title" .Site.Title }}{{ end }}
   {{ if .Site.Params.subtitle }}{{ $.Scratch.Set "subtitle" .Site.Params.subtitle }}{{ end }}
   {{ if .Site.Params.bigimg }}{{ $.Scratch.Set "bigimg" .Site.Params.bigimg }}{{ end }}
 {{ else }}


### PR DESCRIPTION
This allows you to set a custom title in `_index.md` apart from the `Site.Title`

The purpose of this is to be able to customize the `<h1>` text on the index page without affecting the rest of the site where the `Site.Title` is used.

The purpose of using `isset .Params "title"` in the code instead of `if .Title` is that it allows you to set `title = ""` and have that `<h1>` title disappear without removing the text from `<title></title`