### PR TITLE
fix pagination to respect PaginatePath configuration option

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -49,12 +49,12 @@
           <ul class="pager main-pager">
             {{ if .Paginator.HasPrev }}
               <li class="previous">
-                <a href="{{ .URL }}page/{{ .Paginator.Prev.PageNumber }}/">&larr; {{ i18n "newerPosts" }}</a>
+                <a href="{{ .Paginator.Prev.URL | absURL }}">&larr; {{ i18n "newerPosts" }}</a>
               </li>
             {{ end }}
             {{ if .Paginator.HasNext }}
               <li class="next">
-                <a href="{{ .URL }}page/{{ .Paginator.Next.PageNumber }}/">{{ i18n "olderPosts" }} &rarr;</a>
+                <a href="{{ .Paginator.Next.URL | absURL }}">{{ i18n "olderPosts" }} &rarr;</a>
               </li>
             {{ end }}
           </ul>


### PR DESCRIPTION
Please take a look at https://gohugo.io/content-management/urls/

Current pagination url ignores PaginatePath set by user in configuration file which is wrong:

My config.toml looks like this:

```
Paginate = 8
PaginatePath = "/blog/page"
```

Hugo generates my pages at "/blog/page" but Beautiful Hugo Next and Previous buttons always point to /page/2 /page/3, ... which obviously does not respect the user's choice and only works for the default /page value.

This commit fixes that, so whatever is the PaginatePath's value the pagination works.