### PR TITLE
Added tag styling like Beautiful Jekyll

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -49,11 +49,11 @@
               </div>
 
               {{ if .Params.tags }}
-                <span class="post-meta">
+                <div class="blog-tags">
                   {{ range .Params.tags }}
-                    #<a href="{{ $.Site.LanguagePrefix | absURL }}/tags/{{ . | urlize }}/">{{ . }}</a>&nbsp;
+                    <a href="{{ $.Site.LanguagePrefix | absURL }}/tags/{{ . | urlize }}/">{{ . }}</a>&nbsp;
                   {{ end }}
-                </span>
+                </div>
               {{ end }}
 
             </article>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,6 +4,15 @@
     <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
       <article role="main" class="blog-post">
         {{ .Content }}
+
+        {{ if .Params.tags }}
+          <div class="blog-tags">
+            {{ range .Params.tags }}
+              <a href="{{ $.Site.LanguagePrefix | absURL }}/tags/{{ . | urlize }}/">{{ . }}</a>&nbsp;
+            {{ end }}
+          </div>
+        {{ end }}
+
         {{ if .Site.Params.socialShare }}
             <hr/>
             <section id="social-share">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -35,11 +35,11 @@
               </div>
 
               {{ if .Params.tags }}
-                <span class="post-meta">
-                {{ range .Params.tags }}
-                  #<a href="{{ $.Site.LanguagePrefix | absURL }}/tags/{{ . | urlize }}/">{{ . }}</a>&nbsp;
-                {{ end }}
-                </span>
+                <div class="blog-tags">
+                  {{ range .Params.tags }}
+                    <a href="{{ $.Site.LanguagePrefix | absURL }}/tags/{{ . | urlize }}/">{{ . }}</a>&nbsp;
+                  {{ end }}
+                </div>
               {{ end }}
             </article>
           {{ end }}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -427,10 +427,18 @@ footer .theme-by {
   margin-bottom: 30px;
 }
 
+.blog-tags:before {
+  content: "Tags: ";
+}
+
 .blog-tags a {
   color: #008AFF;
   text-decoration: none;
   padding: 0px 5px;
+}
+
+.blog-tags a:before {
+  content: "#";
 }
 
 .blog-tags a:hover {


### PR DESCRIPTION
I managed to close my [previous pull request](https://github.com/halogenica/beautifulhugo/pull/153) by updating the main branch of my forked repo, so here we go again:

> I wanted to change the styling of the post tags. I noticed there is a `blog-tags` class in `main.css`, so I went to the Jekyll repo and noticed tags are surrounded in a `<div class="blog-tags">`, so I did the same at it looks pretty good.
> 
> I have also:
> - Added a list of tags after the post content, like in Beautiful Jekyll
> - Moved the "Tags: " and "#" prefixes to the CSS, so they can be customised without changing the theme.