### PR TITLE
Adding some useful shortcodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,33 @@ This can be achieved by running the next command prior to calling Hugo:
 ```
   
 See at [xor-gate/xor-gate.org](https://github.com/xor-gate/xor-gate.org) an example of how to add it to a continuous integration system.
-  
+ 
+### Extra shortcodes
+
+There are two extra shortcodes provided (along with the customized figure shortcode):
+
+#### Details
+
+This simply adds the html5 detail attribute, supported on all *modern* browsers. Use it like this:
+
+```
+{{% details "This is the details title (click to expand)" %}}
+This is the content (hidden until clicked).
+{{% /details %}}
+```
+
+#### Split
+
+This adds a two column side-by-side environment (will turn into 1 col for narrow devices):
+
+```
+{{< columns >}}
+This is column 1.
+{{< column >}}
+This is column 2.
+{{< endcolumn >}}
+```
+
 ## About
 
 This is a port of the Jekyll theme [Beautiful Jekyll](https://deanattali.com/beautiful-jekyll/) by [Dean Attali](https://deanattali.com/aboutme#contact). It supports most of the features of the original theme.

--- a/layouts/shortcodes/column.html
+++ b/layouts/shortcodes/column.html
@@ -1,0 +1,1 @@
+</div><div class="right">

--- a/layouts/shortcodes/columns.html
+++ b/layouts/shortcodes/columns.html
@@ -1,0 +1,1 @@
+<div class="splitbox"><div class="left">

--- a/layouts/shortcodes/details.html
+++ b/layouts/shortcodes/details.html
@@ -1,0 +1,3 @@
+<details><summary>{{ .Get 0 }}</summary>
+{{ .Inner }}
+</details>

--- a/layouts/shortcodes/endcolumns.html
+++ b/layouts/shortcodes/endcolumns.html
@@ -1,0 +1,1 @@
+</div><div style="clear:both"></div></div>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -719,3 +719,26 @@ input.gsc-input, .gsc-input-box, .gsc-input-box-hover, .gsc-input-box-focus, .gs
   box-sizing: content-box;
   line-height: normal;
 }
+
+/* IPython split style */
+div.splitbox {width:100%; overflow:auto;}
+
+div.splitbox div.left {
+               width:48%;
+               display:inline-block;
+               float:left;}
+div.splitbox div.right {
+               width:48%;
+               display:inline-block;
+               float:right;}
+
+@media only screen and (max-width: 600px) {
+div.splitbox div.left {
+               width:100%;
+               display:inline-block;
+               float:left;}
+div.splitbox div.right {
+               width:100%;
+               display:inline-block;
+               float:left;}
+}


### PR DESCRIPTION
This adds two useful shortcodes:
* details: an expandable list supported on most (all modern) browsers
* columns: A side by side comparison environment, supporting narrow windows (like iPhones) gracefully.

Notes added to readme about the new shortcodes.

<details><summary>If you'd like to see more about details, click here</summary>
This is what it looks like.

😄 
</details></br>


Note: nested shortcodes are not used for columns due to a bug in Hugo: https://github.com/gohugoio/hugo/issues/1642