### PR TITLE
Rename figure to beautifulfigure

### DIFF
--- a/exampleSite/content/post/2017-03-20-photoswipe-gallery-sample.md
+++ b/exampleSite/content/post/2017-03-20-photoswipe-gallery-sample.md
@@ -8,9 +8,9 @@ tags: ["example", "photoswipe"]
 Beautiful Hugo adds a few custom shortcodes created by [Li-Wen Yip](https://www.liwen.id.au/heg/) and [Gert-Jan van den Berg](https://github.com/GjjvdBurg/HugoPhotoSwipe) for making galleries with [PhotoSwipe](http://photoswipe.com) . 
 
 {{< gallery caption-effect="fade" >}}
-  {{< figure thumb="-thumb" link="/img/hexagon.jpg" >}}
-  {{< figure thumb="-thumb" link="/img/sphere.jpg" caption="Sphere" >}}
-  {{< figure thumb="-thumb" link="/img/triangle.jpg" caption="Triangle" alt="This is a long comment about a triangle" >}}
+  {{< beautifulfigure thumb="-thumb" link="/img/hexagon.jpg" >}}
+  {{< beautifulfigure thumb="-thumb" link="/img/sphere.jpg" caption="Sphere" >}}
+  {{< beautifulfigure thumb="-thumb" link="/img/triangle.jpg" caption="Triangle" alt="This is a long comment about a triangle" >}}
 {{< /gallery >}}
 
 <!--more-->
@@ -18,9 +18,9 @@ Beautiful Hugo adds a few custom shortcodes created by [Li-Wen Yip](https://www.
 The above gallery was created using the following shortcodes:
 ```
 {{</* gallery caption-effect="fade" */>}}
-  {{</* figure thumb="-thumb" link="/img/hexagon.jpg" */>}}
-  {{</* figure thumb="-thumb" link="/img/sphere.jpg" caption="Sphere" */>}}
-  {{</* figure thumb="-thumb" link="/img/triangle.jpg" caption="Triangle" alt="This is a long comment about a triangle" */>}}
+  {{</* beautifulfigure thumb="-thumb" link="/img/hexagon.jpg" */>}}
+  {{</* beautifulfigure thumb="-thumb" link="/img/sphere.jpg" caption="Sphere" */>}}
+  {{</* beautifulfigure thumb="-thumb" link="/img/triangle.jpg" caption="Triangle" alt="This is a long comment about a triangle" */>}}
 {{</* /gallery */>}}
 ```
 
@@ -28,9 +28,9 @@ The above gallery was created using the following shortcodes:
 For full details please see the [hugo-easy-gallery GitHub](https://github.com/liwenyip/hugo-easy-gallery/) page. Basic usages from above are:
 
 - Create a gallery with open and close tags `{{</* gallery */>}}` and `{{</* /gallery */>}}`
-- `{{</* figure src="image.jpg" */>}}` will use `image.jpg` for thumbnail and lightbox
-- `{{</* figure src="thumb.jpg" link="image.jpg" */>}}` will use `thumb.jpg` for thumbnail and `image.jpg` for lightbox
-- `{{</* figure thumb="-small" link="image.jpg" */>}}` will use `image-small.jpg` for thumbnail and `image.jpg` for lightbox
+- `{{</* beautifulfigure src="image.jpg" */>}}` will use `image.jpg` for thumbnail and lightbox
+- `{{</* beautifulfigure src="thumb.jpg" link="image.jpg" */>}}` will use `thumb.jpg` for thumbnail and `image.jpg` for lightbox
+- `{{</* beautifulfigure thumb="-small" link="image.jpg" */>}}` will use `image-small.jpg` for thumbnail and `image.jpg` for lightbox
 - All the [features/parameters](https://gohugo.io/extras/shortcodes) of Hugo's built-in `figure` shortcode work as normal, i.e. src, link, title, caption, class, attr (attribution), attrlink, alt
 - `{{</* gallery caption-effect="fade" */>}}` will fade in captions for all figures in this gallery instead of the default slide-up behavior
 - Many gallery styles for captions and hover effects exist; view the [hugo-easy-gallery GitHub](https://github.com/liwenyip/hugo-easy-gallery/) for all options

--- a/layouts/shortcodes/beautifulfigure.html
+++ b/layouts/shortcodes/beautifulfigure.html
@@ -1,6 +1,5 @@
 <!--
-Put this file in /layouts/shortcodes/figure.html
-NB this overrides Hugo's built-in "figure" shortcode but is backwards compatible
+Put this file in /layouts/shortcodes/beautifulfigure.html
 Documentation and licence at https://github.com/liwenyip/hugo-easy-gallery/
 -->
 <!-- count how many times we've called this shortcode; load the css if it's the first time -->


### PR DESCRIPTION
This fixes #114 by renaming figure to beautifulfigure. That way, a figure is still usable without adding all the gallery type additions that beautifulfigure adds. For centered figures, diagrams, etc., this is much cleaner.

I picked `beautifulfigure`, but other ideas include `picture`, `gallery`, and `fancyfigure`. This is a fairly intrusive change, but there currently is no way for a normal user to restore the default "figure" environment without modifying beautifulhugo, and figure != gallery for some (most?) users.