### PR TITLE
fix missing slash for tags -> "view all"

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -19,7 +19,7 @@
             </a>
             <div id="collapse{{ $value.Name }}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading{{ $value.Name }}">
               <div class="panel-body">
-                <a href="{{ $.Site.LanguagePrefix | absURL }}{{ $data.Plural }}/{{ $value.Name | urlize }}/" class="list-group-item view-all">
+                <a href="{{ $.Site.LanguagePrefix | absURL }}/{{ $data.Plural }}/{{ $value.Name | urlize }}/" class="list-group-item view-all">
                 View all</a>
                 <div class="list-group">
                   {{ range $item := $value.WeightedPages }}


### PR DESCRIPTION
This won't probably show in "hugo serve" - all other occurences of `$.Site.LanguagePrefix | absUrl` seem to add a trailing slash, and it broke for me with a baseURL of `https://example.com` instead of `https://example.com/`.