### PR TITLE
Remove double foreward slash in tag links

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -51,7 +51,7 @@
               {{ if .Params.tags }}
                 <div class="blog-tags">
                   {{ range .Params.tags }}
-                    <a href="{{ $.Site.LanguagePrefix | absURL }}/tags/{{ . | urlize }}/">{{ . }}</a>&nbsp;
+                    <a href="{{ $.Site.LanguagePrefix | absURL }}tags/{{ . | urlize }}/">{{ . }}</a>&nbsp;
                   {{ end }}
                 </div>
               {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -8,7 +8,7 @@
         {{ if .Params.tags }}
           <div class="blog-tags">
             {{ range .Params.tags }}
-              <a href="{{ $.Site.LanguagePrefix | absURL }}/tags/{{ . | urlize }}/">{{ . }}</a>&nbsp;
+              <a href="{{ $.Site.LanguagePrefix | absURL }}tags/{{ . | urlize }}/">{{ . }}</a>&nbsp;
             {{ end }}
           </div>
         {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -37,7 +37,7 @@
               {{ if .Params.tags }}
                 <div class="blog-tags">
                   {{ range .Params.tags }}
-                    <a href="{{ $.Site.LanguagePrefix | absURL }}/tags/{{ . | urlize }}/">{{ . }}</a>&nbsp;
+                    <a href="{{ $.Site.LanguagePrefix | absURL }}tags/{{ . | urlize }}/">{{ . }}</a>&nbsp;
                   {{ end }}
                 </div>
               {{ end }}


### PR DESCRIPTION
baseurl should contain the trailing slash after the domain name.

By having a slash in these links, actual links contain double slashes.