### PR TITLE
Allow custom summaries

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -27,7 +27,7 @@
               {{ partial "post_meta.html" . }}
               <div class="post-entry">
                 {{ if .Truncated }}
-                  {{ .Summary }}
+                  {{ if .Params.summary }}{{ .Params.summary }}{{ else }}{{ .Summary }}{{ end }}
                   <a href="{{ .Permalink }}" class="post-read-more">[{{ i18n "readMore" }}]</a>
                 {{ else }}
                   {{ .Content }}


### PR DESCRIPTION
This is an "escape hatch" that can be used when neither automatic nor manual summary splitting is sufficient to create a good summary.  This is specifically useful for articles that begin with a disclaimer or anything else that shouldn't be included in the summary.  It's also useful for footnote links and other mid-text items that should be excluded from the summary.

See https://github.com/gohugoio/hugo/issues/1634 for more use cases.