### PR TITLE
Make sure one can override socialShare on a page by page basis

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -13,7 +13,7 @@
           </div>
         {{ end }}
 
-        {{ if .Site.Params.socialShare }}
+        {{ if $.Param "socialShare" }}
             <hr/>
             <section id="social-share">
               <ul class="list-inline footer-links">


### PR DESCRIPTION
By using $.Param instead of .Site.Params, the socialShare icon settings
can be overridden on a page by page basis in the Front Matter