### PR TITLE
Add a default Description for taxonomy pages

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,19 +1,28 @@
+{{- if eq .Kind "taxonomyTerm" }}
+  {{- range $key, $value := .Data.Terms.ByCount }}
+    {{- $.Scratch.Add "most_used" (slice $value.Name) }}
+  {{- end }}
+  {{- $description := printf "A full overview of all pages with %s, ordered by %s, such as: %s" .Data.Plural .Data.Singular ( delimit ( $.Scratch.Get "most_used" ) ", " ", and " ) | truncate 180 }}
+  {{- $.Scratch.Set "Description" $description }}
+
+  {{- $title := printf "Overview of all pages with %s, ordered by %s" .Data.Plural .Data.Singular }}
+  {{- $.Scratch.Set "Title" $title }}
+{{- else if eq .Kind "taxonomy" }}
+  {{- $description := printf "Overview of all pages with the %s #%s, such as: %s" .Data.Singular $.Title ( index .Pages 0).Title | truncate 160 }}
+  {{- $.Scratch.Set "Description" $description }}
+
+  {{- $title := printf "Overview of all pages with the %s #%s" .Data.Singular $.Title }}
+  {{- $.Scratch.Set "Title" $title }}
+{{- end }}
 <head>
   <meta charset="utf-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
 <!-- Site Title, Description, Author, and Favicon -->
-{{- with .Title | default .Site.Title }}
+{{- with ($.Scratch.Get "Title") | default .Title | default .Site.Title }}
   <title>{{ . }}</title>
   <meta property="og:title" content="{{ . }}" />
   <meta name="twitter:title" content="{{ . | truncate 70 }}" />
-{{- end }}
-{{- if eq .Kind "taxonomyTerm" }}
-  {{- $text := printf "Overview of all pages by %s" .Data.Singular }}
-  {{- $.Scratch.Set "Description" $text }}
-{{- else if eq .Kind "taxonomy" }}
-  {{- $text := printf "Overview of all pages with the %s #%s" .Data.Singular $.Title }}
-  {{- $.Scratch.Set "Description" $text }}
 {{- end }}
 {{- with .Description | default .Params.subtitle | default .Summary | default ($.Scratch.Get "Description") }}
   <meta name="description" content="{{ . }}">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -13,18 +13,21 @@
 
   {{- $title := printf "Overview of all pages with the %s #%s" .Data.Singular $.Title }}
   {{- $.Scratch.Set "Title" $title }}
+{{- else }}
+  {{- $.Scratch.Set "Description" ( .Description | default .Params.subtitle | default .Summary ) }}
+  {{- $.Scratch.Set "Title" ( .Title | default .Site.Title ) }}
 {{- end }}
 <head>
   <meta charset="utf-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
 <!-- Site Title, Description, Author, and Favicon -->
-{{- with ($.Scratch.Get "Title") | default .Title | default .Site.Title }}
-  <title>{{ . }}</title>
+{{- with ($.Scratch.Get "Title") }}
+  <title>{{ . }} - {{ $.Site.Title }}</title>
   <meta property="og:title" content="{{ . }}" />
   <meta name="twitter:title" content="{{ . | truncate 70 }}" />
 {{- end }}
-{{- with .Description | default .Params.subtitle | default .Summary | default ($.Scratch.Get "Description") }}
+{{- with ($.Scratch.Get "Description") }}
   <meta name="description" content="{{ . }}">
   <meta property="og:description" content="{{ . }}">
   <meta name="twitter:description" content="{{ . | truncate 200 }}">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,7 +8,14 @@
   <meta property="og:title" content="{{ . }}" />
   <meta name="twitter:title" content="{{ . | truncate 70 }}" />
 {{- end }}
-{{- with .Description | default .Params.subtitle | default .Summary }}
+{{- if eq .Kind "taxonomyTerm" }}
+  {{- $text := printf "Overview of all pages by %s" .Data.Singular }}
+  {{- $.Scratch.Set "Description" $text }}
+{{- else if eq .Kind "taxonomy" }}
+  {{- $text := printf "Overview of all pages with the %s #%s" .Data.Singular $.Title }}
+  {{- $.Scratch.Set "Description" $text }}
+{{- end }}
+{{- with .Description | default .Params.subtitle | default .Summary | default ($.Scratch.Get "Description") }}
   <meta name="description" content="{{ . }}">
   <meta property="og:description" content="{{ . }}">
   <meta name="twitter:description" content="{{ . | truncate 200 }}">


### PR DESCRIPTION
Make use of the detection of the .Kind of page to have a default
description for SEO purposes