### PR TITLE
Ability to disable KaTex and Photoswipe

### DIFF
--- a/data/beautifulhugo/social.toml
+++ b/data/beautifulhugo/social.toml
@@ -129,3 +129,9 @@ id = "telegram"
 url = "https://telegram.me/%s"
 title = "Telegram"
 icon = "fa-telegram"
+
+[[social_icons]]
+id = "500px"
+url = "https://500px.com/%s"
+title = "500px"
+icon = "fa-500px"

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -24,6 +24,8 @@ pygmentsCodefencesGuessSyntax = true
   comments = true
   readingTime = true
   useHLJS = true
+  useKaTeX = true
+  usePhotoswipe = true
   socialShare = true
 #  gcse = "012345678901234567890:abcdefghijk" # Get your code from google.com/cse. Make sure to go to "Look and Feel" and change Layout to "Full Width" and Theme to "Classic"
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -57,8 +57,10 @@
   </div>
 </footer>
 
+{{- if .Site.Params.useKaTeX }}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.7.1/katex.min.js" integrity="sha384-/y1Nn9+QQAipbNQWU65krzJralCnuOasHncUFXGkdwntGeSvQicrYkiUBwsgUqc1" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.7.1/contrib/auto-render.min.js" integrity="sha384-dq1/gEHSxPZQ7DdrM82ID4YVol9BYyU7GbWlIwnwyPzotpoc57wDw/guX8EaYGPx" crossorigin="anonymous"></script>
+{{- end }}
 <script src="https://code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ=" crossorigin="anonymous"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 <script src="{{ "js/main.js" | absURL }}"></script>
@@ -70,10 +72,14 @@
 <script> hljs.initHighlightingOnLoad(); </script>
 <script> $(document).ready(function() {$("pre.chroma").css("padding","0");}); </script>
 {{- end -}}
+{{- if .Site.Params.useKaTeX }}
 <script> renderMathInElement(document.body); </script>
+{{- end }}
+{{- if .Site.Params.usePhotoswipe }}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/photoswipe/4.1.2/photoswipe.min.js" integrity="sha384-QELNnmcmU8IR9ZAykt67vGr9/rZJdHbiWi64V88fCPaOohUlHCqUD/unNN0BXSqy" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/photoswipe/4.1.2/photoswipe-ui-default.min.js" integrity="sha384-m67o7SkQ1ALzKZIFh4CiTA8tmadaujiTa9Vu+nqPSwDOqHrDmxLezTdFln8077+q" crossorigin="anonymous"></script>
 <script src="{{ "js/load-photoswipe.js" | absURL }}"></script>
+{{- end }}
 <!-- Google Custom Search Engine -->
 {{ if .Site.Params.gcse }}
 <script>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -42,7 +42,9 @@
   {{- else }}
   <link rel="alternate" href="{{ .Site.RSSLink }}" type="application/rss+xml" title="{{ .Site.Title }}">
   {{- end }}
+  {{- if .Site.Params.useKaTeX }}
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.7.1/katex.min.css" integrity="sha384-wITovz90syo1dJWVh32uuETPVEtGigN07tkttEqPv+uR2SE/mbQcG7ATL28aI9H0" crossorigin="anonymous">
+  {{- end }}
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
   <link rel="stylesheet" href="{{ "css/main.css" | absURL }}" />
@@ -62,8 +64,10 @@
   <script src='https://www.google.com/recaptcha/api.js'></script>
   {{- end -}}
 
+  {{- if .Site.Params.usePhotoswipe }}
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/photoswipe/4.1.2/photoswipe.min.css" integrity="sha384-h/L2W9KefUClHWaty3SLE5F/qvc4djlyR4qY3NUV5HGQBBW7stbcfff1+I/vmsHh" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/photoswipe/4.1.2/default-skin/default-skin.min.css" integrity="sha384-iD0dNku6PYSIQLyfTOpB06F2KCZJAKLOThS5HRe8b3ibhdEQ6eKsFf/EeFxdOt5R" crossorigin="anonymous">
+  {{- end }}
 
 {{- partial "head_custom.html" . }}
 {{ template "_internal/google_analytics_async.html" . }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,4 +1,6 @@
+{{- if .Site.Params.usePhotoswipe }}
 {{- partial "load-photoswipe-theme.html" . }}
+{{- end }}
 
 {{ if .IsHome }}
   {{ if .Site.Params.homeTitle }}{{ $.Scratch.Set "title" .Site.Params.homeTitle }}{{ else }}{{ $.Scratch.Set "title" .Site.Title }}{{ end }}


### PR DESCRIPTION
This PR adds a way to
- disable loading KaText scripts and styles when nod needed
- disable loading Photoswipe scripts and styles when nod needed

Many people probably do not use KaTex or Photoswipe, so why transfer more data when not needed.