### PR TITLE
Fix broken pagination links when using baseURL with path

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -49,12 +49,12 @@
           <ul class="pager main-pager">
             {{ if .Paginator.HasPrev }}
               <li class="previous">
-                <a href="{{ .Paginator.Prev.URL | absURL }}">&larr; {{ i18n "newerPosts" }}</a>
+                <a href="{{ .URL }}page/{{ .Paginator.Prev.PageNumber }}/">&larr; {{ i18n "newerPosts" }}</a>
               </li>
             {{ end }}
             {{ if .Paginator.HasNext }}
               <li class="next">
-                <a href="{{ .Paginator.Next.URL | absURL }}">{{ i18n "olderPosts" }} &rarr;</a>
+                <a href="{{ .URL }}page/{{ .Paginator.Next.PageNumber }}/">{{ i18n "olderPosts" }} &rarr;</a>
               </li>
             {{ end }}
           </ul>


### PR DESCRIPTION
If the `baseURL` contains a path, i.e. `https://my.domain.tld/thissite`, the pagination links are broken as they point to `https://my.domain.tld/page/2` instead of `https://my.domain.tld/thissite/page/2`.

This replaces the corresponding links in `index.html` with the code found in `_default/list.html` which fixes this issue.