### PR TITLE
Improved codeblock rendering.

### DIFF
--- a/static/css/codeblock.css
+++ b/static/css/codeblock.css
@@ -1,9 +1,33 @@
 /* --- Code blocks --- */
 
-.chroma .ln { 
-  margin-right: 0.8em; 
-  padding: 0 0.4em 0 0.4em; 
+.chroma .ln {
+  margin-right: 0.8em;
+  padding: 0 0.4em 0 0.4em;
 }
 pre code.hljs {
   padding: 9.5px;
+}
+
+.highlight tr, .highlight pre {
+  border: none;
+}
+
+.highlight div:first-child {
+  border-radius: 4px;
+}
+
+.highlight td:first-child pre {
+  border-top-left-radius: 4px;
+  border-top-right-radius: unset;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: unset;
+  overflow: hidden;
+}
+
+.highlight td:last-child pre {
+  border-radius: unset;
+}
+
+.highlight td:last-child pre code {
+  white-space: pre;
 }


### PR DESCRIPTION
Makes code blocks with table style render nicer:
![code_diff](https://user-images.githubusercontent.com/2993230/46852965-3fa52980-ce59-11e8-9e2e-4ea61e8a0a26.png)

* no scroll bar for line number cell
* rounded corners
* no middle border
* long code line doesn't wrap
* scroll bar for long code lines

cc: #137