### PR TITLE
Fixed reference from Jekyll to Hugo and add link 

### DIFF
--- a/exampleSite/content/post/2015-02-20-test-markdown.md
+++ b/exampleSite/content/post/2015-02-20-test-markdown.md
@@ -5,7 +5,7 @@ date: 2015-02-20
 tags: ["example", "markdown"]
 ---
 
-You can write regular [markdown](http://markdowntutorial.com/) here and Jekyll will automatically convert it to a nice webpage.  I strongly encourage you to [take 5 minutes to learn how to write in markdown](http://markdowntutorial.com/) - it'll teach you how to transform regular text into bold/italics/headings/tables/etc.
+You can write regular [markdown](http://markdowntutorial.com/) here and [Hugo](https://gohugo.io) will automatically convert it to a nice webpage.  I strongly encourage you to [take 5 minutes to learn how to write in markdown](http://markdowntutorial.com/) - it'll teach you how to transform regular text into bold/italics/headings/tables/etc.
 
 **Here is some bold text**
 


### PR DESCRIPTION
This Theme is about [Hugo](https://gohugo.io) and an example page contains reference to Jekyll. This was fixed.
