### PR TITLE
[Feature] Allow to use customised Month names in posted date month

### DIFF
--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -1,9 +1,20 @@
 <span class="post-meta">
-  {{ $lastmodstr := default (i18n "dateFormat") .Site.Params.dateformat | .Lastmod.Format }}
-  {{ $datestr := default (i18n "dateFormat") .Site.Params.dateformat | .Date.Format }}
-  <i class="fas fa-calendar"></i>&nbsp;{{ $datestr | i18n "postedOnDate"}}
-  {{ if ne $datestr $lastmodstr }}
-    &nbsp;{{ $lastmodstr | i18n "lastModified"  }}
+  {{ if $.Site.Params.Months }}
+    {{ $monthDate :=  index $.Site.Params.Months (printf "%d" .Date.Month) }}
+    {{ $monthMod :=  index $.Site.Params.Months (printf "%d" .Lastmod.Month) }}
+    {{ $lastmodstr := printf "%d %s %d" .Lastmod.Day $monthMod .Lastmod.Year }}
+    {{ $datestr := printf "%d %s %d" .Date.Day $monthDate .Date.Year }}
+    <i class="fas fa-calendar"></i>&nbsp;{{ $datestr | i18n "postedOnDate"}}
+    {{ if ne $datestr $lastmodstr }}
+      &nbsp;{{ $lastmodstr | i18n "lastModified"  }}
+    {{ end }}
+  {{ else }}
+    {{ $lastmodstr := default (i18n "dateFormat") .Site.Params.dateformat | .Lastmod.Format }}
+    {{ $datestr := default (i18n "dateFormat") .Site.Params.dateformat | .Date.Format }}
+    <i class="fas fa-calendar"></i>&nbsp;{{ $datestr | i18n "postedOnDate"}}
+    {{ if ne $datestr $lastmodstr }}
+      &nbsp;{{ $lastmodstr | i18n "lastModified"  }}
+    {{ end }}
   {{ end }}
   {{ if .Site.Params.readingTime }}
     &nbsp;|&nbsp;<i class="fas fa-clock"></i>&nbsp;{{ i18n "readingTime"}}{{ .ReadingTime }}&nbsp;{{ i18n "readTime" }}


### PR DESCRIPTION
    This is a workaround for missing localization in month names. Plus it allows a more generic approach by giving the possibility to rename the months however you want beyond translation.
    Once this code is in place in you can just set the config.yaml file as follows:

    languages:
      en:
        languageName: English
        title: "My awesome blog"
        weight: 1
      it:
        languageName: Italiano
        title: "Il mio fantastico blog"
        params:
          Months:
            1: "Gennaio"
            2: "Febbraio"
            3: "Marzo"
            4: "Aprile"
            5: "Maggio"
            6: "Giugno"
            7: "Luglio"
            8: "Agosto"
            9: "Settembre"
            10: "Ottobre"
            11: "Novembre"
            12: "Dicembre"