### PR TITLE
[Bug fix] Corrected Chinese Staticman UI string

### DIFF
--- a/i18n/zh-CN.yaml
+++ b/i18n/zh-CN.yaml
@@ -49,11 +49,11 @@
 
 # Staticman
 - id: noComment
-  translation: "没有意见"
+  translation: "没有评论"
 - id: oneComment
-  translation: "评论"
+  translation: "则评论"
 - id: moreComment
-  translation: "评论"
+  translation: "则评论"
 - id: useMarkdown
   translation: "您可以使用Markdown语法"
 - id: yourName
@@ -67,7 +67,7 @@
 - id: show
   translation: "显示"
 - id: comments
-  translation: "条评论" 
+  translation: "则评论"
 
 # Related posts
 - id: seeAlso

--- a/i18n/zh-TW.yaml
+++ b/i18n/zh-TW.yaml
@@ -51,13 +51,13 @@
 - id: noComment
   translation: "沒有評論"
 - id: oneComment
-  translation: "評論"
+  translation: "則評論"
 - id: moreComment
-  translation: "更多評論"
+  translation: "則評論"
 - id: useMarkdown
   translation: "您可以使用Markdown語法"
 - id: yourName
-  translation: "您的大名"
+  translation: "您的名字"
 - id: yourEmail
   translation: "您的電子信箱"
 - id: yourWebsite
@@ -67,7 +67,7 @@
 - id: show
   translation: "顯示"
 - id: comments
-  translation: "條評論" 
+  translation: "則評論"
 
 # Related posts
 - id: seeAlso


### PR DESCRIPTION
As a native Cantonese speaker, I found the some Chinese UI strings for Staticman in #215 a bit unnatural.

Traditional Chinese characters `zh-TW` has been used for two thousand years in (but not limited to) the Han culture.  PRC's authorities "simplied" strokes in many characters and announced the "simplified characters" `zh-CN` decades ago in order to boost the literacy rate.  Therefore, we have (online) Simplified/Traditional character converters.

Here's a list of changes I've made.

1. `noComment`
    - "意见" means "opinion".  It *doesn't* match the rest of the existing translations.  I've replaced it to with "评论".
2. `oneComment`, `moreComment`, `comments`
    - In Chinese, most nouns have "units".  "則" sounds more natural to me than "條" in Cantonese (a spoken dialet of Chinese).  The former is used in Disqus's Traditional Chinese UI.
    - "more" can be litterally translated to "更多".  However, the existing translations for `moreComment` doesn't fit into this context because `{{ len $comments  }} {{ i18n "moreComment" }}` should be translated to "2 則評論" ("2 comments") instead of "2 更多評論", which *doesn't* make sense.
3. `yourName`: "名字" is a more appropriate translation to "name" for an HTML form's field name.

References:
[DISQUS 整合性留言管理系統 (支援 WordPress、Blogger)](https://sofree.cc/disqus/)