### PR TITLE
[Documentation] Changed to config.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,18 +61,23 @@ To use this feature, uncomment and fill out the `disqusShortname` parameter in `
 
 ### Staticman support
 
-Add *staticman* configuration section in `config.toml` or `config.yaml`
+Add *Staticman* configuration section in `config.toml` or `config.yaml`
 
-Sample `config.yaml` configuration
+Sample `config.toml` configuration
 
 ```
-  staticman:
-    api: https://api.staticman.net/v2/entry/<USERNAME>/<REPOSITORY-BLOGNAME>/master/comments
-    pulls: https://github.com/<USERNAME>/<REPOSITORY-BLOGNAME>/pulls
-    recaptcha:
+[Params.staticman]
+  api = "https://<API-ENDPOINT>/v3/entry/{GIT-HOST}/<USERNAME>/<REPOSITORY-BLOGNAME>/master/comments"
+[Params.staticman.recaptcha]
       sitekey: "6LeGeTgUAAAAAAqVrfTwox1kJQFdWl-mLzKasV0v"
       secret: "hsGjWtWHR4HK4pT7cUsWTArJdZDxxE2pkdg/ArwCguqYQrhuubjj3RS9C5qa8xu4cx/Y9EwHwAMEeXPCZbLR9eW1K9LshissvNcYFfC/b8KKb4deH4V1+oqJEk/JcoK6jp6Rr2nZV4rjDP9M7nunC3WR5UGwMIYb8kKhur9pAic="
 ```
+
+Note: The public `API-ENDPOINT` https://staticman.net is currently hitting its API limit, so one may use other API instances to provide Staticman comment service.
+
+The section `[Params.staticman.recaptcha]` is *optional*.  To add reCAPTCHA to your site, you have to replace the default values with your own ones (to be obtained from Google.)  The site `secret` has to be encrypted with
+
+    https://<API-ENDPOINT>/v3/encrypt/<SITE-SECRET>
 
 You must also configure the `staticman.yml` in you blog website.
 
@@ -99,7 +104,7 @@ comments:
     secret: "hsGjWtWHR4HK4pT7cUsWTArJdZDxxE2pkdg/ArwCguqYQrhuubjj3RS9C5qa8xu4cx/Y9EwHwAMEeXPCZbLR9eW1K9LshissvNcYFfC/b8KKb4deH4V1+oqJEk/JcoK6jp6Rr2nZV4rjDP9M7nunC3WR5UGwMIYb8kKhur9pAic="
 ```
 
-
+If you *don't* have the section `[Params.staticman]` in `config.toml`, you *won't* need the section `reCaptcha`  in `staticman.yml`
 
 ### Google Analytics
 


### PR DESCRIPTION
To match `config.toml` in `exampleSite`, its better to document the site config file in TOML.