### PR TITLE
[Enhancement]: Use Hugo's built-in GitInfo for Git commit SHA on the footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,20 +107,15 @@ To add Google Analytics, simply sign up to [Google Analytics](https://www.google
 
 ### Commit SHA on the footer
 
-If the source of your site is in a Git repo, the SHA corresponding to the commit the site is built from can be shown on the footer. To do so, two environment variables have to be set (`GIT_COMMIT_SHA` and `GIT_COMMIT_SHA_SHORT`) and parameter `commit` has to be defined in the config file:
+If the source of your site is in a Git repo, the SHA corresponding to the commit the site is built from can be shown on the footer. To do so, two site parameters `commit` has to be defined in the config file `config.toml`:
 
 ```
+enableGitInfo = true
 [Params]
   commit = "https://github.com/<username>/<siterepo>/tree/"
 ```
-  
-This can be achieved by running the next command prior to calling Hugo:
 
-```
-  GIT_COMMIT_SHA=`git rev-parse --verify HEAD` GIT_COMMIT_SHA_SHORT=`git rev-parse --short HEAD`
-```
-  
-See at [xor-gate/xor-gate.org](https://github.com/xor-gate/xor-gate.org) an example of how to add it to a continuous integration system.
+See at [vincenttam/vincenttam.gitlab.io](https://gitlab.com/vincenttam/vincenttam.gitlab.io) for an example of how to add it to a continuous integration system.
  
 ### Extra shortcodes
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -54,7 +54,7 @@
         <!-- Please don't remove this, keep my open source work credited :) -->
         <p class="credits theme-by text-muted">
           {{ i18n "poweredBy" . | safeHTML }}
-          {{ with .Site.Params.commit }}&nbsp;&bull;&nbsp;[<a href="{{.}}{{ getenv "GIT_COMMIT_SHA" }}">{{ getenv "GIT_COMMIT_SHA_SHORT" }}</a>]{{ end }}
+          {{ if $.GitInfo }}&nbsp;&bull;&nbsp;[<a href="{{ .Site.Params.commit }}{{ .GitInfo.Hash }}">{{ substr .GitInfo.Hash 0 8 }}</a>]{{ end }}
         </p>
       </div>
     </div>


### PR DESCRIPTION
The current Git commit SHA is GitHub specific.  That *doesn't* work on [GitLab](https://gitlab.com).

In fact, Hugo's [native Git variable](https://gohugo.io/variables/git/) enables display of Git repo information, provided that `enableGitInfo = true` in `config.toml`.

This enables Git commit SHA in whatever Git service provider, as well as in `hugo server`.