### PR TITLE
Fix #261

### DIFF
--- a/i18n/br.yaml
+++ b/i18n/br.yaml
@@ -33,7 +33,7 @@
 
 # Footer
 - id: poweredBy # Accepts HTML
-  translation: '<a href="http://gohugo.io">Hugo v{{ .Hugo.Version }}</a> powered &nbsp;&bull;&nbsp; Tema por <a href="http://deanattali.com/beautiful-jekyll/">Beautiful Jekyll</a> adaptado para <a href="https://github.com/halogenica/beautifulhugo">Beautiful Hugo</a>'
+  translation: '<a href="http://gohugo.io">Hugo v{{ .Site.Hugo.Version }}</a> powered &nbsp;&bull;&nbsp; Tema por <a href="http://deanattali.com/beautiful-jekyll/">Beautiful Jekyll</a> adaptado para <a href="https://github.com/halogenica/beautifulhugo">Beautiful Hugo</a>'
 
 # Navigation
 - id: toggleNavigation

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -33,7 +33,7 @@
 
 # Footer
 - id: poweredBy # Accepts HTML
-  translation: '<a href="http://gohugo.io">Hugo v{{ .Hugo.Version }}</a> powered &nbsp;&bull;&nbsp; Theme by <a href="http://deanattali.com/beautiful-jekyll/">Beautiful Jekyll</a> adapted to <a href="https://github.com/halogenica/beautifulhugo">Beautiful Hugo</a>'
+  translation: '<a href="http://gohugo.io">Hugo v{{ .Site.Hugo.Version }}</a> powered &nbsp;&bull;&nbsp; Theme by <a href="http://deanattali.com/beautiful-jekyll/">Beautiful Jekyll</a> adapted to <a href="https://github.com/halogenica/beautifulhugo">Beautiful Hugo</a>'
 
 # Navigation
 - id: toggleNavigation

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -33,7 +33,7 @@
 
 # Footer
 - id: poweredBy # Accepts HTML
-  translation: '<a href="http://gohugo.io">Hugo v{{ .Hugo.Version }}</a> powered &nbsp;&bull;&nbsp; Theme by <a href="http://deanattali.com/beautiful-jekyll/">Beautiful Jekyll</a> adapted to <a href="https://github.com/halogenica/beautifulhugo">Beautiful Hugo</a>'
+  translation: '<a href="http://gohugo.io">Hugo v{{ .Site.Hugo.Version }}</a> powered &nbsp;&bull;&nbsp; Theme by <a href="http://deanattali.com/beautiful-jekyll/">Beautiful Jekyll</a> adapted to <a href="https://github.com/halogenica/beautifulhugo">Beautiful Hugo</a>'
 
 # Navigation
 - id: toggleNavigation

--- a/i18n/eo.yaml
+++ b/i18n/eo.yaml
@@ -33,7 +33,7 @@
 
 # Footer
 - id: poweredBy # Accepts HTML
-  translation: '<a href="http://gohugo.io">Hugo v{{ .Hugo.Version }}</a>-povigita &nbsp;&bull;&nbsp; Haŭto de <a href="http://deanattali.com/beautiful-jekyll/">Beautiful Jekyll</a> adaptiĝis al <a href="https://github.com/halogenica/beautifulhugo">Beautiful Hugo</a>'
+  translation: '<a href="http://gohugo.io">Hugo v{{ .Site.Hugo.Version }}</a>-povigita &nbsp;&bull;&nbsp; Haŭto de <a href="http://deanattali.com/beautiful-jekyll/">Beautiful Jekyll</a> adaptiĝis al <a href="https://github.com/halogenica/beautifulhugo">Beautiful Hugo</a>'
 
 # Navigation
 - id: toggleNavigation

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -33,7 +33,7 @@
 
 # Footer
 - id: poweredBy # Accepts HTML
-  translation: '<a href="http://gohugo.io">Hugo v{{ .Hugo.Version }}</a> powered &nbsp;&bull;&nbsp; Theme by <a href="http://deanattali.com/beautiful-jekyll/">Beautiful Jekyll</a> adapted to <a href="https://github.com/halogenica/beautifulhugo">Beautiful Hugo</a>'
+  translation: '<a href="http://gohugo.io">Hugo v{{ .Site.Hugo.Version }}</a> powered &nbsp;&bull;&nbsp; Theme by <a href="http://deanattali.com/beautiful-jekyll/">Beautiful Jekyll</a> adapted to <a href="https://github.com/halogenica/beautifulhugo">Beautiful Hugo</a>'
 
 # Navigation
 - id: toggleNavigation

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -33,7 +33,7 @@
 
 # Footer
 - id: poweredBy # Accepts HTML
-  translation: 'Carbure avec <a href="http://gohugo.io">Hugo v{{ .Hugo.Version }}</a>&nbsp;&bull;&nbsp; Avec le Theme <a href="http://deanattali.com/beautiful-jekyll/">Beautiful Jekyll</a> adapté en <a href="https://github.com/halogenica/beautifulhugo">Beautiful Hugo</a>'
+  translation: 'Carbure avec <a href="http://gohugo.io">Hugo v{{ .Site.Hugo.Version }}</a>&nbsp;&bull;&nbsp; Avec le Theme <a href="http://deanattali.com/beautiful-jekyll/">Beautiful Jekyll</a> adapté en <a href="https://github.com/halogenica/beautifulhugo">Beautiful Hugo</a>'
 
 # Navigation
 - id: toggleNavigation

--- a/i18n/it.yaml
+++ b/i18n/it.yaml
@@ -33,7 +33,7 @@
 
 # Footer
 - id: poweredBy # Accepts HTML
-  translation: '<a href="http://gohugo.io">Sviluppato con Hugo v{{ .Hugo.Version }}</a> &nbsp;&bull;&nbsp; Tema: <a href="http://deanattali.com/beautiful-jekyll/">Beautiful Jekyll</a> adattato a <a href="https://github.com/halogenica/beautifulhugo">Beautiful Hugo</a>'
+  translation: '<a href="http://gohugo.io">Sviluppato con Hugo v{{ .Site.Hugo.Version }}</a> &nbsp;&bull;&nbsp; Tema: <a href="http://deanattali.com/beautiful-jekyll/">Beautiful Jekyll</a> adattato a <a href="https://github.com/halogenica/beautifulhugo">Beautiful Hugo</a>'
 
 # Navigation
 - id: toggleNavigation

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -33,7 +33,7 @@
 
 # Footer
 - id: poweredBy # Accepts HTML
-  translation: '起動力に<a href="http://gohugo.io">Hugo v{{ .Hugo.Version }}</a> &nbsp;&bull;&nbsp; テーマに<a href="http://deanattali.com/beautiful-jekyll/">Beautiful Jekyll</a>に基づいている<a href="https://github.com/halogenica/beautifulhugo">Beautiful Hugo</a>'
+  translation: '起動力に<a href="http://gohugo.io">Hugo v{{ .Site.Hugo.Version }}</a> &nbsp;&bull;&nbsp; テーマに<a href="http://deanattali.com/beautiful-jekyll/">Beautiful Jekyll</a>に基づいている<a href="https://github.com/halogenica/beautifulhugo">Beautiful Hugo</a>'
 
 # Navigation
 - id: toggleNavigation

--- a/i18n/nb.yaml
+++ b/i18n/nb.yaml
@@ -33,7 +33,7 @@
 
 # Footer
 - id: poweredBy # Accepts HTML
-  translation: 'Kjører på <a href="http://gohugo.io">Hugo v{{ .Hugo.Version }}</a>&nbsp;&bull;&nbsp; Tema fra <a href="http://deanattali.com/beautiful-jekyll/">Beautiful Jekyll</a> tilpasset til <a href="https://github.com/halogenica/beautifulhugo">Beautiful Hugo</a>'
+  translation: 'Kjører på <a href="http://gohugo.io">Hugo v{{ .Site.Hugo.Version }}</a>&nbsp;&bull;&nbsp; Tema fra <a href="http://deanattali.com/beautiful-jekyll/">Beautiful Jekyll</a> tilpasset til <a href="https://github.com/halogenica/beautifulhugo">Beautiful Hugo</a>'
 
 # Navigation
 - id: toggleNavigation

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -33,7 +33,7 @@
 
 # Footer
 - id: poweredBy # Accepts HTML
-  translation: '<a href="http://gohugo.io">Hugo v{{ .Hugo.Version }}</a>-aangedreven &nbsp;&bull;&nbsp; Thema door <a href="http://deanattali.com/beautiful-jekyll/">Beautiful Jekyll</a> aangepast voor <a href="https://github.com/halogenica/beautifulhugo">Beautiful Hugo</a>'
+  translation: '<a href="http://gohugo.io">Hugo v{{ .Site.Hugo.Version }}</a>-aangedreven &nbsp;&bull;&nbsp; Thema door <a href="http://deanattali.com/beautiful-jekyll/">Beautiful Jekyll</a> aangepast voor <a href="https://github.com/halogenica/beautifulhugo">Beautiful Hugo</a>'
 
 # Navigation
 - id: toggleNavigation

--- a/i18n/pl.yaml
+++ b/i18n/pl.yaml
@@ -33,7 +33,7 @@
 
 # Footer
 - id: poweredBy # Accepts HTML
-  translation: '<a href="http://gohugo.io">Hugo v{{ .Hugo.Version }}</a> powered &nbsp;&bull;&nbsp; Theme by <a href="http://deanattali.com/beautiful-jekyll/">Beautiful Jekyll</a> adapted to <a href="https://github.com/halogenica/beautifulhugo">Beautiful Hugo</a>'
+  translation: '<a href="http://gohugo.io">Hugo v{{ .Site.Hugo.Version }}</a> powered &nbsp;&bull;&nbsp; Theme by <a href="http://deanattali.com/beautiful-jekyll/">Beautiful Jekyll</a> adapted to <a href="https://github.com/halogenica/beautifulhugo">Beautiful Hugo</a>'
 
 # Navigation
 - id: toggleNavigation

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -33,7 +33,7 @@
 
 # Footer
 - id: poweredBy # Accepts HTML
-  translation: 'На базе <a href="http://gohugo.io">Hugo v{{ .Hugo.Version }}</a> &nbsp;&bull;&nbsp; Тема <a href="https://github.com/halogenica/beautifulhugo">Beautiful Hugo</a> на базе <a href="http://deanattali.com/beautiful-jekyll/">Beautiful Jekyll</a>'
+  translation: 'На базе <a href="http://gohugo.io">Hugo v{{ .Site.Hugo.Version }}</a> &nbsp;&bull;&nbsp; Тема <a href="https://github.com/halogenica/beautifulhugo">Beautiful Hugo</a> на базе <a href="http://deanattali.com/beautiful-jekyll/">Beautiful Jekyll</a>'
 
 # Navigation
 - id: toggleNavigation

--- a/i18n/zh-CN.yaml
+++ b/i18n/zh-CN.yaml
@@ -33,7 +33,7 @@
 
 # Footer
 - id: poweredBy # Accepts HTML
-  translation: '由 <a href="http://gohugo.io">Hugo v{{ .Hugo.Version }}</a> 强力驱动 &nbsp;&bull;&nbsp; 主题 <a href="https://github.com/halogenica/beautifulhugo">Beautiful Hugo</a> 移植自 <a href="http://deanattali.com/beautiful-jekyll/">Beautiful Jekyll</a>'
+  translation: '由 <a href="http://gohugo.io">Hugo v{{ .Site.Hugo.Version }}</a> 强力驱动 &nbsp;&bull;&nbsp; 主题 <a href="https://github.com/halogenica/beautifulhugo">Beautiful Hugo</a> 移植自 <a href="http://deanattali.com/beautiful-jekyll/">Beautiful Jekyll</a>'
 
 # Navigation
 - id: toggleNavigation

--- a/i18n/zh-TW.yaml
+++ b/i18n/zh-TW.yaml
@@ -33,7 +33,7 @@
 
 # Footer
 - id: poweredBy # Accepts HTML
-  translation: '由 <a href="http://gohugo.io">Hugo v{{ .Hugo.Version }}</a> 提供 &nbsp;&bull;&nbsp; 主題 <a href="https://github.com/halogenica/beautifulhugo">Beautiful Hugo</a> 移植自 <a href="http://deanattali.com/beautiful-jekyll/">Beautiful Jekyll</a>'
+  translation: '由 <a href="http://gohugo.io">Hugo v{{ .Site.Hugo.Version }}</a> 提供 &nbsp;&bull;&nbsp; 主題 <a href="https://github.com/halogenica/beautifulhugo">Beautiful Hugo</a> 移植自 <a href="http://deanattali.com/beautiful-jekyll/">Beautiful Jekyll</a>'
 
 # Navigation
 - id: toggleNavigation

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -47,12 +47,12 @@
           <ul class="pager main-pager">
             {{ if .Paginator.HasPrev }}
               <li class="previous">
-                <a href="{{ .URL }}page/{{ .Paginator.Prev.PageNumber }}/">&larr; {{ i18n "newerPosts" }}</a>
+                <a href="{{ .Permalink }}page/{{ .Paginator.Prev.PageNumber }}/">&larr; {{ i18n "newerPosts" }}</a>
               </li>
             {{ end }}
             {{ if .Paginator.HasNext }}
               <li class="next">
-                <a href="{{ .URL }}page/{{ .Paginator.Next.PageNumber }}/">{{ i18n "olderPosts" }} &rarr;</a>
+                <a href="{{ .Permalink }}page/{{ .Paginator.Next.PageNumber }}/">{{ i18n "olderPosts" }} &rarr;</a>
               </li>
             {{ end }}
           </ul>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -49,12 +49,12 @@
           <ul class="pager main-pager">
             {{ if .Paginator.HasPrev }}
               <li class="previous">
-                <a href="{{ .URL }}page/{{ .Paginator.Prev.PageNumber }}/">&larr; {{ i18n "newerPosts" }}</a>
+                <a href="{{ .Permalink }}page/{{ .Paginator.Prev.PageNumber }}/">&larr; {{ i18n "newerPosts" }}</a>
               </li>
             {{ end }}
             {{ if .Paginator.HasNext }}
               <li class="next">
-                <a href="{{ .URL }}page/{{ .Paginator.Next.PageNumber }}/">{{ i18n "olderPosts" }} &rarr;</a>
+                <a href="{{ .Permalink }}page/{{ .Paginator.Next.PageNumber }}/">{{ i18n "olderPosts" }} &rarr;</a>
               </li>
             {{ end }}
           </ul>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -17,11 +17,7 @@
           {{ end }}
           {{ if .Site.Params.rss }}
           <li>
-            {{ if .RSSLink }}
-            <a href="{{ .RSSLink }}" title="RSS">
-            {{ else }}
-            <a href="{{ .Site.RSSLink }}" title="RSS">
-            {{ end }}
+            <a href="{{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}" title="RSS">
               <span class="fa-stack fa-lg">
                 <i class="fas fa-circle fa-stack-2x"></i>
                 <i class="fas fa-rss fa-stack-1x fa-inverse"></i>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -57,11 +57,11 @@
 {{- with .Site.Params.fb_app_id }}
   <meta property="fb:app_id" content="{{ . }}" />
 {{- end }}
-  <meta property="og:url" content="{{ .URL | absLangURL }}" />
+  <meta property="og:url" content="{{ .Permalink | absLangURL }}" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="{{ .Site.Title }}" />
 <!-- Hugo Version number -->
-  {{ .Hugo.Generator -}}
+  {{ hugo.Generator -}}
 <!-- Links and stylesheets -->
   <link rel="alternate" href="{{ "index.xml" | absLangURL }}" type="application/rss+xml" title="{{ .Site.Title }}">
 

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -18,7 +18,7 @@
   {{ end }}
   {{- if .Site.Params.staticman -}}
     &nbsp;|&nbsp;<i class="fas fa-comment"></i>&nbsp;
-    {{ $slug := replace .URL "/" "" }}
+    {{ $slug := replace .relPermalink "/" "" }}
     {{ if .Site.Data.comments }}
       {{ $comments := index $.Site.Data.comments $slug }}
       {{ if $comments }}

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -18,7 +18,7 @@
   {{ end }}
   {{- if .Site.Params.staticman -}}
     &nbsp;|&nbsp;<i class="fas fa-comment"></i>&nbsp;
-    {{ $slug := replace .relPermalink "/" "" }}
+    {{ $slug := replace .RelPermalink "/" "" }}
     {{ if .Site.Data.comments }}
       {{ $comments := index $.Site.Data.comments $slug }}
       {{ if $comments }}

--- a/layouts/partials/seo/opengraph.html
+++ b/layouts/partials/seo/opengraph.html
@@ -10,6 +10,6 @@
 {{- with .Site.Params.fb_app_id }}
 <meta property="fb:app_id" content="{{ . }}" />
 {{- end }}
-<meta property="og:url" content="{{ .URL | absLangURL }}" />
+<meta property="og:url" content="{{ .Permalink | absLangURL }}" />
 <meta property="og:type" content="website" />
 <meta property="og:site_name" content="{{ .Site.Title }}" />

--- a/layouts/partials/staticman-comments.html
+++ b/layouts/partials/staticman-comments.html
@@ -1,6 +1,6 @@
 <section class="js-comments staticman-comments">
 
-  {{ $slug := replace .URL "/" "" }}
+  {{ $slug := replace .relPermalink "/" "" }}
 
   {{ if .Site.Data.comments }}
     {{ $comments := index $.Site.Data.comments $slug }}
@@ -36,7 +36,7 @@
 
 
 <form class="js-form form" method="post" action="{{ .Site.Params.staticman.api }}">
-  <input type="hidden" name="options[slug]" value="{{ replace .URL "/" "" }}">
+  <input type="hidden" name="options[slug]" value="{{ replace .relPermalink "/" "" }}">
   <input type="hidden" name="options[parent]" value="">
 
   {{ if .Site.Params.staticman.recaptcha }}

--- a/layouts/partials/staticman-comments.html
+++ b/layouts/partials/staticman-comments.html
@@ -1,6 +1,6 @@
 <section class="js-comments staticman-comments">
 
-  {{ $slug := replace .relPermalink "/" "" }}
+  {{ $slug := replace .RelPermalink "/" "" }}
 
   {{ if .Site.Data.comments }}
     {{ $comments := index $.Site.Data.comments $slug }}
@@ -36,7 +36,7 @@
 
 
 <form class="js-form form" method="post" action="{{ .Site.Params.staticman.api }}">
-  <input type="hidden" name="options[slug]" value="{{ replace .relPermalink "/" "" }}">
+  <input type="hidden" name="options[slug]" value="{{ replace .RelPermalink "/" "" }}">
   <input type="hidden" name="options[parent]" value="">
 
   {{ if .Site.Params.staticman.recaptcha }}


### PR DESCRIPTION
# Overview

This PR resolves #261 by replacing _deprecated_ Hugo syntax with updated one.

`hugo server`'s response to the _current_ syntax

```
Building sites … WARN 2019/04/09 10:14:55 Page's .URL is deprecated and will be removed in a future release. Use .Permalink or .RelPermalink. If what you want is the front matter URL value, use .Params.url.
WARN 2019/04/09 10:14:55 Page's .Hugo is deprecated and will be removed in a future release. Use the global hugo function.
WARN 2019/04/09 10:14:55 Page's .RSSLink is deprecated and will be removed in a future release. Use the Output Format's link, e.g. something like:
    {{ with .OutputFormats.Get "RSS" }}{{ . RelPermalink }}{{ end }}.
```

Message source: https://gist.github.com/chris-short/78582dc32f877d65eb388f832d2c1dfa

# Changes implemented

1. `{{ .Hugo.Generator }}` → `{{ hugo.Generator }}`
2. `{{ .RSSLink }}` → `{{ with .OutputFormats.Get "RSS" }}{{ . RelPermalink }}{{ end }}`
3. `{{ .Hugo.Version }}` → `{{ .Site.Hugo.Version }}`
4. `{{ .URL }}` →
    - `{{ .Permalink }}` in "Older/Newer Posts", `<meta>` tag
    - `{{ .RelPermalink }}` in page's `slug` for [Staticman](https://staticman.net/)

# Quick guide to test this pull request

If you're using a theme as a Git submodule (as recommended in Hugo's official tutorial), you may create a new (local/GitLab/etc) (private) repo for this theme and run these commands to get this PR merged against a testing branch `pr269` in the private repo.  I denote the URL of this repo as the `upstream`.

```
$ git remote -v
upstream	https://github.com/halogenica/beautifulhugo.git (fetch)
upstream	https://github.com/halogenica/beautifulhugo.git (push)
... # other remote omitted
$ git checkout -b pr269 # test on a new branch pr269
$ git fetch upstream pull/269/head # git pull will be rejected
$ git merge FETCH_HEAD # manually merge the this PR against branch pr269
$ cd <your-blog>
... # edit your .gitmodules with url="<repo-containing-pr269>" and branch = "pr269"
$ git submodule sync # inform Git the changes in .gitmodules
$ git submodule update --remote --recursive # switch to the HEAD of your cloned repo for the theme
```

Related posts:

1. [My SO question](https://stackoverflow.com/q/55836908/3184351)
2. [.Hugo.Generator は廃止されるので hugo.Generator を使おう](https://qiita.com/peaceiris/items/b6d611e184b2f28cc0ab)
3. [My Hugo Discourse question](https://discourse.gohugo.io/t/show-hugos-version-number-in-yaml-file/18288?u=vincenttam)
4. victoriadotdev/hugo-theme-introduction#146
5. [My dedicated blog post](https://vincenttam.gitlab.io/post/2019-04-25-replacing-deprecated-hugo-syntax-in-blog-theme/)