### PR TITLE
Fixed error from HTML5 validator and used input type URL

### DIFF
--- a/layouts/partials/staticman-comments.html
+++ b/layouts/partials/staticman-comments.html
@@ -46,7 +46,7 @@
 
   <fieldset>
   <div class="textfield">
-    <textarea name="fields[comment]" type="text" placeholder="{{ i18n "useMarkdown" }}"></textarea>
+    <textarea name="fields[comment]" placeholder="{{ i18n "useMarkdown" }}"></textarea>
   </div>
   </fieldset>
 

--- a/layouts/partials/staticman-comments.html
+++ b/layouts/partials/staticman-comments.html
@@ -64,7 +64,7 @@
 
   <fieldset>
     <div class="textfield">
-      <input type="text" name="fields[website]"  placeholder="{{ i18n "yourWebsite" }}"/>
+      <input type="url" name="fields[website]"  placeholder="{{ i18n "yourWebsite" }}"/>
     </div>
   </fieldset>
 


### PR DESCRIPTION
From the [HTML standard for `<textarea>`](https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element), the attribute `type` is *not* listed under "[**Content attributes**](https://html.spec.whatwg.org/multipage/dom.html#concept-element-attributes)".  As a consequence, passing _any_ site with [Staticman](https://staticman.net/) _enabled_ would reproduce this error in [W3C's HTML5 validator](https://validator.w3.org/nu/):

> **Error: Attribute `type` not allowed on element [`textarea`](https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element) at this point.**