### PR TITLE
Fixed staticman.css typo

### DIFF
--- a/static/css/staticman.css
+++ b/static/css/staticman.css
@@ -82,7 +82,7 @@
  	height: 10em;
 }
 
-form--loading:before {
+.form--loading:before {
 	content: '';
 }
 


### PR DESCRIPTION
Found this while porting my PR for nested Staticman comments to [Huginn](https://framagit.org/staticman-gitlab-pages/huginn).  Btw, `:before` is CSS2 syntax, and its CSS3 counterpart is `::before`.

Reference: https://developer.mozilla.org/en-US/docs/Web/CSS/::before