### PR TITLE
Authors link on posts implemented 

### DIFF
--- a/exampleSite/content/post/2017-03-20-photoswipe-gallery-sample.md
+++ b/exampleSite/content/post/2017-03-20-photoswipe-gallery-sample.md
@@ -2,6 +2,8 @@
 title: Photoswipe Gallery Sample
 subtitle: Making a Gallery
 date: 2017-03-20
+author: Cassio Batista
+author_link: https://cassota.gitlab.io/
 tags: ["example", "photoswipe"]
 ---
 

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -12,7 +12,11 @@
     &nbsp;|&nbsp;<i class="fas fa-book"></i>&nbsp;{{ .WordCount }}&nbsp;{{ i18n "words" }}
   {{ end }}
   {{ if .Params.author }}
-    &nbsp;|&nbsp;<i class="fas fa-user"></i>&nbsp;{{ .Params.author | safeHTML }}
+    {{ if .Params.author_link }}
+      &nbsp;|&nbsp;<i class="fas fa-user"></i>&nbsp;<a href="{{ .Params.author_link | safeHTML }}" target="_blank">{{ .Params.author | safeHTML }}</a>
+    {{ else }}
+      &nbsp;|&nbsp;<i class="fas fa-user"></i>&nbsp;{{ .Params.author | safeHTML }}
+    {{ end }}
   {{ else }}
     &nbsp;|&nbsp;<i class="fas fa-user"></i>&nbsp;{{ .Site.Author.name | safeHTML }}
   {{ end }}


### PR DESCRIPTION
## Purpose
This PR solves issue #288 to allow author names on posts to be clickable and lead to an eventual personal webpage, which would obviously be exclusive for each author and defined at the post's front matter via `author_link` parameter.

## Layout screen
It can be seen at issue #288 

## Details
- file `layouts/partials/post_meta.html` updated with an HTML tag `<a>` to make the author name clickable
- file `exampleSite/content/post/2017...photoswipe....md` updated with the `author_link` param leading to my personal academic webpage as example.