### PR TITLE
Fixed tags and categories links

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -47,12 +47,12 @@
           <ul class="pager main-pager">
             {{ if .Paginator.HasPrev }}
               <li class="previous">
-                <a href="{{ printf "page/%d" .Paginator.Prev.PageNumber | relLangURL }}">&larr; {{ i18n "newerPosts" }}</a>
+                <a href="{{ path.Join .RelPermalink "page" .Paginator.Prev.PageNumber }}">&larr; {{ i18n "newerPosts" }}</a>
               </li>
             {{ end }}
             {{ if .Paginator.HasNext }}
               <li class="next">
-                <a href="{{ printf "page/%d" .Paginator.Next.PageNumber | relLangURL }}">{{ i18n "olderPosts" }} &rarr;</a>
+                <a href="{{ path.Join .RelPermalink "page" .Paginator.Next.PageNumber }}">{{ i18n "olderPosts" }} &rarr;</a>
               </li>
             {{ end }}
           </ul>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -35,7 +35,7 @@
               {{ if .Params.tags }}
                 <div class="blog-tags">
                   {{ range .Params.tags }}
-                    <a href="{{ $.Site.LanguagePrefix | absURL }}/tags/{{ . | urlize }}/">{{ . }}</a>&nbsp;
+                    <a href="{{ printf "tags/%s" (urlize .) | relLangURL }}">{{ . }}</a>&nbsp;
                   {{ end }}
                 </div>
               {{ end }}
@@ -47,12 +47,12 @@
           <ul class="pager main-pager">
             {{ if .Paginator.HasPrev }}
               <li class="previous">
-                <a href="{{ .Permalink }}page/{{ .Paginator.Prev.PageNumber }}/">&larr; {{ i18n "newerPosts" }}</a>
+                <a href="{{ printf "page/%d" .Paginator.Prev.PageNumber | relLangURL }}">&larr; {{ i18n "newerPosts" }}</a>
               </li>
             {{ end }}
             {{ if .Paginator.HasNext }}
               <li class="next">
-                <a href="{{ .Permalink }}page/{{ .Paginator.Next.PageNumber }}/">{{ i18n "olderPosts" }} &rarr;</a>
+                <a href="{{ printf "page/%d" .Paginator.Next.PageNumber | relLangURL }}">{{ i18n "olderPosts" }} &rarr;</a>
               </li>
             {{ end }}
           </ul>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -8,7 +8,7 @@
         {{ if .Params.tags }}
           <div class="blog-tags">
             {{ range .Params.tags }}
-              <a href="{{ $.Site.LanguagePrefix | absURL }}/tags/{{ . | urlize }}/">{{ . }}</a>&nbsp;
+              <a href="{{ printf "tags/%s" (urlize .) | relLangURL }}">{{ . }}</a>&nbsp;
             {{ end }}
           </div>
         {{ end }}
@@ -54,7 +54,7 @@
       {{ if (.Params.comments) | or (and (or (not (isset .Params "comments")) (eq .Params.comments nil)) (and .Site.Params.comments (ne .Type "page"))) }}
         {{ if .Site.DisqusShortname }}
           {{ if .Site.Params.delayDisqus }}
-          <div class="disqus-comments">                  
+          <div class="disqus-comments">
             <button id="show-comments" class="btn btn-default" type="button">{{ i18n "show" }} <span class="disqus-comment-count" data-disqus-url="{{ trim .Permalink "/" }}">{{ i18n "comments" }}</span></button>
             <div id="disqus_thread"></div>
 

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -3,7 +3,7 @@
 {{ $data := .Data }}
 
 <div class="container" role="main">
-  <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1"> 
+  <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
     <article class="post-preview">
       <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
         {{ range $key, $value := .Data.Terms.ByCount }}
@@ -18,7 +18,7 @@
             </a>
             <div id="collapse{{ $value.Name }}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading{{ $value.Name }}">
               <div class="panel-body">
-                <a href="{{ $.Site.LanguagePrefix | absURL }}/{{ $data.Plural }}/{{ $value.Name | urlize }}/" class="list-group-item view-all">
+                <a href="{{ printf "%s/%s/" $data.Plural (urlize $value.Name) | relLangURL }}" class="list-group-item view-all">
                 View all</a>
                 <div class="list-group">
                   {{ range $item := $value.WeightedPages }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -37,7 +37,7 @@
               {{ if .Params.tags }}
                 <div class="blog-tags">
                   {{ range .Params.tags }}
-                    <a href="{{ $.Site.LanguagePrefix | absURL }}/tags/{{ . | urlize }}/">{{ . }}</a>&nbsp;
+                    <a href="{{ printf "tags/%s" (urlize .) | relLangURL }}">{{ . }}</a>&nbsp;
                   {{ end }}
                 </div>
               {{ end }}
@@ -49,12 +49,12 @@
           <ul class="pager main-pager">
             {{ if .Paginator.HasPrev }}
               <li class="previous">
-                <a href="{{ .Permalink }}page/{{ .Paginator.Prev.PageNumber }}/">&larr; {{ i18n "newerPosts" }}</a>
+                <a href="{{ printf "page/%d" .Paginator.Prev.PageNumber | relLangURL }}">&larr; {{ i18n "newerPosts" }}</a>
               </li>
             {{ end }}
             {{ if .Paginator.HasNext }}
               <li class="next">
-                <a href="{{ .Permalink }}page/{{ .Paginator.Next.PageNumber }}/">{{ i18n "olderPosts" }} &rarr;</a>
+                <a href="{{ printf "page/%d" .Paginator.Next.PageNumber | relLangURL }}">{{ i18n "olderPosts" }} &rarr;</a>
               </li>
             {{ end }}
           </ul>


### PR DESCRIPTION
Resolve #123 by using Hugo's internal [`relLangURL`](https://gohugo.io/functions/rellangurl/) method.

References:

1. [Hugo Discourse about `absURL`](https://discourse.gohugo.io/t/forward-slashes-in-url/933/17?u=vincenttam)
2. [`/subpath/staring/with/slash` isn't quite portable](https://github.com/gohugoio/hugo/issues/4733#issuecomment-390200427)
3. [Hugo Theme's common permalink issues](https://github.com/gohugoio/hugoThemes#common-permalink-issues)