### PR TITLE
Use Site.RegularPages for index

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -9,7 +9,7 @@
         {{ end }}
 
         <div class="posts-list">
-          {{ $pag := .Paginate (where .Data.Pages "Type" "post") }}
+          {{ $pag := .Paginate (where .Site.RegularPages "Type" "post") }}
           {{ range $pag.Pages }}
             <article class="post-preview">
               <a href="{{ .Permalink }}">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -9,7 +9,7 @@
         {{ end }}
 
         <div class="posts-list">
-          {{ $pag := .Paginate (where .Site.RegularPages "Type" "post") }}
+          {{ $pag := .Paginate (where site.RegularPages "Type" "in" site.Params.mainSections) }}
           {{ range $pag.Pages }}
             <article class="post-preview">
               <a href="{{ .Permalink }}">


### PR DESCRIPTION
Index page will only contain "Posts" link when built with hugo `v0.57.0`. It is caused by change of semantics of `.Pages` as noted on the release notes - https://github.com/gohugoio/hugo/releases/tag/v0.57.0

See issue #300 