### PR TITLE
Fix details for Hugo 0.60+

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,9 @@ There are two extra shortcodes provided (along with the customized figure shortc
 This simply adds the html5 detail attribute, supported on all *modern* browsers. Use it like this:
 
 ```
-{{% details "This is the details title (click to expand)" %}}
+{{< details "This is the details title (click to expand)" >}}
 This is the content (hidden until clicked).
-{{% /details %}}
+{{< /details >}}
 ```
 
 #### Split

--- a/layouts/shortcodes/details.html
+++ b/layouts/shortcodes/details.html
@@ -1,3 +1,3 @@
 <details><summary>{{ .Get 0 }}</summary>
-{{ .Inner }}
+{{ .Inner | markdownify }}
 </details>

--- a/layouts/shortcodes/details.html
+++ b/layouts/shortcodes/details.html
@@ -1,3 +1,3 @@
-<details><summary>{{ .Get 0 }}</summary>
+<details><summary>{{ .Get 0 | markdownify }}</summary>
 {{ .Inner | markdownify }}
 </details>


### PR DESCRIPTION
The markdown parser now strips raw html (since Hugo 0.60), so `{{<>}}` is required for all shortcodes containing HTML. This will cause the details shortcode to start failing to render markdown if the change is made. This fixes it to continue to render markdown inside.