### PR TITLE
Fix dateFormat translation for RU

### DIFF
--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -1,6 +1,6 @@
 # Content
 - id: dateFormat
-  translation: "Январь 2, 2006"
+  translation: "02.01.2006"
 - id: shortdateFormat
   translation: "2 Jan, 2006 15:04:05"
 - id: postedOnDate


### PR DESCRIPTION
Hello. I use two languages for my blog. But in Russian translate date shows incorrectly.
This change is helping me to fix bug

The incorrect "translated" date. ( Current master ) 
As you can see here the all months is "Январь" but it is not a real date.
![date](https://user-images.githubusercontent.com/20345096/71450984-796c0280-2775-11ea-85fa-4ef8a3dabdb0.png)

The correct date ( After this changes ) 
![date2](https://user-images.githubusercontent.com/20345096/71450985-7bce5c80-2775-11ea-9c76-cc56974fa3dc.png)
