### PR TITLE
Let Hugo resize the Post Preview Image in Overviews

### DIFF
--- a/layouts/partials/post_preview.html
+++ b/layouts/partials/post_preview.html
@@ -6,8 +6,15 @@
             {{ .Params.subtitle }}
         </h3>
         {{ end }}
-        {{ if .Params.image }}
-        <img src="{{ .Params.image }}" alt="{{ .Title }}" class="img-title" />
+        {{ $images := .Resources.Match "*_header.{png,jpg}" }}
+        {{ if or (.Params.image) ($images) }}
+            {{ with $images }}
+                {{ $image := index (.) 0 }}
+                {{ $image := $image.Resize "750x" }}
+                <img src="{{ $image.RelPermalink }}" title="{{ $.Page.Title }}" class="img-title" />
+            {{ else }}
+                <img src="{{ $.Page.Params.image }}" alt="{{ $.Page.Title }}" class="img-title" />
+            {{ end }}
         {{ end }}
         {{ if .Params.video }}
         <video loop autoplay muted playsinline class="img-title">

--- a/layouts/partials/seo/opengraph.html
+++ b/layouts/partials/seo/opengraph.html
@@ -4,7 +4,7 @@
 {{- with .Description | default .Params.subtitle | default .Summary }}
 <meta property="og:description" content="{{ . }}">
 {{- end }}
-{{- with .Params.share_img | default .Params.image | default .Site.Params.logo }}
+{{- with .Params.share_img | default (partial "seo/preview_image.html" .) | default .Params.image | default .Site.Params.logo }}
 <meta property="og:image" content="{{ . | absURL }}" />
 {{- end }}
 {{- with .Site.Params.fb_app_id }}

--- a/layouts/partials/seo/preview_image.html
+++ b/layouts/partials/seo/preview_image.html
@@ -1,0 +1,4 @@
+{{- $preview := .Page.Resources.Match "*_header.{png,jpg}" -}}
+{{- if $preview -}}
+  {{- return (index ($preview) 0).RelPermalink -}}
+{{- end -}}

--- a/layouts/partials/seo/twitter.html
+++ b/layouts/partials/seo/twitter.html
@@ -7,7 +7,7 @@
 {{- with .Params.share_img | default .Params.image | default .Site.Params.logo }}
   <meta name="twitter:image" content="{{ . | absURL }}" />
 {{- end }}
-  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:card" content="summary_large_image" />
 {{- with .Site.Author.twitter }}
   <meta name="twitter:site" content="@{{ . }}" />
   <meta name="twitter:creator" content="@{{ . }}" />

--- a/layouts/partials/seo/twitter.html
+++ b/layouts/partials/seo/twitter.html
@@ -4,7 +4,9 @@
 {{- with .Description | default .Params.subtitle | default .Summary }}
   <meta name="twitter:description" content="{{ . | truncate 200 }}">
 {{- end }}
-{{- with .Params.share_img | default .Params.image | default .Site.Params.logo }}
+
+
+{{- with .Params.share_img | default (partial "seo/preview_image.html" .) | default .Params.image | default .Site.Params.logo }}
   <meta name="twitter:image" content="{{ . | absURL }}" />
 {{- end }}
   <meta name="twitter:card" content="summary_large_image" />


### PR DESCRIPTION
For a smaller Post Preview Image I changed the way of adding it to the post_overwiew.
It use the Hugo [Resize](https://gohugo.io/content-management/image-processing/#resize) function to fit it to the max size of image withe. 
Therefore the Image have to be stored in the post folder with `*_header.{png,jpg}`as name.

The old way with the page variable will also work, but without resizing.