### PR TITLE
use page leaf bundle image resources with figure shortcode

### DIFF
--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -10,10 +10,15 @@ Documentation and licence at https://github.com/liwenyip/hugo-easy-gallery/
 {{- $thumb := .Get "src" | default (printf "%s." (.Get "thumb") | replace (.Get "link") ".") }}
 <div class="box{{ with .Get "caption-position" }} fancy-figure caption-position-{{.}}{{end}}{{ with .Get "caption-effect" }} caption-effect-{{.}}{{end}}" {{ with .Get "width" }}style="max-width:{{.}}"{{end}}>
   <figure {{ with .Get "class" }}class="{{.}}"{{ end }} itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject">
-    <div class="img"{{ if .Parent }} style="background-image: url('{{ print .Site.BaseURL $thumb }}');"{{ end }}{{ with .Get "size" }} data-size="{{.}}"{{ end }}>
-      <img itemprop="thumbnail" src="{{ $thumb }}" {{ with .Get "alt" | default (.Get "caption") | default $thumb }}alt="{{.}}"{{ end }}/><!-- <img> hidden if in .gallery -->
+    <div class="img"{{ if .Parent }} {{ with $.Page.Resources.GetMatch $thumb }} style="background-image: url('{{ .Permalink }}');"{{ end }}{{ end }}{{ with .Get "size" }} data-size="{{.}}"{{ end }}>
+      {{ $altText := .Get "caption" | default (.Get "alt") | default $thumb }}
+      {{ with $.Page.Resources.GetMatch $thumb }}
+      <img itemprop="thumbnail" src="{{ .Permalink }}" alt="{{$altText}}" /><!-- <img> hidden if in .gallery -->
+      {{ end }}
     </div>
-    {{ with .Get "link" | default (.Get "src") }}<a href="{{.}}" itemprop="contentUrl"></a>{{ end }}
+    {{ with $.Page.Resources.GetMatch (.Get "link") }}
+    <a href="{{ .Permalink }}" itemprop="contentUrl"></a>
+    {{ end }}
     {{- if or (or (.Get "title") (.Get "caption")) (.Get "attr")}}
       <figcaption>
         {{- with .Get "title" }}<h4>{{.}}</h4>{{ end }}


### PR DESCRIPTION
This change allows you to use [page leaf bundle](https://gohugo.io/content-management/page-bundles/#leaf-bundles) image resources with the `< figure >` shortcode. This means you can use images stored with the post in a directory instead of having to store all of your images in the root static directory.

Additional changes would be needed to support directory galleries. They might be here https://github.com/liwenyip/hugo-easy-gallery/issues/54 but I have no need for this so I didn't spend any time reviewing it.