### PR TITLE
fix: support dates in Hugo 0.76 (but not earlier)

### DIFF
--- a/i18n/br.yaml
+++ b/i18n/br.yaml
@@ -4,9 +4,9 @@
 - id: shortdateFormat
   translation: "02/Jan/2006 15:04:05"
 - id: postedOnDate
-  translation: "Postado em {{ .Count }}"
+  translation: "Postado em {{ . }}"
 - id: lastModified
-  translation: "(Ultima modificação em {{ .Count }})"
+  translation: "(Ultima modificação em {{ . }})"
 - id: translationsLabel
   translation: "Outras linguagens: "
 - id: translationsSeparator

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -4,9 +4,9 @@
 - id: shortdateFormat
   translation: "2 Jan, 2006 15:04:05"
 - id: postedOnDate
-  translation: "Gepostet am {{ .Count }}"
+  translation: "Gepostet am {{ . }}"
 - id: lastModified
-  translation: "(Zuletzt geändert am {{ .Count }})"
+  translation: "(Zuletzt geändert am {{ . }})"
 - id: translationsLabel
   translation: "Andere Sprachen: "
 - id: translationsSeparator

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -4,9 +4,9 @@
 - id: shortdateFormat
   translation: "Jan 2, 2006 15:04:05"
 - id: postedOnDate
-  translation: "Posted on {{ .Count }}"
+  translation: "Posted on {{ . }}"
 - id: lastModified
-  translation: "(Last modified on {{ .Count }})"
+  translation: "(Last modified on {{ . }})"
 - id: translationsLabel
   translation: "Other languages: "
 - id: translationsSeparator

--- a/i18n/eo.yaml
+++ b/i18n/eo.yaml
@@ -4,9 +4,9 @@
 - id: shortdateFormat
   translation: "2 Jan, 2006 15:04:05"
 - id: postedOnDate
-  translation: "Afiŝiĝis je {{ .Count }}"
+  translation: "Afiŝiĝis je {{ . }}"
 - id: lastModified
-  translation: "(Laste aliiĝis je {{ .Count }})"
+  translation: "(Laste aliiĝis je {{ . }})"
 - id: translationsLabel
   translation: "Aliaj lingvoj: "
 - id: translationsSeparator

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -4,9 +4,9 @@
 - id: shortdateFormat
   translation: "2 Jan, 2006 15:04:05"
 - id: postedOnDate
-  translation: "Publicado el {{ .Count }}"
+  translation: "Publicado el {{ . }}"
 - id: lastModified
-  translation: "(Última modificación en {{ .Count }})"
+  translation: "(Última modificación en {{ . }})"
 - id: translationsLabel
   translation: "Otros idiomas: "
 - id: translationsSeparator

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -4,9 +4,9 @@
 - id: shortdateFormat
   translation: "2 Jan, 2006 15:04:05"
 - id: postedOnDate
-  translation: "Posté le {{ .Count }}"
+  translation: "Posté le {{ . }}"
 - id: lastModified
-  translation: "(Dernière modification le {{ .Count }})"
+  translation: "(Dernière modification le {{ . }})"
 - id: translationsLabel
   translation: "Autres langues : "
 - id: translationsSeparator

--- a/i18n/it.yaml
+++ b/i18n/it.yaml
@@ -4,9 +4,9 @@
 - id: shortdateFormat
   translation: "2 Jan 2006 15:04:05"
 - id: postedOnDate
-  translation: "Redatto il {{ .Count }}"
+  translation: "Redatto il {{ . }}"
 - id: lastModified
-  translation: "(Ultima modifica il {{ .Count }})"
+  translation: "(Ultima modifica il {{ . }})"
 - id: translationsLabel
   translation: "Altre lingue: "
 - id: translationsSeparator

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -4,9 +4,9 @@
 - id: shortdateFormat
   translation: "2 Jan, 2006 15:04:05"
 - id: postedOnDate
-  translation: "{{ .Count }}に投稿"
+  translation: "{{ . }}に投稿"
 - id: lastModified
-  translation: "(最終更新日時{{ .Count }})"
+  translation: "(最終更新日時{{ . }})"
 - id: translationsLabel
   translation: "翻訳："
 - id: translationsSeparator

--- a/i18n/nb.yaml
+++ b/i18n/nb.yaml
@@ -4,9 +4,9 @@
 - id: shortdateFormat
   translation: "2 Jan, 2006 15:04:05"
 - id: postedOnDate
-  translation: "Postet {{ .Count }}"
+  translation: "Postet {{ . }}"
 - id: lastModified
-  translation: "(Sist endret {{ .Count }})"
+  translation: "(Sist endret {{ . }})"
 - id: translationsLabel
   translation: "Andre språk: "
 - id: translationsSeparator

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -4,9 +4,9 @@
 - id: shortdateFormat
   translation: "2 Jan, 2006 15:04:05"
 - id: postedOnDate
-  translation: "Gepost op {{ .Count }}"
+  translation: "Gepost op {{ . }}"
 - id: lastModified
-  translation: "(Laatst gewijzigd op {{ .Count }})"
+  translation: "(Laatst gewijzigd op {{ . }})"
 - id: translationsLabel
   translation: "Andere talen: "
 - id: translationsSeparator

--- a/i18n/pl.yaml
+++ b/i18n/pl.yaml
@@ -4,9 +4,9 @@
 - id: shortdateFormat
   translation: "2 Jan, 2006 15:04:05"
 - id: postedOnDate
-  translation: "Opublikowany {{ .Count }}"
+  translation: "Opublikowany {{ . }}"
 - id: lastModified
-  translation: "(Ostatnia modyfikacja {{ .Count }})"
+  translation: "(Ostatnia modyfikacja {{ . }})"
 - id: translationsLabel
   translation: "Inne języki: "
 - id: translationsSeparator

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -4,9 +4,9 @@
 - id: shortdateFormat
   translation: "2 Jan, 2006 15:04:05"
 - id: postedOnDate
-  translation: "Опубликовано {{ .Count }}"
+  translation: "Опубликовано {{ . }}"
 - id: lastModified
-  translation: "(Последнее изменение {{ .Count }})"
+  translation: "(Последнее изменение {{ . }})"
 - id: translationsLabel
   translation: "Другие языки: "
 - id: translationsSeparator

--- a/i18n/zh-CN.yaml
+++ b/i18n/zh-CN.yaml
@@ -4,9 +4,9 @@
 - id: shortdateFormat
   translation: "2 Jan, 2006 15:04:05"
 - id: postedOnDate
-  translation: "发表于 {{ .Count }}"
+  translation: "发表于 {{ . }}"
 - id: lastModified
-  translation: "(上次修改时间 {{ .Count }})"
+  translation: "(上次修改时间 {{ . }})"
 - id: translationsLabel
   translation: "其它语言: "
 - id: translationsSeparator

--- a/i18n/zh-TW.yaml
+++ b/i18n/zh-TW.yaml
@@ -4,9 +4,9 @@
 - id: shortdateFormat
   translation: "2 Jan, 2006 15:04:05"
 - id: postedOnDate
-  translation: "發表於 {{ .Count }}"
+  translation: "發表於 {{ . }}"
 - id: lastModified
-  translation: "(最後修改於 {{ .Count }})"
+  translation: "(最後修改於 {{ . }})"
 - id: translationsLabel
   translation: "其他語言: "
 - id: translationsSeparator


### PR DESCRIPTION
The upgrade to 0.76 broke the dates in this theme. This is a possible fix, as suggested in https://github.com/gohugoio/hugo/issues/7822
though it might only work on 0.76+. Since locally and on CI I'm always up to date with Hugo, this was good enough for me, though maybe there's a compatible way to do this? (also, maybe someone should verify that 0.75 does break with this - since a date was never a "count", this seems to make more sense).