### PR TITLE
Don't render header if title is empty

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -53,6 +53,7 @@
         <span class="img-desc" style="display: inline;"></span>
       </div>
     {{end}}
+    {{ if $title }}
     <div class="intro-header no-img">
       <div class="container">
         <div class="row">
@@ -81,6 +82,7 @@
         </div>
       </div>
     </div>
+  {{ end }}
   </header>
 {{ else }}
   <div class="intro-header"></div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1431625/105435430-326b6d80-5c12-11eb-86b0-b03634cc2034.png)

This is the current behavior on a small screen if the title is empty.

![image](https://user-images.githubusercontent.com/1431625/105435500-4f07a580-5c12-11eb-97d9-311259de8c96.png)

After the change