### PR TITLE
fix typos in translation files

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -61,7 +61,7 @@
 - id: yourEmail
   translation: "Your email address"
 - id: yourWebsite
-  translation: "You website"
+  translation: "Your website"
 
 # Delayed Disqus
 - id: show

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -59,7 +59,7 @@
 - id: yourName
   translation: "Votre nom"
 - id: yourEmail
-  translation: "Votre addresse mail"
+  translation: "Votre adresse mail"
 - id: yourWebsite
   translation: "Votre site web"
 


### PR DESCRIPTION
Fix two typos in translation files (yes, "address" is written "adresse" in french, with only one `d`)