### PR TITLE
fix terms with special characters

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -3,20 +3,20 @@
 {{ $data := .Data }}
 
 <div class="container" role="main">
-  <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1"> 
+  <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
     <article class="post-preview">
       <div class="panel-group" id="accordion">
         {{ range $key, $value := .Data.Terms.ByCount }}
           <div class="panel panel-default">
-            <a class="collapsed" role="button" data-toggle="collapse" data-target="#collapse{{ $value.Name }}" data-parent="#accordion">
-                <div class="panel-heading" id="header{{ $value.Name }}">
+            <a class="collapsed" role="button" data-toggle="collapse" data-target="#collapse{{ $value.Name | anchorize }}" data-parent="#accordion">
+                <div class="panel-heading" id="header{{ $value.Name | anchorize }}">
                   <h4 class="panel-title">
                       {{ $value.Name }}
                     <span class="badge">{{ $value.Count }}</span>
                   </h4>
                 </div>
             </a>
-            <div id="collapse{{ $value.Name }}" class="panel-collapse collapse">
+            <div id="collapse{{ $value.Name | anchorize }}" class="panel-collapse collapse">
               <div class="panel-body">
                 <a href="{{ $.Site.LanguagePrefix | absURL }}/{{ $data.Plural }}/{{ $value.Name | urlize }}/" class="list-group-item view-all">
                 View all</a>


### PR DESCRIPTION
Special characters make the `tags` page not to work.