### PR TITLE
Display inline math using the '$' delimiter

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -80,8 +80,21 @@
 <script src="{{ "js/highlight.min.js" | absURL }}"></script>
 <script> hljs.initHighlightingOnLoad(); </script>
 <script> $(document).ready(function() {$("pre.chroma").css("padding","0");}); </script>
-{{- end -}}
-<script> renderMathInElement(document.body); </script>
+{{- end  }}
+<script>
+  renderMathInElement(
+    document.body,
+    {
+      delimiters: [
+        {left: "$", right: "$", display: false},
+        {left: "\\begin{equation}", right: "\\end{equation}", display: true},
+        {left: "\\begin{align}", right: "\\end{align}", display: true},
+        {left: "\\begin{alignat}", right: "\\end{alignat}", display: true},
+        {left: "\\begin{gather}", right: "\\end{gather}", display: true}
+      ]
+    }
+  );
+</script>
 
 {{- if .Site.Params.selfHosted -}}
 <script src="{{ "js/photoswipe.min.js" | absURL }}"></script>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -91,7 +91,7 @@
         {left: "\\begin{equation}", right: "\\end{equation}", display: true},
         {left: "\\begin{align}", right: "\\end{align}", display: true},
         {left: "\\begin{alignat}", right: "\\end{alignat}", display: true},
-        {left: "\\begin{gather}", right: "\\end{gather}", display: true}
+        {left: "\\begin{gather}", right: "\\end{gather}", display: true},
         {left: "\\(", right: "\\)", display: false},
         {left: "\\[", right: "\\]", display: true}
       ]

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -86,11 +86,14 @@
     document.body,
     {
       delimiters: [
+        {left: "$$", right: "$$", display: true},
         {left: "$", right: "$", display: false},
         {left: "\\begin{equation}", right: "\\end{equation}", display: true},
         {left: "\\begin{align}", right: "\\end{align}", display: true},
         {left: "\\begin{alignat}", right: "\\end{alignat}", display: true},
         {left: "\\begin{gather}", right: "\\end{gather}", display: true}
+        {left: "\\(", right: "\\)", display: false},
+        {left: "\\[", right: "\\]", display: true}
       ]
     }
   );


### PR DESCRIPTION
That's the default LaTeX syntax.  Using `\\(` and `\\)` worsens the editing experience.

Code extracted from https://github.com/KaTeX/KaTeX/blob/5c44c47bd2ca70c2a8585c19d9fae598b1227a57/contrib/auto-render/index.html#L44-L48

~I'm not going to repeat the `delimiters` found in `static/js/auto-render.min.js`.~