### PR TITLE
Corrected TR translation

### DIFF
--- a/i18n/tr.yaml
+++ b/i18n/tr.yaml
@@ -4,9 +4,9 @@
 - id: shortdateFormat
   translation: "2 Oca 2006 15.04.05"
 - id: postedOnDate
-  translation: "{{ .Count }} tarihinde paylaşıldı"
+  translation: "{{ . }} tarihinde paylaşıldı"
 - id: lastModified
-  translation: "({{ .Count }} tarihinde güncellendi)"
+  translation: "({{ . }} tarihinde güncellendi)"
 - id: translationsLabel
   translation: "Diğer diller: "
 - id: translationsSeparator


### PR DESCRIPTION
Inside the EN translation, these variables are defined as `{{ . }}` -- but in Turkish translation, it was `{{ .Count }}` which seems to be incorrect and causes empty parts inside the rendered HTML.