### PR TITLE
Add support for Netlify one-click deploy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,8 @@
+[build]
+  publish = "exampleSite/public"
+  command = "cd exampleSite && hugo --gc --themesDir ../.."
+  
+[build.environment]
+  HUGO_VERSION = "0.79.0"
+  HUGO_THEME = "repo"
+  HUGO_BASEURL = "/"


### PR DESCRIPTION
The file `netlify.toml` allows to use [Netlify deploys](https://docs.netlify.com/site-deploys/overview/).

You can already check it out with the following URL:
https://app.netlify.com/start/deploy?repository=https://github.com/RoneoOrg/WonderfulHugo
(under testing, use it at your own risk!)

Ref:
- https://gohugo.io/hosting-and-deployment/hosting-on-netlify/
- https://docs.netlify.com/site-deploys/overview/