### PR TITLE
Use time.format to get localised date string

### DIFF
--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -1,6 +1,6 @@
 <span class="post-meta">
-  {{ $lastmodstr := default (i18n "dateFormat") .Site.Params.dateformat | .Lastmod.Format }}
-  {{ $datestr := default (i18n "dateFormat") .Site.Params.dateformat | .Date.Format }}
+  {{ $lastmodstr := time.Format (default (i18n "dateFormat") .Site.Params.dateformat) .Lastmod}}
+  {{ $datestr := time.Format (default (i18n "dateFormat") .Site.Params.dateformat) .Date}}
   <i class="fas fa-calendar"></i>&nbsp;{{ $datestr | i18n "postedOnDate"}}
   {{ if ne $datestr $lastmodstr }}
     &nbsp;{{ $lastmodstr | i18n "lastModified"  }}


### PR DESCRIPTION
By using the time.Format from the go time package, we can get localised date in the post meta information. So if you want to display days or months in text, you won't default to english ( Lunes 1 Febrero instead of Monday 1 February in spanish for instance).
https://pkg.go.dev/time#ANSIC