### PR TITLE
Use ga4 internal template

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -88,4 +88,4 @@
   {{- end -}}
 
 {{- partial "head_custom.html" . }}
-{{ template "_internal/google_analytics_async.html" . }}
+{{ template "_internal/google_analytics.html" . }}


### PR DESCRIPTION
Change to use internal template for Google Analytics version 4.
https://gohugo.io/templates/internal/#use-the-google-analytics-template