### PR TITLE
Fix figure shortcode with attrlink

### DIFF
--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -20,7 +20,7 @@ Documentation and licence at https://github.com/liwenyip/hugo-easy-gallery/
         {{- if or (.Get "caption") (.Get "attr")}}
           <p>
             {{- .Get "caption" -}}
-            {{- with .Get "attrlink"}}<a href="{{.}}">{{ .Get "attr" }}</a>{{ else }}{{ .Get "attr"}}{{ end -}}
+            {{- with .Get "attrlink"}}<a href="{{.}}">{{ $.Get "attr" }}</a>{{ else }}{{ .Get "attr"}}{{ end -}}
           </p>
         {{- end }}
       </figcaption>

--- a/static/css/hugo-easy-gallery.css
+++ b/static/css/hugo-easy-gallery.css
@@ -107,6 +107,9 @@ figure a {
     top: 0;
     bottom: 0;
 }
+figure figcaption a {
+    position: static;
+}
 
 /*
 figcaption styles


### PR DESCRIPTION
There were a couple of problems when using the custom figure
shortcode with the attrlink parameter. First, there was a
scoping issue that caused the hugo templates to fail when
attempting to get the attr parameter. Second, the css for
the anchor tag placed the link in the wrong place.

This is similar to PR #435 except that it also fixes a secondary problem with the css for the generated anchor tag.

Closes #258