### PR TITLE
Fallback to first bigimg when JavaScript disabled

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -15,12 +15,12 @@
 
 {{ if or $bigimg $title }}
   {{ if $bigimg }}
-    <div id="header-big-imgs" data-num-img={{len $bigimg}} 
+    <div id="header-big-imgs" data-num-img={{len $bigimg}}
       {{range $i, $img := $bigimg}}
-         {{ if (fileExists $img.src)}} 
-          data-img-src-{{add $i 1}}="{{$img.src | absURL }}" 
+         {{ if (fileExists $img.src)}}
+          data-img-src-{{add $i 1}}="{{$img.src | absURL }}"
          {{else}}
-          data-img-src-{{add $i 1}}="{{$img.src}}" 
+          data-img-src-{{add $i 1}}="{{$img.src}}"
          {{end}}
          {{ if $img.desc}}data-img-desc-{{add $i 1}}="{{$img.desc}}"{{end}}
       {{end}}></div>
@@ -28,7 +28,8 @@
 
   <header class="header-section {{ if $bigimg }}has-img{{ end }}">
     {{ if $bigimg }}
-      <div class="intro-header big-img">
+      {{ $firstimg := index $bigimg 0 }}
+      <div class="intro-header big-img" style="background-image: url('{{$firstimg.src}}');">
         {{ $subtitle := $.Scratch.Get "subtitle" }}
         <div class="container">
           <div class="row">
@@ -50,7 +51,7 @@
             </div>
           </div>
         </div>
-        <span class="img-desc" style="display: inline;"></span>
+        <span class="img-desc" style="display: {{ cond (isset $firstimg "desc") "inline" "none"}};">{{$firstimg.desc}}</span>
       </div>
     {{end}}
     {{ if $title }}


### PR DESCRIPTION
Solves https://github.com/halogenica/beautifulhugo/issues/455 by statically configuring the page source to use the source and description of the first image in bigimg. When the description is empty, also pre-hides the description box.

When JavaScript is enabled, this theme's main.js
(https://github.com/halogenica/beautifulhugo/blob/master/static/js/main.js) takes over and will overwrite this style attribute, changing the image in use.