### PR TITLE
nav partial: properly link multilingual translation to the permalink

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -34,19 +34,19 @@
             <li class="navlinks-container">
               <a class="navlinks-parent">{{ i18n "languageSwitcherLabel" }}</a>
               <div class="navlinks-children">
-                {{ range .Site.Languages }}
+                {{ range .Translations }}
                   {{ if not (eq .Lang $.Site.Language.Lang) }}
-                  <a href="/{{ .Lang }}" lang="{{ .Lang }}">{{ default .Lang .LanguageName }}</a>
+                  <a href="{{ .Permalink }}">{{ default .Lang .Site.Language.LanguageName }}</a>
                   {{ end }}
                 {{ end }}
               </div>
             </li>
           {{ else }}
             <li>
-              {{ range .Site.Languages }}
-                {{ if not (eq .Lang $.Site.Language.Lang) }}
-                  <a href="/{{ .Lang }}" lang="{{ .Lang }}">{{ default .Lang .LanguageName }}</a>
-                {{ end }}
+              {{ if .IsTranslated }}
+                {{ range .Translations }}
+                  <a href="{{ .Permalink }}">{{ default .Lang .Site.Language.LanguageName }}</a>
+                {{ end}}
               {{ end }}
             </li>
           {{ end }}


### PR DESCRIPTION
For beautifulhugo to properly support multilingual sites, the language links should direct to the same page in the other language, not the home page in the other language.

For illustration, suppose we have a multilingual site with two languages, `en` and `fr`. If we are on page `example.com/en/a`, then clicking on the `fr` link we get to `example.com/fr` instead of `example.com/fr/a`.

With this PR, clicking on the `fr` link gets us to `example.com/fr/a` as intended. 

It also works as intended with more than 2 languages.

I can provide a test repo of my own if needed but the easiest way to check is with the [hugo-multilingual-example](https://github.com/rayjolt/hugo-multilingual-example) repo.