### PR TITLE
fix: remove warning using katex

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -92,7 +92,6 @@
 <script> hljs.initHighlightingOnLoad(); </script>
 <script> $(document).ready(function() {$("pre.chroma").css("padding","0");}); </script>
 {{- end -}}
-<script> renderMathInElement(document.body); </script>
 
 {{- if .Site.Params.selfHosted -}}
 <script src="{{ "js/photoswipe.min.js" | absURL }}"></script>


### PR DESCRIPTION
Followup to #468, removing a console warning that now shows up.
