### PR TITLE
Convert theme to hugo module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.104.2
+      HUGO_VERSION: 0.115.3
     steps:
       - name: Install Hugo CLI
         run: |
@@ -31,7 +31,7 @@ jobs:
           submodules: recursive
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v3
       - name: Build with Hugo
         env:
           # For maximum backward compatibility with Hugo modules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           submodules: recursive
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v3
       - name: Build with Hugo
         env:
           # For maximum backward compatibility with Hugo modules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,19 +19,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.115.3
+      HUGO_VERSION: 0.120.1
     steps:
       - name: Install Hugo CLI
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
       - name: Build with Hugo
         env:
           # For maximum backward compatibility with Hugo modules
@@ -44,7 +44,7 @@ jobs:
             -s "./exampleSite/" \
             --themesDir "../../"
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v2
         with:
           path: ./exampleSite/public
 

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -26,7 +26,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.104.2
+      HUGO_VERSION: 0.115.3
     steps:
       - name: Install Hugo CLI
         run: |
@@ -38,7 +38,7 @@ jobs:
           submodules: recursive
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v3
       - name: Build with Hugo
         env:
           # For maximum backward compatibility with Hugo modules
@@ -69,4 +69,4 @@ jobs:
           success()
           && github.ref == 'refs/heads/master'
           && github.repository == 'halogenica/beautifulhugo'
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -26,14 +26,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.115.3
+      HUGO_VERSION: 0.120.1
     steps:
       - name: Install Hugo CLI
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup Pages
@@ -51,7 +51,7 @@ jobs:
             -s "./exampleSite/" \
             --themesDir "../../"
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v2
         with:
           path: ./exampleSite/public
 

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ Temporary Items
 
 # Hugo's lock
 .hugo_build.lock
+exampleSite/public/

--- a/README.md
+++ b/README.md
@@ -10,14 +10,33 @@ See https://hugo-theme-beautifulhugo.netlify.app/
 
 Install Hugo and create a new site. See [the Hugo documentation](https://gohugo.io/getting-started/quick-start/) for details.
 
-Add Beautifulhugo:
+### Git Submodule
+
+Add Beautifulhugo as git submodule:
 
     $ git submodule add https://github.com/halogenica/beautifulhugo.git themes/beautifulhugo
+
+### Hugo module
+
+Initialize your site as hugo module:
+
+    $ hugo mod init github.com/USERNAME/SITENAME
+
+Add Beautifulhugo module as a dependency of your site:
+
+    $ hugo mod get github.com/halogenica/beautifulhugo
+
+### Site preview
 
 Copy the content of `exampleSite` at the root of your project:
 
     cp -r themes/beautifulhugo/exampleSite/* . -iv
-    
+
+If you installed Beautifulhugo as hugo module, set your theme in your config file (hugo.toml):
+
+    [[module.imports]]
+      path = "github.com/halogenica/beautifulhugo"
+
 Start Hugo:
 
     hugo serve
@@ -56,7 +75,7 @@ pygmentsStyle = "trac"
 pygmentsUseClassic = true
 ```
 
-Pygments is mostly compatable with the newer Chroma. It is slower but has some additional theme options. I recommend Chroma over Pygments. Pygments will use `syntax.css` for highlighting, unless you also set the config `pygmentsUseClasses = false` which will generate the style code directly in the HTML file. 
+Pygments is mostly compatible with the newer Chroma. It is slower but has some additional theme options. I recommend Chroma over Pygments. Pygments will use `syntax.css` for highlighting, unless you also set the config `pygmentsUseClasses = false` which will generate the style code directly in the HTML file. 
 
 #### Highlight.js - Client side syntax highlighting
 ```

--- a/exampleSite/content/page/about.md
+++ b/exampleSite/content/page/about.md
@@ -13,4 +13,4 @@ What else do you need?
 
 ### my history
 
-To be honest, I'm having some trouble remembering right now, so why don't you just watch [my movie](http://en.wikipedia.org/wiki/The_Princess_Bride_%28film%29) and it will answer **all** your questions.
+To be honest, I'm having some trouble remembering right now, so why don't you just watch [my movie](https://en.wikipedia.org/wiki/The_Princess_Bride_%28film%29) and it will answer **all** your questions.

--- a/exampleSite/content/post/2015-02-20-test-markdown.md
+++ b/exampleSite/content/post/2015-02-20-test-markdown.md
@@ -5,7 +5,7 @@ date: 2015-02-20
 tags: ["example", "markdown"]
 ---
 
-You can write regular [markdown](http://markdowntutorial.com/) here and [Hugo](https://gohugo.io) will automatically convert it to a nice webpage.  I strongly encourage you to [take 5 minutes to learn how to write in markdown](http://markdowntutorial.com/) - it'll teach you how to transform regular text into bold/italics/headings/tables/etc.
+You can write regular [markdown](https://markdowntutorial.com/) here and [Hugo](https://gohugo.io) will automatically convert it to a nice webpage.  I strongly encourage you to [take 5 minutes to learn how to write in markdown](https://markdowntutorial.com/) - it'll teach you how to transform regular text into bold/italics/headings/tables/etc.
 
 **Here is some bold text**
 
@@ -23,7 +23,7 @@ Here's a useless table:
 
 How about a yummy crepe?
 
-![Crepe](http://s3-media3.fl.yelpcdn.com/bphoto/cQ1Yoa75m2yUFFbY2xwuqw/348s.jpg)
+![Crepe](https://s3-media3.fl.yelpcdn.com/bphoto/cQ1Yoa75m2yUFFbY2xwuqw/348s.jpg)
 
 Here's a code chunk with syntax highlighting:
 

--- a/exampleSite/content/post/2017-03-05-math-sample.md
+++ b/exampleSite/content/post/2017-03-05-math-sample.md
@@ -11,7 +11,7 @@ $$
 \phi = \frac{(1+\sqrt{5})}{2} = 1.6180339887\cdots
 $$
 
-Additional details can be found on [GitHub](https://github.com/Khan/KaTeX) or on the [Wiki](http://tiddlywiki.com/plugins/tiddlywiki/katex/).
+Additional details can be found on [GitHub](https://github.com/KaTeX/KaTeX) or on the [project homepage](https://katex.org/).
 <!--more-->
 
 ### Example 1

--- a/exampleSite/content/post/2017-03-20-photoswipe-gallery-sample.md
+++ b/exampleSite/content/post/2017-03-20-photoswipe-gallery-sample.md
@@ -5,7 +5,7 @@ date: 2017-03-20
 tags: ["example", "photoswipe"]
 ---
 
-Beautiful Hugo adds a few custom shortcodes created by [Li-Wen Yip](https://www.liwen.id.au/heg/) and [Gert-Jan van den Berg](https://github.com/GjjvdBurg/HugoPhotoSwipe) for making galleries with [PhotoSwipe](http://photoswipe.com) . 
+Beautiful Hugo adds a few custom shortcodes created by [Li-Wen Yip](https://www.liwen.id.au/heg/) and [Gert-Jan van den Berg](https://github.com/GjjvdBurg/HugoPhotoSwipe) for making galleries with [PhotoSwipe](https://photoswipe.com) . 
 
 {{< gallery caption-effect="fade" >}}
   {{< figure thumb="-thumb" link="/img/hexagon.jpg" >}}

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -1,7 +1,10 @@
 baseurl = "https://username.github.io"
 DefaultContentLanguage = "en"
+# Using theme as git submodule 
 title = "Beautiful Hugo"
-theme = "beautifulhugo"
+# Or when using theme as hugo module
+# theme = "beautifulhugo"
+theme = "github.com/halogenica/beautifulhugo"
 pygmentsStyle = "trac"
 pygmentsUseClasses = true
 pygmentsCodeFences = true

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -1,10 +1,10 @@
 baseurl = "https://username.github.io"
 DefaultContentLanguage = "en"
-# Using theme as git submodule 
 title = "Beautiful Hugo"
+# Using theme as git submodule 
+theme = "beautifulhugo"
 # Or when using theme as hugo module
-# theme = "beautifulhugo"
-theme = "github.com/halogenica/beautifulhugo"
+# theme = "github.com/halogenica/beautifulhugo"
 pygmentsStyle = "trac"
 pygmentsUseClasses = true
 pygmentsCodeFences = true

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/halogenica/beautifulhugo
+
+go 1.20

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,6 @@
   command = "cd exampleSite && hugo --gc --themesDir ../.."
   
 [build.environment]
-  HUGO_VERSION = "0.79.0"
+  HUGO_VERSION = "0.115.3"
   HUGO_THEME = "repo"
   HUGO_BASEURL = "/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,6 @@
   command = "cd exampleSite && hugo --gc --themesDir ../.."
   
 [build.environment]
-  HUGO_VERSION = "0.115.3"
+  HUGO_VERSION = "0.120.1"
   HUGO_THEME = "repo"
   HUGO_BASEURL = "/"

--- a/theme.toml
+++ b/theme.toml
@@ -8,10 +8,10 @@ min_version = 0.48
 
 [author]
     name = "halogenica"
-    homepage = "http://halogenica.net"
+    homepage = "https://halogenica.net"
 
 # If Porting existing theme
 [original]
     author =  "dattali"
-    homepage = "http://deanattali.com/beautiful-jekyll/"
+    homepage = "https://beautifuljekyll.com"
     repo = "https://github.com/daattali/beautiful-jekyll"


### PR DESCRIPTION
This PR converts the theme to a hugo module. In `README.md`, a section is added, explaining how to install the theme as hugo module. This PR also bumps some GitHb workflow dependencies to their latest version and converts some links from `http` to `https` protocol.