### PR TITLE
fix #403: Exclude the rss link in the post pages as it's empty.

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -30,14 +30,16 @@
             {{- end -}}
           {{ end }}
           {{ if .Site.Params.rss }}
+          {{ with .OutputFormats.Get "RSS" }}
           <li>
-            <a href="{{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}" title="RSS">
+            <a href="{{ .RelPermalink }}" title="RSS">
               <span class="fa-stack fa-lg">
                 <i class="fas fa-circle fa-stack-2x"></i>
                 <i class="fas fa-rss fa-stack-1x fa-inverse"></i>
               </span>
             </a>
           </li>
+          {{ end }}
           {{ end }}
         </ul>
         <p class="credits copyright text-muted">


### PR DESCRIPTION
Hi,

For posts, the RSS links are empty, so it's better to exclude them.