### PR TITLE
Add Cusdis support

### DIFF
--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -30,6 +30,7 @@ pygmentsCodefencesGuessSyntax = true
   socialShare = true
   delayDisqus = true
   showRelatedPosts = true
+#  cusdisID = "XXX" # Get your App id from cusdis.com
 #  hideAuthor = true
 #  gcse = "012345678901234567890:abcdefghijk" # Get your code from google.com/cse. Make sure to go to "Look and Feel" and change Layout to "Full Width" and Theme to "Classic"
 #  disclaimerText = "The opinions expressed herein are my own personal opinions and do not represent my employer’s view in any way."

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -57,7 +57,22 @@
 
 
       {{ if (.Params.comments) | or (and (or (not (isset .Params "comments")) (eq .Params.comments nil)) (and .Site.Params.comments (ne .Type "page"))) }}
-        {{ if .Site.DisqusShortname }}
+      
+      {{ if .Site.Params.cusdisID }}
+
+        <div id="cusdis_thread"
+          data-host="https://cusdis.com"
+          data-app-id="{{ .Site.Params.cusdisID }}"
+          data-page-id="{{ .Permalink }}"
+          data-page-url="{{ .Permalink }}"
+          data-page-title="{{ .Title }}"
+          data-theme="auto"
+        ></div>
+        <script async defer src="https://cusdis.com/js/cusdis.es.js"></script>
+
+      {{ end }}
+      
+      {{ if .Site.DisqusShortname }}
           {{ if .Site.Params.delayDisqus }}
           <div class="disqus-comments">                  
             <button id="show-comments" class="btn btn-default" type="button">{{ i18n "show" }} <span class="disqus-comment-count" data-disqus-url="{{ trim .Permalink "/" }}">{{ i18n "comments" }}</span></button>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -153,6 +153,10 @@ figure:not(.dark) img, img.white {
   }
 }
 
+#cusdis_thread {
+  margin-top: 30px;
+}
+
 /* --- Navbar --- */
 
 .navbar-custom {


### PR DESCRIPTION
## What is Cusdis

Cusdis is an open source alternative to Disqus for website comment sections. It is lightweight and don't require the reader to create an account to leave comments.

## Implementation

Cusdis support in the theme is implemented in the same way as the existing support for Disqus.
 
The App ID must be specified in the `config.toml` at the root of the project