### PR TITLE
Fix deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.120.1
+      HUGO_VERSION: 0.130.0
     steps:
       - name: Install Hugo CLI
         run: |
@@ -31,7 +31,7 @@ jobs:
           submodules: recursive
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Build with Hugo
         env:
           # For maximum backward compatibility with Hugo modules
@@ -45,7 +45,7 @@ jobs:
           --themesDir "../../"
           --logLevel info
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./exampleSite/public
 

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -26,7 +26,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.120.1
+      HUGO_VERSION: 0.130.0
     steps:
       - name: Install Hugo CLI
         run: |
@@ -38,7 +38,7 @@ jobs:
           submodules: recursive
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Build with Hugo
         env:
           # For maximum backward compatibility with Hugo modules
@@ -51,7 +51,7 @@ jobs:
             -s "./exampleSite/" \
             --themesDir "../../"
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./exampleSite/public
 
@@ -69,4 +69,4 @@ jobs:
           success()
           && github.ref == 'refs/heads/master'
           && github.repository == 'halogenica/beautifulhugo'
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -11,8 +11,12 @@ pygmentsCodeFences = true
 pygmentsCodefencesGuessSyntax = true
 #pygmentsUseClassic = true
 #pygmentOptions = "linenos=inline"
-#disqusShortname = "XXX"
-#googleAnalytics = "XXX"
+
+[Services]
+  [Services.Disqus]
+    # Shortname = "XXX"
+  [Services.googleAnalytics]
+    # id = "XXX"
 
 [Params]
 #  homeTitle = "Beautiful Hugo Theme" # Set a different text for the header on the home page

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
-{{ if le hugo.Version "0.120.0" }}
-	{{ errorf "Please use Hugo version 0.120.0 or higher!" }}
+{{ if le hugo.Version "0.124.0" }}
+	{{ errorf "Please use Hugo version 0.124.0 or higher!" }}
 {{ end }}
 
 {{ if not (eq .Site.DisqusShortname "") }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -56,9 +56,9 @@
 
           &nbsp;&bull;&nbsp;&copy;
           {{ if .Site.Params.since }}
-            {{ .Site.Params.since }} - {{ .Site.LastChange.Format "2006" }}
+            {{ .Site.Params.since }} - {{ .Site.Lastmod.Format "2006" }}
           {{ else }}
-            {{ .Site.LastChange.Format "2006" }}
+            {{ .Site.Lastmod.Format "2006" }}
           {{ end }}
 
           {{ if .Site.Title }}

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -29,7 +29,7 @@
           {{ end }}
         {{ end }}
 
-        {{ if .Site.IsMultiLingual }}
+        {{ if hugo.IsMultilingual }}
           {{ if ge (len .Site.Languages) 3 }}
             <li class="navlinks-container">
               <a class="navlinks-parent" role="button" tabindex="0">{{ i18n "languageSwitcherLabel" }}</a>

--- a/layouts/partials/seo/structured/post.html
+++ b/layouts/partials/seo/structured/post.html
@@ -21,7 +21,7 @@
       "name": "{{ .Site.Params.author.name }}"
   },
   {{- end }}
-  "copyrightYear" : "{{ .Site.Params.since }} - {{ .Site.LastChange.Format "2006" }}",
+  "copyrightYear" : "{{ .Site.Params.since }} - {{ .Site.Lastmod.Format "2006" }}",
   {{ if not .PublishDate.IsZero -}}
     "datePublished": "{{ .PublishDate.Format "2006-01-02T15:04:05-07:00" | safeHTML }}",
   {{- else if not .Date.IsZero -}}

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,6 @@
   command = "cd exampleSite && hugo --gc --themesDir ../.."
   
 [build.environment]
-  HUGO_VERSION = "0.120.0"
+  HUGO_VERSION = "0.130.0"
   HUGO_THEME = "repo"
   HUGO_BASEURL = "/"

--- a/theme.toml
+++ b/theme.toml
@@ -4,7 +4,7 @@ licenselink = "https://github.com/halogenica/Hugo-BeautifulHugo/blob/master/LICE
 description = "An adaptation of the Beautiful Jekyll theme"
 tags = ["blog", "company", "portfolio", "projects", "minimal", "responsive", "seo", "google analytics", "bootstrap", "disqus", "light", "syntax highlighting", "multilingual", "portfolio", "projects", "mobile", "technical"]
 features = ["blog", "company", "portfolio", "projects", "minimal", "responsive", "seo", "google analytics", "bootstrap", "disqus", "light", "syntax highlighting", "multilingual", "portfolio", "projects", "mobile", "technical"]
-min_version = 0.120
+min_version = 0.124
 
 [author]
     name = "halogenica"


### PR DESCRIPTION
When running example site with latest hugo version 0.130.0, deprecation warnings are shown:

```
WARN  deprecated: .Site.IsMultiLingual was deprecated in Hugo v0.124.0 and will be removed in a future release. Use hugo.IsMultilingual instead.
WARN  deprecated: .Site.LastChange was deprecated in Hugo v0.123.0 and will be removed in a future release. Use .Site.Lastmod instead.
```

This PR fixes these issues.