### PR TITLE
Remove the use of .Site.DisqusShortname

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,10 +2,6 @@
 	{{ errorf "Please use Hugo version 0.120.0 or higher!" }}
 {{ end }}
 
-{{ if not (eq .Site.DisqusShortname "") }}
-	{{ errorf "Your use of disqusShortname is deprecated by Hugo; Please reference the README.md for further instructions. This error message will be removed in the future because we are also using .Site.DisqusShortname for checking this." }}
-{{ end }}
-
 <!DOCTYPE html>
 <html lang="{{ .Lang }}" itemscope itemtype="http://schema.org/WebPage">
   <head>


### PR DESCRIPTION
In version 0.132.0, this now leads to an error:

> ERROR deprecated: .Site.DisqusShortname was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.133.0. Use .Site.Config.Services.Disqus.Shortname instead.