### PR TITLE
Add Last.fm social icon

### DIFF
--- a/data/beautifulhugo/social.toml
+++ b/data/beautifulhugo/social.toml
@@ -214,3 +214,9 @@ id = "about"
 url = "%s"
 title = "About"
 icon = "fas fa-at"
+
+[[social_icons]]
+id = "lastfm"
+url = "https://www.last.fm/user/%s"
+title = "Last.fm"
+icon = "fab fa-lastfm"

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -1,7 +1,7 @@
 baseurl = "https://username.github.io"
 DefaultContentLanguage = "en"
 title = "Beautiful Hugo"
-# Using theme as git submodule 
+# Using theme as git submodule
 theme = "beautifulhugo"
 # Or when using theme as hugo module
 # theme = "github.com/halogenica/beautifulhugo"
@@ -84,6 +84,7 @@ pygmentsCodefencesGuessSyntax = true
   medium = "username"
   discord = "invite code (https://discord.gg/XXXXXXX)"
   strava = "userid"
+  lastfm = "username"
 
 [[menu.main]]
     name = "Blog"


### PR DESCRIPTION
I'm an avid Last.fm user. Noticed it was missing and font awesome conveniently already had the logo (in two variations!)

I also took the liberty of including it in `exampleSite/hugo.toml` so it's easily accessible to first-time users