### PR TITLE
Fix Bluesky icon and improve URL

### DIFF
--- a/data/beautifulhugo/social.toml
+++ b/data/beautifulhugo/social.toml
@@ -223,6 +223,6 @@ icon = "fab fa-lastfm"
 
 [[social_icons]]
 id = "bluesky"
-url = "%s"
-title = "About"
-icon = "fas fa-at"
+url = "https://bsky.app/profile/%s"
+title = "Bluesky"
+icon = "fab fa-bluesky"


### PR DESCRIPTION
My last PR to add Bluesky wasn't perfect. This change uses the correct icon and allows you to just set your handle rather than the full url.