### PR TITLE
Add Bluesky to example site

### DIFF
--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -85,6 +85,7 @@ pygmentsCodefencesGuessSyntax = true
   discord = "invite code (https://discord.gg/XXXXXXX)"
   strava = "userid"
   lastfm = "username"
+  bluesky = "username"
 
 [[menu.main]]
     name = "Blog"


### PR DESCRIPTION
To address the point made in #522 this change includes Bluesky in the example site to make it clear that it is a supported social.