### PR TITLE
fix for white header background with dark theme

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -675,7 +675,6 @@ footer div.disclaimer {
 
 .header-section.has-img .no-img {
   margin-top: 0;
-  background: #FCFCFC;
   margin: 0 0 40px;
   padding: 20px 0;
   box-shadow: 0 0 5px #AAA;


### PR DESCRIPTION
fix for white header background with dark theme on devices with screen widths less than 365px