### PR TITLE
Fix internationalization of dates in posts

### DIFF
--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -1,6 +1,6 @@
 <span class="post-meta">
-  {{ $lastmodstr := default (i18n "dateFormat") .Site.Params.dateformat | .Lastmod.Format }}
-  {{ $datestr := default (i18n "dateFormat") .Site.Params.dateformat | .Date.Format }}
+  {{ $lastmodstr := .Lastmod | time.Format ":date_long" }}
+  {{ $datestr := .Date | time.Format ":date_long" }}
   <i class="fas fa-calendar"></i>&nbsp;{{ $datestr | i18n "postedOnDate"}}
   {{ if ne $datestr $lastmodstr }}
     &nbsp;{{ $lastmodstr | i18n "lastModified"  }}


### PR DESCRIPTION
When seeing main page and posts pages, months in the dates were not translated.
The theme is using the old .Date.Format method instead of the newer time.Format function that supports proper localization using tokens like ":date_medium"
This PR fixes it