### PR TITLE
Add generic git forge as a social icon

### DIFF
--- a/data/beautifulhugo/social.toml
+++ b/data/beautifulhugo/social.toml
@@ -23,6 +23,12 @@ title = "GitLab"
 icon = "fab fa-gitlab"
 
 [[social_icons]]
+id = "git"
+url = "%s"
+title = "Git Forge"
+icon = "fab fa-git-alt"
+
+[[social_icons]]
 id = "bitbucket"
 url = "https://bitbucket.org/%s"
 title = "Bitbucket"


### PR DESCRIPTION
As a lot of people are moving away from GitHub and Gitlab, to services such as Gitea, Codeberg or Forgejo, it makes sense to add a social icon for those services.

Given that people might self host and might use multiple different software options, I added a generic git forge, that can be used for any git forge the person might use or host.

If this is not the path you want to take, I can instead open a separate PR for Gitea and Forgejo and Codeberg, although none of them have icons in Font Awesome and it'd require some creativity.

I used the `fa-git-alt` icon as it is the git logo in https://git-scm.com, while `fa-git` is just the world "git".