### PR TITLE
Add demosite link to theme settings

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -2,6 +2,7 @@ name = "Beautiful Hugo"
 license = "MIT"
 licenselink = "https://github.com/halogenica/Hugo-BeautifulHugo/blob/master/LICENSE"
 description = "An adaptation of the Beautiful Jekyll theme"
+demosite = "https://hugo-theme-beautifulhugo.netlify.app/"
 tags = ["blog", "company", "portfolio", "projects", "minimal", "responsive", "seo", "google analytics", "bootstrap", "disqus", "light", "syntax highlighting", "multilingual", "portfolio", "projects", "mobile", "technical"]
 features = ["blog", "company", "portfolio", "projects", "minimal", "responsive", "seo", "google analytics", "bootstrap", "disqus", "light", "syntax highlighting", "multilingual", "portfolio", "projects", "mobile", "technical"]
 min_version = "0.124.0"


### PR DESCRIPTION
It's needed to display the "Demo" button on https://themes.gohugo.io/themes/beautifulhugo/.

See https://github.com/gohugoio/hugoThemesSiteBuilder#theme-configuration