### PR TITLE
Update share-links.html to allow sharing via email

### DIFF
--- a/layouts/partials/share-links.html
+++ b/layouts/partials/share-links.html
@@ -43,6 +43,13 @@
           <i class="fab fa-pinterest"></i>
         </a>
       </li>
+
+      <!-- Email -->
+      <li>
+        <a href="mailto:?body={{ .Permalink }}&amp;subject={{ .Title }}" title="Share via email">
+          <i class="fab fa-at"></i>
+        </a>
+      </li>
     </ul>
   </div>
   {{ end }}


### PR DESCRIPTION
Share via email.

Alternative icons may be:
* envelope
* paper-plan

I chose 'at'. 

Thanks