### PR TITLE
Update de.yaml to avoid problems with wrong grammar

### DIFF
--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -22,7 +22,7 @@
 - id: nextPost
   translation: "Nächster Post"
 - id: readTime
-  translation: "Minuten"
+  translation: "min"
 - id: words
   translation: "Wörter"
 


### PR DESCRIPTION
As the German translation should be more dynamic an easy workaround is to use the abbreviation.

A grammatically correct version would be to distinguish between 1 and more minutes:
* 1 Minute
* 2 Minuten

As other languages have different grammar rules I'd prefer to use the abbreviation which automatically handles singular/plural values.