### PR TITLE
fix: one more _internal

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -117,5 +117,5 @@
   {{- end }}
   {{- partial "head_custom.html" . }}
 {{- if not hugo.IsServer -}}
-  {{ template "_internal/google_analytics.html" . }}
+  {{ partial "google_analytics.html" . }}
 {{- end -}}


### PR DESCRIPTION
One more `_internal` usage (see #532 and #531).   This does, in fact, break <1.46, so it would be nice to know if it fixes something. CI currently passes on latest Hugo.