### PR TITLE
Add: Robot Meta Tag for unavailable_after

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -112,7 +112,10 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/photoswipe/4.1.2/default-skin/default-skin.min.css" integrity="sha384-iD0dNku6PYSIQLyfTOpB06F2KCZJAKLOThS5HRe8b3ibhdEQ6eKsFf/EeFxdOt5R" crossorigin="anonymous">
   {{- end -}}
 
-{{- partial "head_custom.html" . }}
+  {{- with .Page.ExpiryDate -}}
+  {{ partial "meta-robot-unavailable-after.html" . }}
+  {{- end }}
+  {{- partial "head_custom.html" . }}
 {{- if not hugo.IsServer -}}
   {{ template "_internal/google_analytics.html" . }}
 {{- end -}}

--- a/layouts/partials/meta-robot-unavailable-after.html
+++ b/layouts/partials/meta-robot-unavailable-after.html
@@ -1,0 +1,3 @@
+{{- with . }}
+  <meta name="robots" content="unavailable_after: {{ .UTC.Format "2006-01-02T15:04:05Z07:00" }}">
+{{ end }}


### PR DESCRIPTION
This adds a

<meta name"robots" content="unavailble_after: XXXX">

tag when the .expiryDate has been set in a page's front matter section.

This tells search engines such as google not t index the page after the expiration date and or time.