### PR TITLE
Gate data lookups for Hugo v0.156+

### DIFF
--- a/assets/compat/footer-social-icons-hugo-data.html
+++ b/assets/compat/footer-social-icons-hugo-data.html
@@ -1,0 +1,16 @@
+{{ range hugo.Data.beautifulhugo.social.social_icons }}
+  {{- if isset $.Site.Params.author .id }}
+    <li>
+      {{ if or ( hasPrefix ( index $.Site.Params.author .id ) "http://" ) ( hasPrefix ( index $.Site.Params.author .id ) "https://" ) }}
+        <a {{ if .rel }}rel="{{ .rel }}"{{- end -}} href="{{ printf "%s" (index $.Site.Params.author .id) }}" title="{{ .title }}">
+      {{ else }}
+        <a {{ if .rel }}rel="{{ .rel }}"{{- end -}} href="{{ printf .url (index $.Site.Params.author .id) }}" title="{{ .title }}">
+      {{ end }}
+        <span class="fa-stack fa-lg">
+          <i class="fas fa-circle fa-stack-2x"></i>
+          <i class="{{ .icon }} fa-stack-1x fa-inverse"></i>
+        </span>
+      </a>
+    </li>
+  {{- end -}}
+{{ end }}

--- a/assets/compat/footer-social-icons-hugo-data.html
+++ b/assets/compat/footer-social-icons-hugo-data.html
@@ -1,14 +1,15 @@
 {{ range hugo.Data.beautifulhugo.social.social_icons }}
-  {{- if isset $.Site.Params.author .id }}
+  {{- $icon := . -}}
+  {{- with index $.Site.Params.author .id }}
     <li>
-      {{ if or ( hasPrefix ( index $.Site.Params.author .id ) "http://" ) ( hasPrefix ( index $.Site.Params.author .id ) "https://" ) }}
-        <a {{ if .rel }}rel="{{ .rel }}"{{- end -}} href="{{ printf "%s" (index $.Site.Params.author .id) }}" title="{{ .title }}">
+      {{ if or ( hasPrefix . "http://" ) ( hasPrefix . "https://" ) }}
+        <a {{ if $icon.rel }}rel="{{ $icon.rel }}"{{- end -}} href="{{ printf "%s" . }}" title="{{ $icon.title }}">
       {{ else }}
-        <a {{ if .rel }}rel="{{ .rel }}"{{- end -}} href="{{ printf .url (index $.Site.Params.author .id) }}" title="{{ .title }}">
+        <a {{ if $icon.rel }}rel="{{ $icon.rel }}"{{- end -}} href="{{ printf $icon.url . }}" title="{{ $icon.title }}">
       {{ end }}
         <span class="fa-stack fa-lg">
           <i class="fas fa-circle fa-stack-2x"></i>
-          <i class="{{ .icon }} fa-stack-1x fa-inverse"></i>
+          <i class="{{ $icon.icon }} fa-stack-1x fa-inverse"></i>
         </span>
       </a>
     </li>

--- a/assets/compat/footer-social-icons-site-data.html
+++ b/assets/compat/footer-social-icons-site-data.html
@@ -1,0 +1,16 @@
+{{ range .Site.Data.beautifulhugo.social.social_icons }}
+  {{- if isset $.Site.Params.author .id }}
+    <li>
+      {{ if or ( hasPrefix ( index $.Site.Params.author .id ) "http://" ) ( hasPrefix ( index $.Site.Params.author .id ) "https://" ) }}
+        <a {{ if .rel }}rel="{{ .rel }}"{{- end -}} href="{{ printf "%s" (index $.Site.Params.author .id) }}" title="{{ .title }}">
+      {{ else }}
+        <a {{ if .rel }}rel="{{ .rel }}"{{- end -}} href="{{ printf .url (index $.Site.Params.author .id) }}" title="{{ .title }}">
+      {{ end }}
+        <span class="fa-stack fa-lg">
+          <i class="fas fa-circle fa-stack-2x"></i>
+          <i class="{{ .icon }} fa-stack-1x fa-inverse"></i>
+        </span>
+      </a>
+    </li>
+  {{- end -}}
+{{ end }}

--- a/assets/compat/footer-social-icons-site-data.html
+++ b/assets/compat/footer-social-icons-site-data.html
@@ -1,14 +1,14 @@
 {{ range .Site.Data.beautifulhugo.social.social_icons }}
-  {{- if isset $.Site.Params.author .id }}
+  {{- with index $.Site.Params.author .id }}
     <li>
-      {{ if or ( hasPrefix ( index $.Site.Params.author .id ) "http://" ) ( hasPrefix ( index $.Site.Params.author .id ) "https://" ) }}
-        <a {{ if .rel }}rel="{{ .rel }}"{{- end -}} href="{{ printf "%s" (index $.Site.Params.author .id) }}" title="{{ .title }}">
+      {{ if or ( hasPrefix . "http://" ) ( hasPrefix . "https://" ) }}
+        <a {{ if $.rel }}rel="{{ $.rel }}"{{- end -}} href="{{ printf "%s" . }}" title="{{ $.title }}">
       {{ else }}
-        <a {{ if .rel }}rel="{{ .rel }}"{{- end -}} href="{{ printf .url (index $.Site.Params.author .id) }}" title="{{ .title }}">
+        <a {{ if $.rel }}rel="{{ $.rel }}"{{- end -}} href="{{ printf $.url . }}" title="{{ $.title }}">
       {{ end }}
         <span class="fa-stack fa-lg">
           <i class="fas fa-circle fa-stack-2x"></i>
-          <i class="{{ .icon }} fa-stack-1x fa-inverse"></i>
+          <i class="{{ $.icon }} fa-stack-1x fa-inverse"></i>
         </span>
       </a>
     </li>

--- a/assets/compat/footer-social-icons-site-data.html
+++ b/assets/compat/footer-social-icons-site-data.html
@@ -1,14 +1,15 @@
 {{ range .Site.Data.beautifulhugo.social.social_icons }}
+  {{- $icon := . -}}
   {{- with index $.Site.Params.author .id }}
     <li>
       {{ if or ( hasPrefix . "http://" ) ( hasPrefix . "https://" ) }}
-        <a {{ if $.rel }}rel="{{ $.rel }}"{{- end -}} href="{{ printf "%s" . }}" title="{{ $.title }}">
+        <a {{ if $icon.rel }}rel="{{ $icon.rel }}"{{- end -}} href="{{ printf "%s" . }}" title="{{ $icon.title }}">
       {{ else }}
-        <a {{ if $.rel }}rel="{{ $.rel }}"{{- end -}} href="{{ printf $.url . }}" title="{{ $.title }}">
+        <a {{ if $icon.rel }}rel="{{ $icon.rel }}"{{- end -}} href="{{ printf $icon.url . }}" title="{{ $icon.title }}">
       {{ end }}
         <span class="fa-stack fa-lg">
           <i class="fas fa-circle fa-stack-2x"></i>
-          <i class="{{ $.icon }} fa-stack-1x fa-inverse"></i>
+          <i class="{{ $icon.icon }} fa-stack-1x fa-inverse"></i>
         </span>
       </a>
     </li>

--- a/assets/compat/post-meta-comment-count-hugo-data.html
+++ b/assets/compat/post-meta-comment-count-hugo-data.html
@@ -1,0 +1,13 @@
+{{ $slug := replace .RelPermalink "/" "" }}
+{{ if hugo.Data.comments }}
+  {{ $comments := index hugo.Data.comments $slug }}
+  {{ if $comments }}
+    {{ if gt (len $comments) 1  }}
+      {{ len $comments  }} {{ i18n "moreComment" }}
+    {{ else }}
+      {{ len $comments  }} {{ i18n "oneComment" }}
+    {{ end }}
+  {{ else }}
+    0 {{ i18n "oneComment" }}
+  {{ end }}
+{{ end }}

--- a/assets/compat/post-meta-comment-count-site-data.html
+++ b/assets/compat/post-meta-comment-count-site-data.html
@@ -1,0 +1,13 @@
+{{ $slug := replace .RelPermalink "/" "" }}
+{{ if .Site.Data.comments }}
+  {{ $comments := index $.Site.Data.comments $slug }}
+  {{ if $comments }}
+    {{ if gt (len $comments) 1  }}
+      {{ len $comments  }} {{ i18n "moreComment" }}
+    {{ else }}
+      {{ len $comments  }} {{ i18n "oneComment" }}
+    {{ end }}
+  {{ else }}
+    0 {{ i18n "oneComment" }}
+  {{ end }}
+{{ end }}

--- a/assets/compat/staticman-comments-hugo-data.html
+++ b/assets/compat/staticman-comments-hugo-data.html
@@ -1,0 +1,30 @@
+{{ $slug := replace .RelPermalink "/" "" }}
+{{ if hugo.Data.comments }}
+  {{ $comments := index hugo.Data.comments $slug }}
+  {{ if $comments }}
+    {{ if gt (len $comments) 1  }}
+      <h3>{{ len $comments  }} {{ i18n "moreComment" }}</h3>
+    {{ else }}
+      <h3>{{ len $comments  }} {{ i18n "oneComment" }}</h3>
+    {{ end }}
+  {{ else }}
+    <h3>{{ i18n "noComment" }}</h3>
+  {{ end }}
+
+  {{ $.Scratch.Set "hasComments" 0 }}
+  {{ range $index, $comments := (index hugo.Data.comments $slug ) }}
+    {{ if not .parent }}
+      {{ $.Scratch.Add "hasComments" 1 }}
+      <article id="comment-{{ $.Scratch.Get "hasComments" }}" class="static-comment">
+        <img class="comment-avatar" src="https://www.gravatar.com/avatar/{{ .email }}?s=48">
+        {{ if .website }}
+        <h4 class="comment-author"><a rel="external nofollow" href="{{ .website }}">{{ .name }}</a></h4>
+        {{ else }}
+        <h4 class="comment-author">{{ .name }}</h4>
+        {{ end }}
+        <div class="comment-timestamp"><a href="#comment-{{ $.Scratch.Get "hasComments" }}" title="Permalink to this comment"><time datetime="{{ .date }}">{{ dateFormat (default (i18n "shortdateFormat") .Site.Params.dateformat) .date}}</time></a></div>
+        <div class="comment-content"><p>{{ .comment | markdownify }}</p></div>
+      </article>
+    {{ end }}
+  {{ end }}
+{{ end }}

--- a/assets/compat/staticman-comments-hugo-data.html
+++ b/assets/compat/staticman-comments-hugo-data.html
@@ -11,18 +11,18 @@
     <h3>{{ i18n "noComment" }}</h3>
   {{ end }}
 
-  {{ $.Scratch.Set "hasComments" 0 }}
+  {{ $.Store.Set "hasComments" 0 }}
   {{ range $index, $comments := (index hugo.Data.comments $slug ) }}
     {{ if not .parent }}
-      {{ $.Scratch.Add "hasComments" 1 }}
-      <article id="comment-{{ $.Scratch.Get "hasComments" }}" class="static-comment">
+      {{ $.Store.Set "hasComments" (add ($.Store.Get "hasComments") 1) }}
+      <article id="comment-{{ $.Store.Get "hasComments" }}" class="static-comment">
         <img class="comment-avatar" src="https://www.gravatar.com/avatar/{{ .email }}?s=48">
         {{ if .website }}
         <h4 class="comment-author"><a rel="external nofollow" href="{{ .website }}">{{ .name }}</a></h4>
         {{ else }}
         <h4 class="comment-author">{{ .name }}</h4>
         {{ end }}
-        <div class="comment-timestamp"><a href="#comment-{{ $.Scratch.Get "hasComments" }}" title="Permalink to this comment"><time datetime="{{ .date }}">{{ dateFormat (default (i18n "shortdateFormat") .Site.Params.dateformat) .date}}</time></a></div>
+        <div class="comment-timestamp"><a href="#comment-{{ $.Store.Get "hasComments" }}" title="Permalink to this comment"><time datetime="{{ .date }}">{{ dateFormat (default (i18n "shortdateFormat") .Site.Params.dateformat) .date}}</time></a></div>
         <div class="comment-content"><p>{{ .comment | markdownify }}</p></div>
       </article>
     {{ end }}

--- a/assets/compat/staticman-comments-site-data.html
+++ b/assets/compat/staticman-comments-site-data.html
@@ -1,0 +1,30 @@
+{{ $slug := replace .RelPermalink "/" "" }}
+{{ if .Site.Data.comments }}
+  {{ $comments := index $.Site.Data.comments $slug }}
+  {{ if $comments }}
+    {{ if gt (len $comments) 1  }}
+      <h3>{{ len $comments  }} {{ i18n "moreComment" }}</h3>
+    {{ else }}
+      <h3>{{ len $comments  }} {{ i18n "oneComment" }}</h3>
+    {{ end }}
+  {{ else }}
+    <h3>{{ i18n "noComment" }}</h3>
+  {{ end }}
+
+  {{ $.Scratch.Set "hasComments" 0 }}
+  {{ range $index, $comments := (index $.Site.Data.comments $slug ) }}
+    {{ if not .parent }}
+      {{ $.Scratch.Add "hasComments" 1 }}
+      <article id="comment-{{ $.Scratch.Get "hasComments" }}" class="static-comment">
+        <img class="comment-avatar" src="https://www.gravatar.com/avatar/{{ .email }}?s=48">
+        {{ if .website }}
+        <h4 class="comment-author"><a rel="external nofollow" href="{{ .website }}">{{ .name }}</a></h4>
+        {{ else }}
+        <h4 class="comment-author">{{ .name }}</h4>
+        {{ end }}
+        <div class="comment-timestamp"><a href="#comment-{{ $.Scratch.Get "hasComments" }}" title="Permalink to this comment"><time datetime="{{ .date }}">{{ dateFormat (default (i18n "shortdateFormat") .Site.Params.dateformat) .date}}</time></a></div>
+        <div class="comment-content"><p>{{ .comment | markdownify }}</p></div>
+      </article>
+    {{ end }}
+  {{ end }}
+{{ end }}

--- a/assets/compat/staticman-comments-site-data.html
+++ b/assets/compat/staticman-comments-site-data.html
@@ -11,18 +11,18 @@
     <h3>{{ i18n "noComment" }}</h3>
   {{ end }}
 
-  {{ $.Scratch.Set "hasComments" 0 }}
+  {{ $.Store.Set "hasComments" 0 }}
   {{ range $index, $comments := (index $.Site.Data.comments $slug ) }}
     {{ if not .parent }}
-      {{ $.Scratch.Add "hasComments" 1 }}
-      <article id="comment-{{ $.Scratch.Get "hasComments" }}" class="static-comment">
+      {{ $.Store.Set "hasComments" (add ($.Store.Get "hasComments") 1) }}
+      <article id="comment-{{ $.Store.Get "hasComments" }}" class="static-comment">
         <img class="comment-avatar" src="https://www.gravatar.com/avatar/{{ .email }}?s=48">
         {{ if .website }}
         <h4 class="comment-author"><a rel="external nofollow" href="{{ .website }}">{{ .name }}</a></h4>
         {{ else }}
         <h4 class="comment-author">{{ .name }}</h4>
         {{ end }}
-        <div class="comment-timestamp"><a href="#comment-{{ $.Scratch.Get "hasComments" }}" title="Permalink to this comment"><time datetime="{{ .date }}">{{ dateFormat (default (i18n "shortdateFormat") .Site.Params.dateformat) .date}}</time></a></div>
+        <div class="comment-timestamp"><a href="#comment-{{ $.Store.Get "hasComments" }}" title="Permalink to this comment"><time datetime="{{ .date }}">{{ dateFormat (default (i18n "shortdateFormat") .Site.Params.dateformat) .date}}</time></a></div>
         <div class="comment-content"><p>{{ .comment | markdownify }}</p></div>
       </article>
     {{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -18,8 +18,9 @@
         <ul class="list-inline text-center footer-links">
           {{- $useHugoData := eq (partial "functions/hugo-version-gte-0.156.0.html" .) "true" -}}
           {{- $socialIconsTemplate := cond $useHugoData "compat/footer-social-icons-hugo-data.html" "compat/footer-social-icons-site-data.html" -}}
+          {{- $socialIconsTarget := printf "%s-%s" $socialIconsTemplate (default "default" .Site.Language.Lang) -}}
           {{- with resources.Get $socialIconsTemplate -}}
-            {{- with . | resources.ExecuteAsTemplate $socialIconsTemplate $ -}}
+            {{- with . | resources.ExecuteAsTemplate $socialIconsTarget $ -}}
               {{- .Content | safeHTML -}}
             {{- end -}}
           {{- end -}}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -16,24 +16,13 @@
     <div class="row">
       <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
         <ul class="list-inline text-center footer-links">
-          {{ range .Site.Data.beautifulhugo.social.social_icons }}
-            {{- $social := . -}}
-            {{- with index $.Site.Params.author $social.id }}
-              <li>
-		{{- $authorValue := . -}}
-		{{ if or ( hasPrefix $authorValue "http://" ) ( hasPrefix $authorValue "https://" ) }}
-		  <a {{ if $social.rel }}rel="{{ $social.rel }}"{{- end -}} href="{{ printf "%s" $authorValue }}" title="{{ $social.title }}">
-		{{ else }}
-		  <a {{ if $social.rel }}rel="{{ $social.rel }}"{{- end -}} href="{{ printf $social.url $authorValue }}" title="{{ $social.title }}">
-		{{ end }}
-                  <span class="fa-stack fa-lg">
-                    <i class="fas fa-circle fa-stack-2x"></i>
-                    <i class="{{ $social.icon }} fa-stack-1x fa-inverse"></i>
-                  </span>
-                </a>
-              </li>
-            {{- end }}
-          {{ end }}
+          {{- $useHugoData := eq (partial "functions/hugo-version-gte-0.156.0.html" .) "true" -}}
+          {{- $socialIconsTemplate := cond $useHugoData "compat/footer-social-icons-hugo-data.html" "compat/footer-social-icons-site-data.html" -}}
+          {{- with resources.Get $socialIconsTemplate -}}
+            {{- with . | resources.ExecuteAsTemplate $socialIconsTemplate $ -}}
+              {{- .Content | safeHTML -}}
+            {{- end -}}
+          {{- end -}}
           {{ if .Site.Params.rss }}
           {{ with .OutputFormats.Get "RSS" }}
           <li>

--- a/layouts/partials/functions/data/organization-contact-point-hugo-data.html
+++ b/layouts/partials/functions/data/organization-contact-point-hugo-data.html
@@ -1,0 +1,1 @@
+{{- with hugo.Data.organization.contacts.contactPoint -}}, "contactPoint": {{ . }}{{ end }}

--- a/layouts/partials/functions/data/organization-contact-point-site-data.html
+++ b/layouts/partials/functions/data/organization-contact-point-site-data.html
@@ -1,0 +1,1 @@
+{{- with .Site.Data.organization.contacts.contactPoint -}}, "contactPoint": {{ . }}{{ end }}

--- a/layouts/partials/functions/hugo-version-gte-0.156.0.html
+++ b/layouts/partials/functions/hugo-version-gte-0.156.0.html
@@ -1,0 +1,16 @@
+{{- $parts := split hugo.Version "." -}}
+{{- $major := int (index $parts 0) -}}
+{{- $minor := int (index $parts 1) -}}
+{{- $patchPart := default "0" (index $parts 2) -}}
+{{- $patch := int (index (split $patchPart "-") 0) -}}
+{{- if gt $major 0 -}}
+true
+{{- else if gt $minor 156 -}}
+true
+{{- else if lt $minor 156 -}}
+false
+{{- else if ge $patch 0 -}}
+true
+{{- else -}}
+false
+{{- end -}}

--- a/layouts/partials/functions/hugo-version-gte-0.156.0.html
+++ b/layouts/partials/functions/hugo-version-gte-0.156.0.html
@@ -1,20 +1,4 @@
-{{- $parts := split hugo.Version "." -}}
-{{- $major := int (index $parts 0) -}}
-{{- $minor := int (index $parts 1) -}}
-{{- $patchPart := "" -}}
-{{- if ge (len $parts) 3 -}}
-  {{- $patchPart = index $parts 2 -}}
-{{- else -}}
-  {{- $patchPart = "0" -}}
-{{- end -}}
-{{- $patch := int (index (split $patchPart "-") 0) -}}
-{{- if gt $major 0 -}}
-true
-{{- else if gt $minor 156 -}}
-true
-{{- else if lt $minor 156 -}}
-false
-{{- else if ge $patch 0 -}}
+{{- if ge hugo.Version "0.156.0" -}}
 true
 {{- else -}}
 false

--- a/layouts/partials/functions/hugo-version-gte-0.156.0.html
+++ b/layouts/partials/functions/hugo-version-gte-0.156.0.html
@@ -1,7 +1,12 @@
 {{- $parts := split hugo.Version "." -}}
 {{- $major := int (index $parts 0) -}}
 {{- $minor := int (index $parts 1) -}}
-{{- $patchPart := default "0" (index $parts 2) -}}
+{{- $patchPart := "" -}}
+{{- if ge (len $parts) 3 -}}
+  {{- $patchPart = index $parts 2 -}}
+{{- else -}}
+  {{- $patchPart = "0" -}}
+{{- end -}}
 {{- $patch := int (index (split $patchPart "-") 0) -}}
 {{- if gt $major 0 -}}
 true

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -2,6 +2,7 @@
   {{ $format := default (i18n "dateFormat") .Site.Params.dateformat }}
   {{ $datestr := .Date.Format $format }}
   {{ $lastmodstr := .Lastmod.Format $format }}
+  {{- $useHugoData := eq (partial "functions/hugo-version-gte-0.156.0.html" .) "true" -}}
   <i class="fas fa-calendar"></i>&nbsp;{{ $datestr | i18n "postedOnDate"}}
   {{ if ne $datestr $lastmodstr }}
     &nbsp;({{ $lastmodstr | i18n "lastModified"  }})
@@ -27,19 +28,12 @@
   {{ end }}
   {{- if .Site.Params.staticman -}}
     &nbsp;|&nbsp;<i class="fas fa-comment"></i>&nbsp;
-    {{ $slug := replace .RelPermalink "/" "" }}
-    {{ if .Site.Data.comments }}
-      {{ $comments := index $.Site.Data.comments $slug }}
-      {{ if $comments }}
-        {{ if gt (len $comments) 1  }}
-          {{ len $comments  }} {{ i18n "moreComment" }}
-        {{ else }}
-          {{ len $comments  }} {{ i18n "oneComment" }}
-        {{ end }}
-      {{ else }}
-        0 {{ i18n "oneComment" }}
-      {{ end }}
-    {{ end }}
+    {{- $commentCountTemplate := cond $useHugoData "compat/post-meta-comment-count-hugo-data.html" "compat/post-meta-comment-count-site-data.html" -}}
+    {{- with resources.Get $commentCountTemplate -}}
+      {{- with . | resources.ExecuteAsTemplate $commentCountTemplate $ -}}
+        {{- .Content -}}
+      {{- end -}}
+    {{- end -}}
   {{ end }}
   {{ if .IsTranslated -}}
     {{- $sortedTranslations := sort .Translations "Site.Language.Weight" -}}
@@ -49,4 +43,3 @@
     &nbsp;&bull;&nbsp;{{ i18n "translationsLabel" }}{{ $linksOutput | safeHTML }}
   {{- end }}
 </span>
-

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -30,7 +30,7 @@
     &nbsp;|&nbsp;<i class="fas fa-comment"></i>&nbsp;
     {{- $commentCountTemplate := cond $useHugoData "compat/post-meta-comment-count-hugo-data.html" "compat/post-meta-comment-count-site-data.html" -}}
     {{- with resources.Get $commentCountTemplate -}}
-      {{- $slug := replace .RelPermalink "/" "" -}}
+      {{- $slug := replace $.RelPermalink "/" "" -}}
       {{- with . | resources.ExecuteAsTemplate (printf "%s-%s" $commentCountTemplate $slug) $ -}}
         {{- .Content -}}
       {{- end -}}

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -30,7 +30,8 @@
     &nbsp;|&nbsp;<i class="fas fa-comment"></i>&nbsp;
     {{- $commentCountTemplate := cond $useHugoData "compat/post-meta-comment-count-hugo-data.html" "compat/post-meta-comment-count-site-data.html" -}}
     {{- with resources.Get $commentCountTemplate -}}
-      {{- with . | resources.ExecuteAsTemplate $commentCountTemplate $ -}}
+      {{- $slug := replace .RelPermalink "/" "" -}}
+      {{- with . | resources.ExecuteAsTemplate (printf "%s-%s" $commentCountTemplate $slug) $ -}}
         {{- .Content -}}
       {{- end -}}
     {{- end -}}

--- a/layouts/partials/seo/structured/organization.html
+++ b/layouts/partials/seo/structured/organization.html
@@ -1,4 +1,7 @@
 <script type="application/ld+json">
+{{- $useHugoData := eq (partial "functions/hugo-version-gte-0.156.0.html" .) "true" -}}
+{{- $contactPointPartial := cond $useHugoData "functions/data/organization-contact-point-hugo-data.html" "functions/data/organization-contact-point-site-data.html" -}}
+{{- $contactPoint := trim (partial $contactPointPartial .) "\r\n\t " -}}
 {
   "@context": "https://schema.org",
   "@type": "Organization",
@@ -7,7 +10,7 @@
   {{- with .Site.Params.socialProfiles }}, "sameAs": {{ . }}{{ end }}
   {{- with .Site.Params.organizationLogo }}, "logo": {{ . }}{{ end }}
   {{- with .Site.Params.organizationAddress }}, "address": {{ . }}{{ end }}
-  {{- with .Site.Data.organization.contacts.contactPoint }}, "contactPoint": {{ . }}{{ end }}
+  {{- with $contactPoint }}{{ . | safeHTML }}{{ end }}
   "url": {{ .Site.BaseURL }}
 }
 </script>

--- a/layouts/partials/staticman-comments.html
+++ b/layouts/partials/staticman-comments.html
@@ -3,7 +3,7 @@
   {{- $useHugoData := eq (partial "functions/hugo-version-gte-0.156.0.html" .) "true" -}}
   {{- $commentsTemplate := cond $useHugoData "compat/staticman-comments-hugo-data.html" "compat/staticman-comments-site-data.html" -}}
   {{- with resources.Get $commentsTemplate -}}
-    {{- $slug := replace .RelPermalink "/" "" -}}
+    {{- $slug := replace $.RelPermalink "/" "" -}}
     {{- with . | resources.ExecuteAsTemplate (printf "%s-%s" $commentsTemplate $slug) $ -}}
       {{- .Content | safeHTML -}}
     {{- end -}}

--- a/layouts/partials/staticman-comments.html
+++ b/layouts/partials/staticman-comments.html
@@ -3,7 +3,8 @@
   {{- $useHugoData := eq (partial "functions/hugo-version-gte-0.156.0.html" .) "true" -}}
   {{- $commentsTemplate := cond $useHugoData "compat/staticman-comments-hugo-data.html" "compat/staticman-comments-site-data.html" -}}
   {{- with resources.Get $commentsTemplate -}}
-    {{- with . | resources.ExecuteAsTemplate $commentsTemplate $ -}}
+    {{- $slug := replace .RelPermalink "/" "" -}}
+    {{- with . | resources.ExecuteAsTemplate (printf "%s-%s" $commentsTemplate $slug) $ -}}
       {{- .Content | safeHTML -}}
     {{- end -}}
   {{- end -}}

--- a/layouts/partials/staticman-comments.html
+++ b/layouts/partials/staticman-comments.html
@@ -1,37 +1,12 @@
 <section class="js-comments staticman-comments">
 
-  {{ $slug := replace .RelPermalink "/" "" }}
-
-  {{ if .Site.Data.comments }}
-    {{ $comments := index $.Site.Data.comments $slug }}
-    {{ if $comments }}
-      {{ if gt (len $comments) 1  }}
-        <h3>{{ len $comments  }} {{ i18n "moreComment" }}</h3>
-      {{ else }}
-        <h3>{{ len $comments  }} {{ i18n "oneComment" }}</h3>
-      {{ end }}
-    {{ else }}
-      <h3>{{ i18n "noComment" }}</h3>
-    {{ end }}
-
-
-    {{ $.Store.Set "hasComments" 0 }}
-    {{ range $index, $comments := (index $.Site.Data.comments $slug ) }}
-      {{ if not .parent }}
-        {{ $.Store.Set "hasComments" (add ($.Store.Get "hasComments") 1) }}
-        <article id="comment-{{ $.Store.Get "hasComments" }}" class="static-comment">
-          <img class="comment-avatar" src="https://www.gravatar.com/avatar/{{ .email }}?s=48">
-          {{ if .website }}
-          <h4 class="comment-author"><a rel="external nofollow" href="{{ .website }}">{{ .name }}</a></h4>
-          {{ else }}
-          <h4 class="comment-author">{{ .name }}</h4>
-          {{ end }}
-          <div class="comment-timestamp"><a href="#comment-{{ $.Store.Get "hasComments" }}" title="Permalink to this comment"><time datetime="{{ .date }}">{{ dateFormat (default (i18n "shortdateFormat") .Site.Params.dateformat) .date}}</time></a></div>
-          <div class="comment-content"><p>{{ .comment | markdownify }}</p></div>
-        </article>
-      {{ end }}
-    {{ end }}
-  {{ end }}
+  {{- $useHugoData := eq (partial "functions/hugo-version-gte-0.156.0.html" .) "true" -}}
+  {{- $commentsTemplate := cond $useHugoData "compat/staticman-comments-hugo-data.html" "compat/staticman-comments-site-data.html" -}}
+  {{- with resources.Get $commentsTemplate -}}
+    {{- with . | resources.ExecuteAsTemplate $commentsTemplate $ -}}
+      {{- .Content | safeHTML -}}
+    {{- end -}}
+  {{- end -}}
 
 
 


### PR DESCRIPTION
Hugo v0.156.0 deprecated .Site.Data in favor of hugo.Data. On newer Hugo versions this emits a build warning in several partials.

This change adds a version gate and dispatches to separate partials so Hugo v0.156.0 and later use hugo.Data while older versions can continue using .Site.Data without breaking compatibility. See
https://discourse.gohugo.io/t/deprecations-in-v0-156-0/56732.

Fixes #581.