### PR TITLE
Remove isset warnings on current Hugo

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -60,7 +60,7 @@
       {{ end }}
 
 
-      {{ if (.Params.comments) | or (and (or (not (isset .Params "comments")) (eq .Params.comments nil)) (and .Site.Params.comments (ne .Type "page"))) }}
+      {{ if and (ne .Type "page") (.Param "comments") }}
       
       {{ if .Site.Params.cusdisID }}
 

--- a/layouts/partials/disqus-wrapper.html
+++ b/layouts/partials/disqus-wrapper.html
@@ -1,4 +1,4 @@
-{{ if (.Params.comments) | or (and (or (not (isset .Params "comments")) (eq .Params.comments nil)) (.Site.Params.comments)) }}
+{{ if .Param "comments" }}
   {{ if .Site.Config.Services.Disqus.Shortname }}
     <div class="comments">
       {{ partial "disqus.html" . }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,7 +1,7 @@
   {{ if eq .Type "page" }}
     {{ partial "page_meta.html" . }}
   {{ end }}
-  {{- if and (not (isset .Site.Params "author")) (isset .Site "author") -}}
+  {{- if and (not .Site.Params.author) .Site.Author -}}
      {{ errorf "Please move [author] to [params.author]; Hugo has deprecated the former." }}
   {{- end -}}
 <footer>
@@ -17,20 +17,22 @@
       <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
         <ul class="list-inline text-center footer-links">
           {{ range .Site.Data.beautifulhugo.social.social_icons }}
-            {{- if isset $.Site.Params.author .id }}
+            {{- $social := . -}}
+            {{- with index $.Site.Params.author $social.id }}
               <li>
-		{{ if or ( hasPrefix ( index $.Site.Params.author .id ) "http://" ) ( hasPrefix ( index $.Site.Params.author .id ) "https://" ) }}
-		  <a {{ if .rel }}rel="{{ .rel }}"{{- end -}} href="{{ printf "%s" (index $.Site.Params.author .id) }}" title="{{ .title }}">
+		{{- $authorValue := . -}}
+		{{ if or ( hasPrefix $authorValue "http://" ) ( hasPrefix $authorValue "https://" ) }}
+		  <a {{ if $social.rel }}rel="{{ $social.rel }}"{{- end -}} href="{{ printf "%s" $authorValue }}" title="{{ $social.title }}">
 		{{ else }}
-		  <a {{ if .rel }}rel="{{ .rel }}"{{- end -}} href="{{ printf .url (index $.Site.Params.author .id) }}" title="{{ .title }}">
+		  <a {{ if $social.rel }}rel="{{ $social.rel }}"{{- end -}} href="{{ printf $social.url $authorValue }}" title="{{ $social.title }}">
 		{{ end }}
                   <span class="fa-stack fa-lg">
                     <i class="fas fa-circle fa-stack-2x"></i>
-                    <i class="{{ .icon }} fa-stack-1x fa-inverse"></i>
+                    <i class="{{ $social.icon }} fa-stack-1x fa-inverse"></i>
                   </span>
                 </a>
               </li>
-            {{- end -}}
+            {{- end }}
           {{ end }}
           {{ if .Site.Params.rss }}
           {{ with .OutputFormats.Get "RSS" }}

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -52,7 +52,7 @@
           {{ end }}
         {{ end }}
 
-        {{ if isset .Site.Params "gcse" }}
+        {{ with .Site.Params.gcse }}
           <li>
             <a href="#modalSearch" data-toggle="modal" data-target="#modalSearch" style="outline: none;">
               <span class="hidden-sm hidden-md hidden-lg">{{ i18n "gcseLabelShort" }}</span> <span id="searchGlyph" class="glyphicon glyphicon-search"></span>
@@ -62,15 +62,16 @@
       </ul>
     </div>
 
-    {{ if isset .Site.Params "logo" }}
+    {{ $page := . }}
+    {{ with .Site.Params.logo }}
       <div class="avatar-container">
         <div class="avatar-img-border">
-          <a title="{{ .Site.Title }}" href="{{ "" | absLangURL }}">
-          {{- $image := resources.Get ( $.Site.Params.logo) -}}
+          <a title="{{ $page.Site.Title }}" href="{{ "" | absLangURL }}">
+          {{- $image := resources.Get . -}}
           {{ if $image }}
-            <img class="avatar-img" src="{{ ($image.Fit "300x300 webp q100").Permalink }}" alt="{{ .Site.Title }}" />
+            <img class="avatar-img" src="{{ ($image.Fit "300x300 webp q100").Permalink }}" alt="{{ $page.Site.Title }}" />
           {{else}}
-            <img class="avatar-img" src="{{ .Site.Params.logo | absURL }}" alt="{{ .Site.Title }}" />
+            <img class="avatar-img" src="{{ . | absURL }}" alt="{{ $page.Site.Title }}" />
            {{end}}
           </a>
         </div>
@@ -81,13 +82,14 @@
 </nav>
 
 <!-- Search Modal -->
-{{ if isset .Site.Params "gcse" }}
+{{ $page := . }}
+{{ with .Site.Params.gcse }}
   <div id="modalSearch" class="modal fade" role="dialog">
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
           <button type="button" class="close" data-dismiss="modal">&times;</button>
-          <h4 class="modal-title">{{ i18n "gcseLabelLong" . }}</h4>
+          <h4 class="modal-title">{{ i18n "gcseLabelLong" $page }}</h4>
         </div>
         <div class="modal-body">
           <gcse:search></gcse:search>


### PR DESCRIPTION
Hugo v0.160.0 warns when isset is called with unsupported values in several theme templates.

Example warning: 'calling IsSet with unsupported type "ptr" (*page.siteWrapper) will always return false'.

This commit replaces those guards with direct parameter lookups and .Param where appropriate so the templates build cleanly.

Fixes #582.