### PR TITLE
Replace deprecated .Site.Languages in nav

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -30,11 +30,13 @@
         {{ end }}
 
         {{ if hugo.IsMultilingual }}
-          {{ if ge (len .Site.Languages) 3 }}
+          {{ $pageTranslations := .AllTranslations }}
+          {{ $siteLanguages := .Site.Home.AllTranslations }}
+          {{ if ge (len $siteLanguages) 3 }}
             <li class="navlinks-container">
               <a class="navlinks-parent" role="button" tabindex="0">{{ i18n "languageSwitcherLabel" }}</a>
               <div class="navlinks-children">
-                {{ range .Translations }}
+                {{ range $pageTranslations }}
                   {{ if not (eq .Lang $.Site.Language.Lang) }}
                   <a href="{{ .Permalink }}">{{ default .Lang .Site.Language.LanguageName }}</a>
                   {{ end }}


### PR DESCRIPTION
Hugo v0.156.0 deprecated .Site.Languages and recommends basing language selectors on the current page instead of the site object.

This updates the navigation language switcher to use the current page's translations rather than .Site.Languages. See
https://discourse.gohugo.io/t/deprecations-in-v0-156-0/56732.

Fixes #583.