### PR TITLE
fix: multiple bugs

### DIFF
--- a/layouts/partials/disqus-wrapper.html
+++ b/layouts/partials/disqus-wrapper.html
@@ -1,7 +1,7 @@
 {{ if .Param "comments" }}
   {{ if .Site.Config.Services.Disqus.Shortname }}
     <div class="comments">
-      {{ template "_internal/disqus.html" . }}
+      {{ partial "disqus.html" . }}
     </div>
   {{ end }}
 {{ end }}

--- a/layouts/partials/disqus-wrapper.html
+++ b/layouts/partials/disqus-wrapper.html
@@ -1,7 +1,7 @@
 {{ if .Param "comments" }}
   {{ if .Site.Config.Services.Disqus.Shortname }}
     <div class="comments">
-      {{ partial "disqus.html" . }}
+      {{ template "_internal/disqus.html" . }}
     </div>
   {{ end }}
 {{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,9 +1,6 @@
   {{ if eq .Type "page" }}
     {{ partial "page_meta.html" . }}
   {{ end }}
-  {{- if and (not .Site.Params.author) .Site.Author -}}
-     {{ errorf "Please move [author] to [params.author]; Hugo has deprecated the former." }}
-  {{- end -}}
 <footer>
   <div class="container">
     {{ if .Site.Params.disclaimerText }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,4 +1,4 @@
-{{- if eq .Kind "taxonomyTerm" }}
+{{- if eq .Kind "taxonomy" }}
   {{- range $key, $value := .Data.Terms.ByCount }}
     {{- $.Store.Set "most_used" (append $value.Name ($.Store.Get "most_used" | default slice)) }}
   {{- end }}
@@ -12,7 +12,7 @@
 
   {{- $title := printf "Overview of all pages with %s, ordered by %s" .Data.Plural .Data.Singular }}
   {{- $.Store.Set "Title" $title }}
-{{- else if eq .Kind "taxonomy" }}
+{{- else if eq .Kind "term" }}
   {{- $description := printf "Overview of all pages with the %s #%s, such as: %s" .Data.Singular $.Title ( index .Pages 0).Title | truncate 160 }}
   {{- $.Store.Set "Description" $description }}
 
@@ -115,5 +115,5 @@
   {{- end }}
   {{- partial "head_custom.html" . }}
 {{- if not hugo.IsServer -}}
-  {{ partial "google_analytics.html" . }}
+  {{ template "_internal/google_analytics.html" . }}
 {{- end -}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -115,5 +115,5 @@
   {{- end }}
   {{- partial "head_custom.html" . }}
 {{- if not hugo.IsServer -}}
-  {{ template "_internal/google_analytics.html" . }}
+  {{ partial "google_analytics.html" . }}
 {{- end -}}

--- a/layouts/partials/seo/structured/article.html
+++ b/layouts/partials/seo/structured/article.html
@@ -2,38 +2,38 @@
 {
   "@context": "https://schema.org",
   "@type": "Article",
-  "@id": {{ printf "%s#article" .Permalink }},
+  "@id": {{ printf "%s#article" .Permalink | jsonify }},
   "isPartOf": {
-    "@id": {{ .Permalink }}
+    "@id": {{ .Permalink | jsonify }}
   },
   "author": {
-    "name": "{{ .Params.author | default .Site.Params.author.name }}",
-    "url": {{ .Site.BaseURL }},
-    "@id": {{ printf "%s#author" .Site.BaseURL }}
+    "name": {{ .Params.author | default .Site.Params.author.name | jsonify }},
+    "url": {{ .Site.BaseURL | jsonify }},
+    "@id": {{ printf "%s#author" .Site.BaseURL | jsonify }}
   },
-  "headline": {{ .Title }},
-  "description": "{{ if .Description }}{{ .Description | plainify }}{{ else }}{{if .IsPage}}{{ .Summary | plainify  }}{{ end }}{{ end }}",
-  "inLanguage": {{ .Lang }},
+  "headline": {{ .Title | jsonify }},
+  "description": {{ if .Description }}{{ .Description | plainify | jsonify }}{{ else }}{{if .IsPage}}{{ .Summary | plainify | jsonify }}{{ else }}""{{ end }}{{ end }},
+  "inLanguage": {{ .Lang | jsonify }},
   "wordCount": {{ .WordCount }},
   {{- if gt .ReadingTime 5 }}
-  "timeRequired": {{ printf "PT%dM" .ReadingTime }},
+  "timeRequired": {{ printf "PT%dM" .ReadingTime | jsonify }},
   {{- end }}
-  "dateCreated": {{ .PublishDate.Format "2006-01-02T15:04:05-07:00" }},
-  "datePublished": {{ .PublishDate.Format "2006-01-02T15:04:05-07:00" }},
-  "dateModified": {{ .Lastmod.Format "2006-01-02T15:04:05-07:00"  }},
+  "dateCreated": {{ .PublishDate.Format "2006-01-02T15:04:05-07:00" | jsonify }},
+  "datePublished": {{ .PublishDate.Format "2006-01-02T15:04:05-07:00" | jsonify }},
+  "dateModified": {{ .Lastmod.Format "2006-01-02T15:04:05-07:00" | jsonify }},
   {{- if .Site.Params.logo }}
-  "image": {{ .Site.Params.logo | absURL }},
+  "image": {{ .Site.Params.logo | absURL | jsonify }},
   {{- end }}
-  "keywords": [ "{{ range $i, $e := .Params.tags }}{{ if $i }}, {{ end }}{{ $e }}{{ end }}" ],
+  "keywords": [ {{ range $i, $e := .Params.tags }}{{ if $i }}, {{ end }}{{ $e | jsonify }}{{ end }} ],
   "mainEntityOfPage": {
-    "@id": {{ .Permalink }}
+    "@id": {{ .Permalink | jsonify }}
   },
   "publisher": {
     "@type": "Organization",
-    "name": {{ .Site.BaseURL }},
+    "name": {{ .Site.Title | jsonify }},
     "logo": {
         "@type": "ImageObject",
-        "url": {{ .Site.Params.logo | absURL }},
+        "url": {{ .Site.Params.logo | absURL | jsonify }},
         "height": 60 ,
         "width": 60
     }

--- a/layouts/partials/seo/structured/organization.html
+++ b/layouts/partials/seo/structured/organization.html
@@ -2,12 +2,12 @@
 {
   "@context": "https://schema.org",
   "@type": "Organization",
-  "name": {{ .Site.Params.organizationName | default .Site.Params.Author.name }},
-  "@id": {{ printf "%s#organization" .Site.BaseURL }},
-  {{- with .Site.Params.socialProfiles }}, "sameAs": {{ . }}{{ end }}
-  {{- with .Site.Params.organizationLogo }}, "logo": {{ . }}{{ end }}
-  {{- with .Site.Params.organizationAddress }}, "address": {{ . }}{{ end }}
-  {{- with .Site.Data.organization.contacts.contactPoint }}, "contactPoint": {{ . }}{{ end }}
-  "url": {{ .Site.BaseURL }}
+  "name": {{ .Site.Params.organizationName | default .Site.Params.author.name | jsonify }},
+  "@id": {{ printf "%s#organization" .Site.BaseURL | jsonify }},
+  {{- with .Site.Params.socialProfiles }}, "sameAs": {{ . | jsonify }}{{ end }}
+  {{- with .Site.Params.organizationLogo }}, "logo": {{ . | jsonify }}{{ end }}
+  {{- with .Site.Params.organizationAddress }}, "address": {{ . | jsonify }}{{ end }}
+  {{- with .Site.Data.organization.contacts.contactPoint }}, "contactPoint": {{ . | jsonify }}{{ end }}
+  "url": {{ .Site.BaseURL | jsonify }}
 }
 </script>

--- a/layouts/partials/seo/structured/webpage.html
+++ b/layouts/partials/seo/structured/webpage.html
@@ -2,11 +2,11 @@
 {
   "@context": "https://schema.org",
   "@type": "WebPage",
-  "name": {{ .Title }},
-  "@id": {{ .Permalink }},
-  "url": {{ .Permalink }},
+  "name": {{ .Title | jsonify }},
+  "@id": {{ .Permalink | jsonify }},
+  "url": {{ .Permalink | jsonify }},
   "breadcrumb": {
-    "@id": {{ printf "%s#breadcrumb" .Permalink }}
+    "@id": {{ printf "%s#breadcrumb" .Permalink | jsonify }}
   }
 }
 </script>

--- a/layouts/partials/seo/structured/website.html
+++ b/layouts/partials/seo/structured/website.html
@@ -2,11 +2,11 @@
 {
   "@context": "https://schema.org",
   "@type": "WebSite",
-  "name": {{ .Site.Title }},
-  {{ with .Site.Params.alternatePageName }},
-  "alternateName": {{ . }},
+  "name": {{ .Site.Title | jsonify }},
+  {{- with .Site.Params.alternatePageName -}}
+  "alternateName": {{ . | jsonify }},
   {{- end -}}
-  "url": {{ .Site.BaseURL }},
-  "@id": {{ printf "%s#website" .Site.BaseURL }}
+  "url": {{ .Site.BaseURL | jsonify }},
+  "@id": {{ printf "%s#website" .Site.BaseURL | jsonify }}
 }
 </script>

--- a/layouts/partials/staticman-comments.html
+++ b/layouts/partials/staticman-comments.html
@@ -20,7 +20,7 @@
       {{ if not .parent }}
         {{ $.Store.Set "hasComments" (add ($.Store.Get "hasComments") 1) }}
         <article id="comment-{{ $.Store.Get "hasComments" }}" class="static-comment">
-          <img class="comment-avatar" src="https://www.gravatar.com/avatar/{{ .email }}?s=48">
+          <img class="comment-avatar" src="https://www.gravatar.com/avatar/{{ md5 .email }}?s=48">
           {{ if .website }}
           <h4 class="comment-author"><a rel="external nofollow" href="{{ .website }}">{{ .name }}</a></h4>
           {{ else }}

--- a/layouts/shortcodes/mermaid.html
+++ b/layouts/shortcodes/mermaid.html
@@ -1,5 +1,6 @@
 <link href="{{"css/mermaid.css" | relURL}}" type="text/css" rel="stylesheet"/>
-<script defer src="{{"js/mermaid.js" | relURL}}">
+<script defer src="{{"js/mermaid.js" | relURL}}"></script>
+<script>
     mermaid.initialize({startOnLoad:true});
 </script>
 <div class="mermaid" align="{{ if .Get "align" }}{{ .Get "align" }}{{ else }}center{{ end }}" >

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -127,7 +127,11 @@ div.card-body a.list-group-item.view-all {
   text-shadow: none;
   background: #0085a1;
 }
-img::-moz-selection, img::selection {
+img::-moz-selection {
+  color: white;
+  background: transparent;
+}
+img::selection {
   color: white;
   background: transparent;
 }
@@ -806,8 +810,6 @@ table tr {
   background-color: #ffffff;
   margin: 0;
   padding: 0;
-}
-@media (prefers-color-scheme: dark) {
 }
 table tr:nth-child(2n) {
   background-color: #f8f8f8;


### PR DESCRIPTION

I've requested fixes for the first section in #591, critical bugs. I reverted the first one, as it was a false positive (0.146 added the partials).

:robot:

All **critical bugs** from #591 are fixed and the example site builds cleanly. Here's a summary of each fix:

| # | Bug | File(s) | Fix |
|---|-----|---------|-----|
| 2 | Dead taxonomy `.Kind` checks | `head.html` | `taxonomyTerm` → `taxonomy` (list page), `taxonomy` → `term` (individual term page) — matches Hugo 0.73+ |
| 3 | Invalid JSON-LD (raw unquoted strings) | `seo/structured/*.html` (4 partials) | Added `jsonify` pipe to **all** string values in schema.org output, producing valid JSON |
| 4 | Broken Mermaid init | `shortcodes/mermaid.html` | Split `<script src=...>mermaid.initialize(...)</script>` into two separate `<script>` tags (inline JS is ignored in `src` scripts per HTML spec) |
| 5 | Gravatar leaks raw emails | `staticman-comments.html` | Wrapped `.email` with `md5` → `{{ md5 .email }}` |
| 6 | `.Site.Author` removed | `footer.html` | Removed the deprecated `.Site.Author` check + `errorf` (was already superseded by `AGENTS.md` guidance) |
| 7 | Typo in Org schema | `seo/structured/organization.html` | `.Site.Params.Author.name` → `.Site.Params.author.name` (lowercase `a`) |
| 8 | Invalid CSS | `main.css` | Split `img::-moz-selection, img::selection` grouped rule into two separate rules (Firefox doesn't support the comma-grouped pseudo-element syntax) |

The example site builds with **zero errors** and only a pre-existing deprecation warning about `.Site.Data`.

Assisted-by: OpenCode:Kimi-K2.6
