### PR TITLE
fix: better accessibility

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -19,9 +19,9 @@
               <li>
 		{{- $authorValue := . -}}
 		{{ if or ( hasPrefix $authorValue "http://" ) ( hasPrefix $authorValue "https://" ) }}
-		  <a {{ if $social.rel }}rel="{{ $social.rel }}"{{- end -}} href="{{ printf "%s" $authorValue }}" title="{{ $social.title }}">
+		  <a {{ if $social.rel }}rel="{{ $social.rel }} noopener noreferrer"{{ else }}rel="noopener noreferrer"{{ end }} href="{{ printf "%s" $authorValue }}" title="{{ $social.title }}">
 		{{ else }}
-		  <a {{ if $social.rel }}rel="{{ $social.rel }}"{{- end -}} href="{{ printf $social.url $authorValue }}" title="{{ $social.title }}">
+		  <a {{ if $social.rel }}rel="{{ $social.rel }} noopener noreferrer"{{ else }}rel="noopener noreferrer"{{ end }} href="{{ printf $social.url $authorValue }}" title="{{ $social.title }}">
 		{{ end }}
                   <span class="fa-stack fa-lg">
                     <i class="fas fa-circle fa-stack-2x"></i>

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -10,7 +10,7 @@
         {{ range .Site.Menus.main.ByWeight }}
           {{ if .HasChildren }}
             <li class="nav-item navlinks-container">
-              <a class="nav-link navlinks-parent" role="button" tabindex="0">{{ .Name }}</a>
+              <a class="nav-link navlinks-parent" role="button" tabindex="0" aria-expanded="false" aria-haspopup="true">{{ .Name }}</a>
               <div class="navlinks-children">
                 {{ range .Children }}
                   <a href="{{ .URL | relLangURL }}">{{ .Name }}</a>
@@ -24,12 +24,12 @@
           {{ end }}
         {{ end }}
 
-        {{ if hugo.IsMultilingual }}
-          {{ $pageTranslations := .AllTranslations }}
-          {{ $siteLanguages := .Site.Home.AllTranslations }}
-          {{ if ge (len $siteLanguages) 3 }}
-            <li class="nav-item navlinks-container">
-              <a class="nav-link navlinks-parent" role="button" tabindex="0">{{ i18n "languageSwitcherLabel" }}</a>
+          {{ if hugo.IsMultilingual }}
+            {{ $pageTranslations := .AllTranslations }}
+            {{ $siteLanguages := .Site.Home.AllTranslations }}
+            {{ if ge (len $siteLanguages) 3 }}
+              <li class="nav-item navlinks-container">
+                <a class="nav-link navlinks-parent" role="button" tabindex="0" aria-expanded="false" aria-haspopup="true">{{ i18n "languageSwitcherLabel" }}</a>
               <div class="navlinks-children">
                 {{ range $pageTranslations }}
                   {{ if not (eq .Lang $.Site.Language.Lang) }}
@@ -81,11 +81,11 @@
 <!-- Search Modal -->
 {{ $page := . }}
 {{ with .Site.Params.gcse }}
-  <div id="modalSearch" class="modal fade" role="dialog">
+  <div id="modalSearch" class="modal fade" role="dialog" aria-modal="true" aria-labelledby="searchModalTitle">
     <div class="modal-dialog" role="document">
       <div class="modal-content">
         <div class="modal-header">
-          <h5 class="modal-title">{{ i18n "gcseLabelLong" $page }}</h5>
+          <h5 class="modal-title" id="searchModalTitle">{{ i18n "gcseLabelLong" $page }}</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">

--- a/layouts/partials/share-links.html
+++ b/layouts/partials/share-links.html
@@ -1,53 +1,53 @@
 {{ if or .Params.socialShare (and .Site.Params.socialShare (ne .Params.socialShare false)) }}
 <!-- Social Share Button HTML -->
-<div class="share-box" aria-hidden="true">
-    <ul class="share">
+<div class="share-box" role="region">
+    <ul class="share" aria-label="Social sharing">
       <!-- Twitter -->
       <li>
-        <a href="//twitter.com/share?url={{ .Permalink }}&amp;text={{ .Title }}&amp;via={{ .Site.Params.author.twitter }}" target="_blank" title="Share on Twitter">
-          <i class="fab fa-twitter"></i>
+        <a href="//twitter.com/share?url={{ .Permalink }}&amp;text={{ .Title }}&amp;via={{ .Site.Params.author.twitter }}" target="_blank" rel="noopener noreferrer" title="Share on Twitter">
+          <i class="fab fa-twitter" aria-hidden="true"></i>
         </a>
       </li>
-  
+
       <!-- Facebook -->
       <li>
-        <a href="//www.facebook.com/sharer/sharer.php?u={{ .Permalink }}" target="_blank" title="Share on Facebook">
-          <i class="fab fa-facebook"></i>
+        <a href="//www.facebook.com/sharer/sharer.php?u={{ .Permalink }}" target="_blank" rel="noopener noreferrer" title="Share on Facebook">
+          <i class="fab fa-facebook" aria-hidden="true"></i>
         </a>
       </li>
-  
+
       <!-- Reddit -->
       <li>
-        <a href="//reddit.com/submit?url={{ .Permalink }}&amp;title={{ .Title }}" target="_blank" title="Share on Reddit">
-          <i class="fab fa-reddit"></i>
+        <a href="//reddit.com/submit?url={{ .Permalink }}&amp;title={{ .Title }}" target="_blank" rel="noopener noreferrer" title="Share on Reddit">
+          <i class="fab fa-reddit" aria-hidden="true"></i>
         </a>
       </li>
-  
+
       <!-- LinkedIn -->
       <li>
-        <a href="//www.linkedin.com/shareArticle?url={{ .Permalink }}&amp;title={{ .Title }}" target="_blank" title="Share on LinkedIn">
-          <i class="fab fa-linkedin"></i>
+        <a href="//www.linkedin.com/shareArticle?url={{ .Permalink }}&amp;title={{ .Title }}" target="_blank" rel="noopener noreferrer" title="Share on LinkedIn">
+          <i class="fab fa-linkedin" aria-hidden="true"></i>
         </a>
       </li>
-  
+
       <!-- StumbleUpon -->
       <li>
-        <a href="//www.stumbleupon.com/submit?url={{ .Permalink }}&amp;title={{ .Title }}" target="_blank" title="Share on StumbleUpon">
-          <i class="fab fa-stumbleupon"></i>
+        <a href="//www.stumbleupon.com/submit?url={{ .Permalink }}&amp;title={{ .Title }}" target="_blank" rel="noopener noreferrer" title="Share on StumbleUpon">
+          <i class="fab fa-stumbleupon" aria-hidden="true"></i>
         </a>
       </li>
-  
+
       <!-- Pinterest -->
       <li>
-        <a href="//www.pinterest.com/pin/create/button/?url={{ .Permalink }}&amp;description={{ .Title }}" target="_blank" title="Share on Pinterest">
-          <i class="fab fa-pinterest"></i>
+        <a href="//www.pinterest.com/pin/create/button/?url={{ .Permalink }}&amp;description={{ .Title }}" target="_blank" rel="noopener noreferrer" title="Share on Pinterest">
+          <i class="fab fa-pinterest" aria-hidden="true"></i>
         </a>
       </li>
 
       <!-- Email -->
       <li>
         <a href="mailto:?body={{ .Permalink }}&amp;subject={{ .Title }}" title="Share via email">
-          <i class="fab fa-at"></i>
+          <i class="fab fa-at" aria-hidden="true"></i>
         </a>
       </li>
     </ul>

--- a/layouts/partials/staticman-comments.html
+++ b/layouts/partials/staticman-comments.html
@@ -22,7 +22,7 @@
         <article id="comment-{{ $.Store.Get "hasComments" }}" class="static-comment">
           <img class="comment-avatar" src="https://www.gravatar.com/avatar/{{ md5 .email }}?s=48">
           {{ if .website }}
-          <h4 class="comment-author"><a rel="external nofollow" href="{{ .website }}">{{ .name }}</a></h4>
+          <h4 class="comment-author"><a rel="external nofollow noopener noreferrer" href="{{ .website }}">{{ .name }}</a></h4>
           {{ else }}
           <h4 class="comment-author">{{ .name }}</h4>
           {{ end }}
@@ -82,9 +82,9 @@
 </form>
 </section>
 
-<article class="modal">
+<article class="modal" role="dialog" aria-modal="true" aria-labelledby="staticman-modal-title" tabindex="-1">
   <div class="title">
-    <h2 class="js-modal-title"></h2>
+    <h2 class="js-modal-title" id="staticman-modal-title"></h2>
   </div>
   <div class="js-modal-text"></div>
   <div>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -37,11 +37,11 @@ p + p {
 }
 p a {
   /* text-decoration: underline */
-  color: #008AFF;
+  color: #0066CC;
 }
 @media (prefers-color-scheme: dark) {
   p a {
-    color: #50afff;
+    color: #66bfff;
   }
 }
 
@@ -50,11 +50,11 @@ h1,h2,h3,h4,h5,h6 {
   font-weight: 800;
 }
 a {
-  color: #008AFF;
+  color: #0066CC;
 }
 @media (prefers-color-scheme: dark) {
   a {
-    color: #50afff;
+    color: #66bfff;
   }
 }
 a:hover,
@@ -62,7 +62,7 @@ a:focus {
   color: #0085a1;
 }
 blockquote {
-  color: #808080;
+  color: #666;
   font-style: italic;
 }
 blockquote p:first-child {
@@ -230,6 +230,13 @@ figure:not(.dark) img, img.white {
   height: 40px;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .navbar-custom .navbar-brand-logo,
+  .navbar-custom .navbar-brand-logo img {
+    transition: none;
+  }
+}
+
 @media only screen and (min-width: 768px) {
   .navbar-custom {
     padding: 20px 0;
@@ -241,6 +248,12 @@ figure:not(.dark) img, img.white {
   }
 }
 
+@media only screen and (min-width: 768px) and (prefers-reduced-motion: reduce) {
+  .navbar-custom {
+    transition: none;
+  }
+}
+
 .navbar-custom .avatar-container {
   opacity: 1;
   visibility: visible;
@@ -249,6 +262,12 @@ figure:not(.dark) img, img.white {
   left: 50%;
   bottom: -25px;
   width: 50px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .navbar-custom .avatar-container {
+    transition: none;
+  }
 }
 .navbar-custom .avatar-container  .avatar-img-border {
   width: 100%;
@@ -460,7 +479,7 @@ footer div.disclaimer {
 .post-preview .post-meta,
 .post-heading .post-meta,
 .page-meta {
-  color: #808080;
+  color: #666;
   font-size: 18px;
   font-style: italic;
   margin: 0 0 10px;
@@ -495,6 +514,12 @@ footer div.disclaimer {
 .post-image:hover {
   filter: grayscale(0%);
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .post-image:hover {
+    filter: grayscale(90%);
+  }
+}
 .post-image img {
   border-radius: 100px;
   height: 192px;
@@ -515,7 +540,7 @@ footer div.disclaimer {
 
 .blog-tags {
   font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  color: #999;
+  color: #666;
   font-size: 15px;
   margin-bottom: 30px;
 }
@@ -525,7 +550,7 @@ footer div.disclaimer {
 }
 
 .blog-tags a {
-  color: #008AFF;
+  color: #0066CC;
   text-decoration: none;
   padding: 0px 5px;
 }
@@ -536,7 +561,7 @@ footer div.disclaimer {
 
 .blog-tags a:hover {
   border-radius: 2px;
-  color: #008AFF;
+  color: #004C99;
   background-color: #CCC;
 }
 
@@ -592,6 +617,14 @@ footer div.disclaimer {
   -webkit-transition: opacity 1s linear;
   -moz-transition: opacity 1s linear;
   transition: opacity 1s linear;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .intro-header.big-img  .big-img-transition {
+    -webkit-transition: none;
+    -moz-transition: none;
+    transition: none;
+  }
 }
 .intro-header .page-heading,
 .intro-header .tags-heading,
@@ -938,6 +971,12 @@ h4.see-also {
   transition: all 150ms ease-in-out;
   color: #fff;
 }
+
+@media (prefers-reduced-motion: reduce) {
+   ul.share li .fab {
+    transition: none;
+  }
+}
  ul.share li a {
   background-color: #b5c6ce;
   display: block;
@@ -1016,7 +1055,14 @@ h4.see-also {
   z-index: 10;
 }
 
-.highlight:hover .copyCodeButton {
+@media (prefers-reduced-motion: reduce) {
+  .copyCodeButton {
+    transition: none;
+  }
+}
+
+.highlight:hover .copyCodeButton,
+.highlight:focus-within .copyCodeButton {
   display: block;
 }
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -24,15 +24,26 @@ var main = {
     });
 
     // On mobile, when clicking on a multi-level navbar menu, show the child links
-    $('#main-navbar').on("click", ".navlinks-parent", function(e) {
+    // Also handles keyboard (Enter and Space) for accessibility
+    $('#main-navbar').on("click keydown", ".navlinks-parent", function(e) {
+      if (e.type === 'keydown' && e.key !== 'Enter' && e.key !== ' ') {
+        return;
+      }
+      if (e.type === 'keydown') {
+        e.preventDefault();
+      }
       var target = e.target;
+      var isExpanded = false;
       $.each($(".navlinks-parent"), function(key, value) {
         if (value == target) {
-          $(value).parent().toggleClass("show-children");
+          var showing = $(value).parent().toggleClass("show-children").hasClass("show-children");
+          isExpanded = showing;
         } else {
           $(value).parent().removeClass("show-children");
+          $(value).attr("aria-expanded", "false");
         }
       });
+      $(target).attr("aria-expanded", isExpanded ? "true" : "false");
     });
 
     // Ensure nested navbar menus are not longer than the menu header
@@ -85,6 +96,11 @@ var main = {
     var desc = imgInfo.desc;
     var position = imgInfo.position;
       main.setImg(src, desc, position);
+
+    // If the user prefers reduced motion, skip the cycling animation
+    if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      return;
+    }
 
     // For better UX, prefetch the next image so that it will already be loaded when we want to show it
       var getNextImg = function() {

--- a/static/js/staticman.js
+++ b/static/js/staticman.js
@@ -33,14 +33,41 @@
     return false;
   });
 
-  $('.js-close-modal').click(function () {
-    $('body').removeClass('show-modal');
+  $('.js-close-modal').click(closeModal);
+
+  // Close on Escape and trap focus inside modal
+  $(document).on('keydown', function (e) {
+    if (!$('body').hasClass('show-modal')) return;
+    if (e.key === 'Escape') {
+      closeModal();
+    }
+    if (e.key === 'Tab') {
+      var $modal = $('.modal');
+      var focusable = $modal.find('a, button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])').filter(':visible');
+      var first = focusable.first()[0];
+      var last = focusable.last()[0];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
   });
+
+  function closeModal() {
+    $('body').removeClass('show-modal');
+  }
 
   function showModal(title, message) {
     $('.js-modal-title').text(title);
     $('.js-modal-text').html(message);
 
     $('body').addClass('show-modal');
+    // Move focus into modal for accessibility
+    setTimeout(function () {
+      $('.js-close-modal').focus();
+    }, 0);
   }
 })(jQuery);


### PR DESCRIPTION
Based on #519.

:robot:

All 9 accessibility items from the AI review are done, and the example site builds cleanly.

| # | Issue | File(s) | Fix |
|---|-------|---------|-----|
| 1 | No `rel="noopener noreferrer"` on share links | `share-links.html` | Added to all 6 external share links; added `aria-hidden="true"` on the decorative icons so the `<a>` title still reads; replaced `aria-hidden="true"` on the container with `role="region"` + `aria-label` on the `<ul>`. |
| 2 | Navbar dropdown toggles are bare `<a>` | `nav.html` | Added `aria-expanded="false"` and `aria-haspopup="true"` to both menu-parent and language-switcher `<a role="button">`. |
| 3 | `aria-hidden="true"` on share links | `share-links.html` | Removed `aria-hidden="true"` from the wrapper div; kept it only on decorative `<i>` icons. |
| 4 | Search modal lacks `aria-labelledby` | `nav.html` | Added `aria-modal="true"` + `aria-labelledby="searchModalTitle"` to the modal, and `id="searchModalTitle"` on the `<h5>`. |
| 5 | Copy-code button only on `:hover` | `main.css` | Added `:focus-within` so the button appears when keyboard focus enters the code block. |
| 6 | Staticman modal has no dialog semantics | `staticman-comments.html` | Added `role="dialog"`, `aria-modal="true"`, `aria-labelledby="staticman-modal-title"`, `tabindex="-1"`. |
| 6b | Staticman modal missing focus trap & Escape | `staticman.js` | Added Escape-to-close, focus trap (Tab loops inside modal), and moves focus to Close button on open. |
| 7 | Color contrast failures | `main.css` | Darkened `blockquote`/`post-meta`/`blog-tags` from `#808080` → `#666`; links from `#008AFF` → `#0066CC`; dark-mode links from `#50afff` → `#66bfff`. |
| 8 | No `prefers-reduced-motion` | `main.css`, `main.js` | Added `@media (prefers-reduced-motion: reduce)` to remove transitions on navbar, avatar, share icons, big-img cross-fade, copy button, and disabled the cross-fade image cycling in JS. |
| 9 | Keyboard can't open navbar dropdowns | `main.js` | Changed event from `"click"` to `"click keydown"`; added Enter/Space handling, plus `aria-expanded` toggling. |

Footer social links also got `rel="noopener noreferrer"` added (while preserving any existing `rel` like `me` on Mastodon), and staticman comment author links now include it too.

Assisted-by: OpenCode:Kimi-K2.6
