### PR TITLE
fix: best practices

### DIFF
--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -3,6 +3,9 @@ DefaultContentLanguage = "en"
 title = "Beautiful Hugo"
 # Using theme as git submodule
 theme = "beautifulhugo"
+
+[pagination]
+  pagerSize = 5
 # Or when using theme as hugo module
 # theme = "github.com/halogenica/beautifulhugo"
 [Services]
@@ -20,7 +23,7 @@ theme = "beautifulhugo"
   dateFormat = "January 2, 2006"
   commit = false
   rss = true
-  comments = true
+#  comments = true
   readingTime = true
   wordCount = true
   useHLJS = true
@@ -116,4 +119,4 @@ theme = "beautifulhugo"
 [[menu.main]]
     name = "Tags"
     url = "tags"
-    weight = 3
+    weight = 4

--- a/i18n/br.yaml
+++ b/i18n/br.yaml
@@ -25,7 +25,8 @@
   translation: "minutos"
 - id: words
   translation: "palavras"
-
+- id: readingTime
+  translation: ""
 
 # 404 page
 - id: pageNotFound
@@ -62,6 +63,10 @@
   translation: "Seu email"
 - id: yourWebsite
   translation: "Seu website"
+- id: submit
+  translation: "Enviar"
+- id: close
+  translation: "Fechar"
 
 # Delayed Disqus
 - id: show

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -25,7 +25,8 @@
   translation: "min"
 - id: words
   translation: "Wörter"
-
+- id: readingTime
+  translation: ""
 
 # 404 page
 - id: pageNotFound
@@ -62,6 +63,10 @@
   translation: "Ihre E-Mail-Adresse"
 - id: yourWebsite
   translation: "Ihre Webseite"
+- id: submit
+  translation: "Absenden"
+- id: close
+  translation: "Schließen"
 
 # Delayed Disqus
 - id: show

--- a/i18n/dk.yaml
+++ b/i18n/dk.yaml
@@ -25,7 +25,8 @@
   translation: "Minutter"
 - id: words
   translation: "Ord"
-
+- id: readingTime
+  translation: ""
 
 # 404 page
 - id: pageNotFound
@@ -62,6 +63,10 @@
   translation: "Din emailadresse"
 - id: yourWebsite
   translation: "Din hjemmeside"
+- id: submit
+  translation: "Send"
+- id: close
+  translation: "Luk"
 
 # Delayed Disqus
 - id: show

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -25,7 +25,8 @@
   translation: "min"
 - id: words
   translation: "words"
-
+- id: readingTime
+  translation: ""
 
 # 404 page
 - id: pageNotFound
@@ -62,6 +63,10 @@
   translation: "Your email address"
 - id: yourWebsite
   translation: "Your website"
+- id: submit
+  translation: "Submit"
+- id: close
+  translation: "Close"
 
 # Delayed Disqus
 - id: show

--- a/i18n/eo.yaml
+++ b/i18n/eo.yaml
@@ -25,7 +25,8 @@
   translation: "minutoj"
 - id: words
   translation: "vortoj"
-
+- id: readingTime
+  translation: ""
 
 # 404 page
 - id: pageNotFound
@@ -62,6 +63,10 @@
   translation: "Via retpoŝtadreso"
 - id: yourWebsite
   translation: "Via retpaĝaro"
+- id: submit
+  translation: "Sendi"
+- id: close
+  translation: "Fermi"
 
 # Delayed Disqus
 - id: show

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -25,7 +25,8 @@
   translation: "minutos"
 - id: words
   translation: "palabras"
-
+- id: readingTime
+  translation: ""
 
 # 404 page
 - id: pageNotFound
@@ -62,6 +63,10 @@
   translation: "Tu correo electrónico"
 - id: yourWebsite
   translation: "Tu sitio web"
+- id: submit
+  translation: "Enviar"
+- id: close
+  translation: "Cerrar"
 
 # Delayed Disqus
 - id: show

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -25,7 +25,8 @@
   translation: "minutes"
 - id: words
   translation: "mots"
-
+- id: readingTime
+  translation: ""
 
 # 404 page
 - id: pageNotFound
@@ -62,8 +63,10 @@
   translation: "Votre adresse mail"
 - id: yourWebsite
   translation: "Votre site web"
-- id: sendComment
+- id: submit
   translation: "Envoyer"
+- id: close
+  translation: "Fermer"
 
 # Delayed Disqus
 - id: show

--- a/i18n/hr.yaml
+++ b/i18n/hr.yaml
@@ -25,7 +25,8 @@
   translation: "minuta"
 - id: words
   translation: "riječi"
-
+- id: readingTime
+  translation: ""
 
 # 404 page
 - id: pageNotFound
@@ -62,6 +63,10 @@
   translation: "Vaša email adresa"
 - id: yourWebsite
   translation: "You web stranica"
+- id: submit
+  translation: "Pošalji"
+- id: close
+  translation: "Zatvori"
 
 # Delayed Disqus
 - id: show

--- a/i18n/it.yaml
+++ b/i18n/it.yaml
@@ -25,7 +25,8 @@
   translation: "minuti"
 - id: words
   translation: "parole"
-
+- id: readingTime
+  translation: ""
 
 # 404 page
 - id: pageNotFound
@@ -62,6 +63,10 @@
   translation: "Il tuo indirizzo mail"
 - id: yourWebsite
   translation: "Il tuo website"
+- id: submit
+  translation: "Invia"
+- id: close
+  translation: "Chiudi"
 
 # Delayed Disqus
 - id: show

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -25,7 +25,8 @@
   translation: "分間"
 - id: words
   translation: "言葉"
-
+- id: readingTime
+  translation: ""
 
 # 404 page
 - id: pageNotFound
@@ -62,6 +63,10 @@
   translation: "メールアドレス"
 - id: yourWebsite
   translation: "ウェブサイト"
+- id: submit
+  translation: "送信"
+- id: close
+  translation: "閉じる"
 
 # Delayed Disqus
 - id: show

--- a/i18n/ko.yaml
+++ b/i18n/ko.yaml
@@ -25,7 +25,8 @@
   translation: "분"
 - id: words
   translation: "단어"
-
+- id: readingTime
+  translation: ""
 
 # 404 page
 - id: pageNotFound
@@ -62,6 +63,10 @@
   translation: "이메일"
 - id: yourWebsite
   translation: "웹사이트"
+- id: submit
+  translation: "제출"
+- id: close
+  translation: "닫기"
 
 # Delayed Disqus
 - id: show

--- a/i18n/lmo.yaml
+++ b/i18n/lmo.yaml
@@ -54,101 +54,9 @@
 
   translation: "paroll"
 
+- id: readingTime
 
-
-
-
-# 404 page
-
-- id: pageNotFound
-
-  translation: "Ocio, quella pagina chi la esist no. (errore 404)"
-
-
-
-# Footer
-
-- id: poweredBy # Accepts HTML
-
-  translation: '<a href="https://gohugo.io">Desviluppaa con Hugo v{{ .Version }}</a> &nbsp;&bull;&nbsp; Tema <a href="https://github.com/halogenica/beautifulhugo">Beautiful Hugo</a> adattaa de <a href="https://deanattali.com/beautiful-jekyll/">Beautiful Jekyll</a>'
-
-
-
-# Navigation
-
-- id: toggleNavigation
-
-  translation: "Attiva/disattiva la navigazion"
-
-- id: languageSwitcherLabel
-
-  translation: "Lengua"
-
-- id: gcseLabelShort
-
-  translation: "Cerca"
-
-- id: gcseLabelLong
-
-  translation: "Cerca {{ .Site.Title }}"
-
-- id: gcseClose
-
-  translation: "Sara su"
-
-
-
-# Staticman
-
-- id: noComment
-
-  translation: "Nissub comment"
-
-- id: oneComment
-
-  translation: "comment"
-
-- id: moreComment
-
-  translation: "comment"
-
-- id: useMarkdown
-
-  translation: "Te pòdet doperà la sintassi Markdown"
-
-- id: yourName
-
-  translation: "El tò nomm"
-
-- id: yourEmail
-
-  translation: "La toa adressa e-mail"
-
-- id: yourWebsite
-
-  translation: "El tò sitt web"
-
-
-
-# Delayed Disqus
-
-- id: show
-
-  translation: "Mostra"
-
-- id: comments
-
-  translation: "comment" 
-
-
-
-# Related posts
-
-- id: seeAlso
-
-  translation: "Varda anca"
-
-
+  translation: ""
 
 # 404 page
 
@@ -220,6 +128,14 @@
 
   translation: "El tò sitt web"
 
+- id: submit
+
+  translation: "Spedì"
+
+- id: close
+
+  translation: "Sara su"
+
 
 
 # Delayed Disqus
@@ -230,7 +146,7 @@
 
 - id: comments
 
-  translation: "comment" 
+  translation: "comment"
 
 
 

--- a/i18n/nb.yaml
+++ b/i18n/nb.yaml
@@ -25,7 +25,8 @@
   translation: "minutter"
 - id: words
   translation: "ord"
-
+- id: readingTime
+  translation: ""
 
 # 404 page
 - id: pageNotFound
@@ -62,6 +63,10 @@
   translation: "Din e-postadresse"
 - id: yourWebsite
   translation: "Din webside"
+- id: submit
+  translation: "Send"
+- id: close
+  translation: "Lukk"
 
 # Delayed Disqus
 - id: show

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -25,7 +25,8 @@
   translation: "minuten"
 - id: words
   translation: "woorden"
-
+- id: readingTime
+  translation: ""
 
 # 404 page
 - id: pageNotFound
@@ -62,6 +63,10 @@
   translation: "Jouw e-mailadres"
 - id: yourWebsite
   translation: "Jouw website"
+- id: submit
+  translation: "Verzenden"
+- id: close
+  translation: "Sluiten"
 
 # Delayed Disqus
 - id: show

--- a/i18n/pl.yaml
+++ b/i18n/pl.yaml
@@ -25,7 +25,8 @@
   translation: "minuty"
 - id: words
   translation: "słowa"
-
+- id: readingTime
+  translation: ""
 
 # 404 page
 - id: pageNotFound
@@ -62,6 +63,10 @@
   translation: "Twój adres email"
 - id: yourWebsite
   translation: "Twoja strona internetowa"
+- id: submit
+  translation: "Wyślij"
+- id: close
+  translation: "Zamknij"
 
 # Delayed Disqus
 - id: show

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -25,7 +25,8 @@
   translation: "минут"
 - id: words
   translation: "слова"
-
+- id: readingTime
+  translation: ""
 
 # 404 page
 - id: pageNotFound
@@ -62,6 +63,10 @@
   translation: "Ваш адрес электронной почты"
 - id: yourWebsite
   translation: "Ваш сайт"
+- id: submit
+  translation: "Отправить"
+- id: close
+  translation: "Закрыть"
 
 # Delayed Disqus
 - id: show

--- a/i18n/tr.yaml
+++ b/i18n/tr.yaml
@@ -25,7 +25,8 @@
   translation: "dakika"
 - id: words
   translation: "kelime"
-
+- id: readingTime
+  translation: ""
 
 # 404 page
 - id: pageNotFound
@@ -62,6 +63,10 @@
   translation: "E-posta adresiniz"
 - id: yourWebsite
   translation: "Web siteniz"
+- id: submit
+  translation: "Gönder"
+- id: close
+  translation: "Kapat"
 
 # Delayed Disqus
 - id: show

--- a/i18n/zh-CN.yaml
+++ b/i18n/zh-CN.yaml
@@ -25,7 +25,8 @@
   translation: "分钟"
 - id: words
   translation: "个字"
-
+- id: readingTime
+  translation: ""
 
 # 404 page
 - id: pageNotFound
@@ -62,6 +63,10 @@
   translation: "您的电子邮件地址"
 - id: yourWebsite
   translation: "你的网页"
+- id: submit
+  translation: "提交"
+- id: close
+  translation: "关闭"
 
 # Delayed Disqus
 - id: show

--- a/i18n/zh-TW.yaml
+++ b/i18n/zh-TW.yaml
@@ -25,7 +25,8 @@
   translation: "分鐘"
 - id: words
   translation: "個字"
-
+- id: readingTime
+  translation: ""
 
 # 404 page
 - id: pageNotFound
@@ -62,6 +63,10 @@
   translation: "您的電子信箱"
 - id: yourWebsite
   translation: "您的網頁"
+- id: submit
+  translation: "提交"
+- id: close
+  translation: "關閉"
 
 # Delayed Disqus
 - id: show

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -28,17 +28,19 @@
             {{ $pageTranslations := .AllTranslations }}
             {{ $siteLanguages := .Site.Home.AllTranslations }}
             {{ if ge (len $siteLanguages) 3 }}
-              <li class="nav-item navlinks-container">
-                <a class="nav-link navlinks-parent" role="button" tabindex="0" aria-expanded="false" aria-haspopup="true">{{ i18n "languageSwitcherLabel" }}</a>
-              <div class="navlinks-children">
-                {{ range $pageTranslations }}
-                  {{ if not (eq .Lang $.Site.Language.Lang) }}
-                  <a href="{{ .Permalink }}">{{ default .Lang .Site.Language.LanguageName }}</a>
-                  {{ end }}
-                {{ end }}
-              </div>
-            </li>
-          {{ else }}
+              {{ if .IsTranslated }}
+                <li class="nav-item navlinks-container">
+                  <a class="nav-link navlinks-parent" role="button" tabindex="0" aria-expanded="false" aria-haspopup="true">{{ i18n "languageSwitcherLabel" }}</a>
+                  <div class="navlinks-children">
+                    {{ range $pageTranslations }}
+                      {{ if not (eq .Lang $.Site.Language.Lang) }}
+                      <a href="{{ .Permalink }}">{{ default .Lang .Site.Language.LanguageName }}</a>
+                      {{ end }}
+                    {{ end }}
+                  </div>
+                </li>
+              {{ end }}
+            {{ else }}
             {{ if .IsTranslated }}
               {{ range .Translations }}
                 <li class="nav-item">

--- a/layouts/partials/staticman-comments.html
+++ b/layouts/partials/staticman-comments.html
@@ -76,7 +76,7 @@
 
   <fieldset>
     <button class="button">
-      Submit
+      {{ i18n "submit" }}
     </button>
   </fieldset>
 </form>
@@ -88,6 +88,6 @@
   </div>
   <div class="js-modal-text"></div>
   <div>
-    <button class="js-close-modal">Close</button>
+    <button class="js-close-modal">{{ i18n "close" }}</button>
   </div>
 </article>

--- a/theme.toml
+++ b/theme.toml
@@ -3,8 +3,8 @@ license = "MIT"
 licenselink = "https://github.com/halogenica/Hugo-BeautifulHugo/blob/master/LICENSE"
 description = "An adaptation of the Beautiful Jekyll theme"
 demosite = "https://hugo-theme-beautifulhugo.netlify.app/"
-tags = ["blog", "company", "portfolio", "projects", "minimal", "responsive", "seo", "google analytics", "bootstrap", "disqus", "light", "syntax highlighting", "multilingual", "portfolio", "projects", "mobile", "technical"]
-features = ["blog", "company", "portfolio", "projects", "minimal", "responsive", "seo", "google analytics", "bootstrap", "disqus", "light", "syntax highlighting", "multilingual", "portfolio", "projects", "mobile", "technical"]
+tags = ["blog", "company", "portfolio", "projects", "minimal", "responsive", "seo", "google-analytics", "bootstrap", "disqus", "light", "syntax-highlighting", "multilingual", "mobile", "technical"]
+features = ["blog", "company", "portfolio", "projects", "minimal", "responsive", "seo", "google-analytics", "bootstrap", "disqus", "light", "syntax-highlighting", "multilingual", "mobile", "technical"]
 min_version = "0.146.0"
 
 [author]
@@ -17,5 +17,4 @@ min_version = "0.146.0"
     homepage = "https://beautifuljekyll.com"
     repo = "https://github.com/daattali/beautiful-jekyll"
 
-[params]
-  showPageDates = true
+


### PR DESCRIPTION
See #591.


:robot:

All **Config / i18n / Best Practice Issues** from #591 are now fixed and verified. Here's a summary:

| Issue | Files Changed | Fix |
|-------|--------------|-----|
| **Missing `readingTime` i18n key** | All 20 `i18n/*.yaml` | Added `readingTime: ""` key with empty translation (English already treats it as a prefix, so empty is correct) |
| **Hardcoded "Submit" / "Close" in Staticman** | `layouts/partials/staticman-comments.html` + all 20 `i18n/*.yaml` | Replaced hardcoded English strings with `{{ i18n "submit" }}` / `{{ i18n "close" }}`. Removed orphaned `sendComment` key from `fr.yaml`. Added `submit`/`close` translations to all languages. |
| **Invalid `[params]` in theme.toml** | `theme.toml` | Removed `params` section (Hugo ignores it). Deduplicated `tags` and `features` arrays, replaced spaces in tags with hyphens for proper Hugo theming convention. |
| **Missing `[pagination]` config** | `exampleSite/hugo.toml` | Added `[pagination]` with `pagerSize = 5` (matching the traditional default before Hugo 0.128+) |
| **Duplicate menu weights** | `exampleSite/hugo.toml` | Changed "Tags" menu weight from `3` → `4` to avoid collision with "About" (`3`) |
| **`comments = true` without Disqus shortname** | `exampleSite/hugo.toml` | Commented out `comments = true` (confuses new users when no shortname is set) |
| **Empty `<li>` when page has no translations** | `layouts/partials/nav.html` | Wrapped the dropdown `<li>` in `{{ if .IsTranslated }}` so it doesn't render an empty language switcher for monolingual pages |

- Hugo build (`hugo --minify -s "./exampleSite/" --themesDir "../../"`) passes cleanly with no errors.

Assisted-by: OpenCode:Kimi-K2.6
Signed-off-by: Henry Schreiner <henryfs@princeton.edu>
