### PR TITLE
fix: bump min hugo to 0.146.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        hugo: [0.146.0, 0.147.2, 0.155.2, 0.161.1]
+        hugo: [0.146.2, 0.147.2, 0.155.2, 0.161.1]
     steps:
       - name: Install Hugo CLI
         run: >

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -26,7 +26,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.146.0
+      HUGO_VERSION: 0.146.2
     steps:
       - name: Install Hugo CLI
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,9 +18,9 @@ hugo serve -s exampleSite/ --themesDir ../..
 
 ## Hugo Version
 
-- **Minimum Hugo version**: `0.146.0` (enforced at runtime in `layouts/_default/baseof.html`).
-- **CI matrix** tests against `0.146.0`, `0.147.2`, and `0.155.2`.
-- The deploy workflow pins `0.146.0`.
+- **Minimum Hugo version**: `0.146.2` (enforced at runtime in `layouts/_default/baseof.html`).
+- **CI matrix** tests against `0.146.2`, `0.147.2`, and `0.155.2`.
+- The deploy workflow pins `0.146.2`.
 - CI uses the **extended** Hugo binary.
 
 ## Architecture

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
-{{ if lt hugo.Version "0.146.0" }}
-	{{ errorf "Please use Hugo version 0.146.0 or higher!" }}
+{{ if lt hugo.Version "0.146.2" }}
+	{{ errorf "Please use Hugo version 0.146.2 or higher!" }}
 {{ end }}
 
 <!DOCTYPE html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,6 @@
   command = "cd exampleSite && hugo --gc --themesDir ../.."
   
 [build.environment]
-  HUGO_VERSION = "0.146.0"
+  HUGO_VERSION = "0.146.2"
   HUGO_THEME = "repo"
   HUGO_BASEURL = "/"

--- a/theme.toml
+++ b/theme.toml
@@ -5,7 +5,7 @@ description = "An adaptation of the Beautiful Jekyll theme"
 demosite = "https://hugo-theme-beautifulhugo.netlify.app/"
 tags = ["blog", "company", "portfolio", "projects", "minimal", "responsive", "seo", "google-analytics", "bootstrap", "disqus", "light", "syntax-highlighting", "multilingual", "mobile", "technical"]
 features = ["blog", "company", "portfolio", "projects", "minimal", "responsive", "seo", "google-analytics", "bootstrap", "disqus", "light", "syntax-highlighting", "multilingual", "mobile", "technical"]
-min_version = "0.146.0"
+min_version = "0.146.2"
 
 [author]
     name = "halogenica"


### PR DESCRIPTION
fix: raise the minimum to 0.146.2

There was a bug rendering codeblocks as GoAT (Go-based Text-Art).

Assisted-by: OpenCode:Kimi-K2.6
