### PR TITLE
refactor: clean up dark mode css

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -77,6 +77,7 @@
   {{- end -}}
 
   <link rel="stylesheet" href="{{ "css/main.css" | absURL }}" />
+  <link rel="stylesheet" href="{{ "css/dark.css" | absURL }}" />
 
   {{- if .Site.Params.staticman -}}
   <link rel="stylesheet" href="{{ "css/staticman.css" | absURL }}" />

--- a/static/css/dark.css
+++ b/static/css/dark.css
@@ -1,0 +1,118 @@
+/* --- Dark Mode Overrides --- */
+
+@media (prefers-color-scheme: dark) {
+    body {
+      background: black;
+      color: white;
+    }
+
+    p a {
+      color: #66bfff;
+    }
+
+    a {
+      color: #66bfff;
+    }
+
+    blockquote {
+      border-left: 5px solid #444;
+    }
+
+  figure:not(.dark) img, img.white {
+    background-color: white;
+  }
+
+    .navbar-custom {
+      background: #505050;
+      border-bottom: 1px solid #AAA;
+    }
+
+    .navbar-custom .navbar-brand,
+    .navbar-custom .nav-link {
+      color: #b0b0b0;
+    }
+
+    .navbar-custom .navbar-brand:hover,
+    .navbar-custom .navbar-brand:focus ,
+    .navbar-custom .nav-link:hover,
+    .navbar-custom .nav-link:focus {
+      color: #b0e0ff;
+    }
+
+    .navbar-custom .nav-item.navlinks-container:hover {
+      background: #666;
+    }
+    .navbar-custom .nav-item.navlinks-container .navlinks-children a {
+      border: 1px solid #AAA;
+    }
+    .navbar-custom .nav-item.navlinks-container .navlinks-children a {
+      background: #444;
+    }
+
+    footer {
+      background: #444;
+      border-top: 1px #AAA solid;
+    }
+    footer a {
+      color: #AAA;
+    }
+
+    .post-preview a {
+      color: #AAA;
+    }
+
+  .pager li a {
+    background: #444;
+    color: white;
+  }
+
+    .well {
+      background-color: #444;
+      border-color: #555;
+    }
+
+  table tr {
+    background-color: #181818;
+  }
+  table tr:nth-child(2n) {
+    background-color: #303030
+  }
+
+    code {
+      background-color: #222;
+      color: #fbb;
+    }
+    pre code {
+      color: #ccc;
+    }
+    .well {
+      background-color: #444;
+    }
+    .card {
+      background-color: #222;
+    }
+    .list-group-item {
+      background-color: #333;
+    }
+
+    pre.chroma {
+      color: white;
+      background-color: #444;
+    }
+    pre.chroma .k {
+      color: #44AACC;
+    }
+    pre.chroma .kt {
+      color: #33CCCC;
+    }
+    pre.chroma .o {
+      color: #AAA;
+    }
+    pre.chroma .nb {
+      color: #00fee9;
+    }
+    pre.chroma .ow {
+      color: #CC0;
+    }
+
+}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -10,12 +10,6 @@ body {
   flex-flow: column;
   height: 100vh;
 }
-@media (prefers-color-scheme: dark) {
-  body {
-    background: black;
-    color: white;
-  }
-}
 .container[role=main] {
   margin-bottom:50px;
   flex: 1 0 auto;
@@ -39,11 +33,6 @@ p a {
   /* text-decoration: underline */
   color: #0066CC;
 }
-@media (prefers-color-scheme: dark) {
-  p a {
-    color: #66bfff;
-  }
-}
 
 h1,h2,h3,h4,h5,h6 {
   font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
@@ -51,11 +40,6 @@ h1,h2,h3,h4,h5,h6 {
 }
 a {
   color: #0066CC;
-}
-@media (prefers-color-scheme: dark) {
-  a {
-    color: #66bfff;
-  }
 }
 a:hover,
 a:focus {
@@ -67,11 +51,6 @@ blockquote {
 }
 blockquote p:first-child {
   margin-top: 0;
-}
-@media (prefers-color-scheme: dark) {
-  blockquote {
-    border-left: 5px solid #444;
-  }
 }
 hr.small {
   max-width: 100px;
@@ -136,16 +115,10 @@ img::selection {
   background: transparent;
 }
 
-
 img {
   display: block;
   margin: auto;
   max-width: 100%;
-}
-@media (prefers-color-scheme: dark) {
-figure:not(.dark) img, img.white {
-  background-color: white;
-}
 }
 
 .img-title {
@@ -173,12 +146,6 @@ figure:not(.dark) img, img.white {
   border-bottom: 1px solid #EAEAEA;
   font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
-@media (prefers-color-scheme: dark) {
-  .navbar-custom {
-    background: #505050;
-    border-bottom: 1px solid #AAA;
-  }
-}
 
 .navbar-custom .nav-link {
   text-transform: uppercase;
@@ -192,27 +159,11 @@ figure:not(.dark) img, img.white {
   color: #404040;
 }
 
-@media (prefers-color-scheme: dark) {
-  .navbar-custom .navbar-brand,
-  .navbar-custom .nav-link {
-    color: #b0b0b0;
-  }
-}
-
 .navbar-custom .navbar-brand:hover,
 .navbar-custom .navbar-brand:focus ,
 .navbar-custom .nav-link:hover,
 .navbar-custom .nav-link:focus {
   color: #0085a1;
-}
-
-@media (prefers-color-scheme: dark) {
-  .navbar-custom .navbar-brand:hover,
-  .navbar-custom .navbar-brand:focus ,
-  .navbar-custom .nav-link:hover,
-  .navbar-custom .nav-link:focus {
-    color: #b0e0ff;
-  }
 }
 
 .navbar-custom .navbar-brand-logo {
@@ -355,17 +306,6 @@ figure:not(.dark) img, img.white {
     border-width: 0 1px 1px;
   }
 }
-@media (prefers-color-scheme: dark) {
-  .navbar-custom .nav-item.navlinks-container:hover {
-    background: #666;
-  }
-  .navbar-custom .nav-item.navlinks-container .navlinks-children a {
-    border: 1px solid #AAA;
-  }
-  .navbar-custom .nav-item.navlinks-container .navlinks-children a {
-    background: #444;
-  }
-}
 
 /* --- Footer --- */
 
@@ -425,16 +365,6 @@ footer div.disclaimer {
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  footer {
-    background: #444;
-    border-top: 1px #AAA solid;
-  }
-  footer a {
-    color: #AAA;
-  }
-}
-
 /* --- Post preview --- */
 
 .post-preview {
@@ -454,11 +384,6 @@ footer div.disclaimer {
 .post-preview a {
   text-decoration: none;
   color: #404040;
-}
-@media (prefers-color-scheme: dark) {
-  .post-preview a {
-    color: #AAA;
-  }
 }
 
 .post-preview a:focus,
@@ -791,13 +716,6 @@ footer div.disclaimer {
   border: 1px solid #0085a1;
 }
 
-@media (prefers-color-scheme: dark) {
-.pager li a {
-  background: #444;
-  color: white;
-}
-}
-
 .pager {
   margin: 10px 0 0;
 }
@@ -826,12 +744,6 @@ h2.mb-0 button span.badge {
   border-radius: 4px;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, .05);
 }
-@media (prefers-color-scheme: dark) {
-  .well {
-    background-color: #444;
-    border-color: #555;
-  }
-}
 
 /* --- Tables --- */
 
@@ -846,14 +758,6 @@ table tr {
 }
 table tr:nth-child(2n) {
   background-color: #f8f8f8;
-}
-@media (prefers-color-scheme: dark) {
-table tr {
-  background-color: #181818;
-}
-table tr:nth-child(2n) {
-  background-color: #303030
-}
 }
 table tr th {
   font-weight: bold;
@@ -986,46 +890,6 @@ h4.see-also {
 }
  ul.share li:hover .fab {
   transform: scale(1.4)
-}
-
-/* Dark mode */
-@media (prefers-color-scheme: dark) {
-  code {
-    background-color: #222;
-    color: #fbb;
-  }
-  pre code {
-    color: #ccc;
-  }
-  .well {
-    background-color: #444;
-  }
-  .card {
-    background-color: #222;
-  }
-  .list-group-item {
-    background-color: #333;
-  }
-
-  pre.chroma {
-    color: white;
-    background-color: #444;
-  }
-  pre.chroma .k {
-    color: #44AACC;
-  }
-  pre.chroma .kt {
-    color: #33CCCC;
-  }
-  pre.chroma .o {
-    color: #AAA;
-  }
-  pre.chroma .nb {
-    color: #00fee9;
-  }
-  pre.chroma .ow {
-    color: #CC0;
-  }
 }
 
 /* --- Make long KaTeX equations scrollable in the x-axis --- */


### PR DESCRIPTION
This moves the dark mode settings to a separate file. We've already moved hljs dark mode to a separate file. (this might make something like #500 easier...).

:robot:

**Extracted all dark mode styles from `main.css` into a new `static/css/dark.css`**

- Split all 15 `@media (prefers-color-scheme: dark)` blocks out of `main.css`
- `main.css` went from ~1,071 lines to 937 lines — it's now a clean light/base stylesheet with no dark-specific code
- `static/css/dark.css` is a new 118-line file containing all dark overrides in a single, well-organized `@media` block
- Updated `layouts/partials/head.html` to load `dark.css` after `main.css`

**Verified:**
- Brace-balanced CSS in both files
- No remaining dark media queries in `main.css`
- No excess blank lines or formatting issues
- `hugo --minify` builds the example site cleanly
- Generated HTML includes both stylesheets: `<link rel=stylesheet href=.../css/main.css><link rel=stylesheet href=.../css/dark.css>`

Assisted-by: OpenCode:Kimi-K2.6
Signed-off-by: Henry Schreiner <henryfs@princeton.edu>
