### PR TITLE
fix: improve accessibility across templates

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -12,20 +12,20 @@
     {{ end }}
     <div class="row">
       <div class="col-lg-8 offset-lg-2 col-md-10 offset-md-1">
-        <ul class="list-inline text-center footer-links">
+        <ul class="list-inline text-center footer-links" role="list">
           {{ range .Site.Data.beautifulhugo.social.social_icons }}
             {{- $social := . -}}
             {{- with index $.Site.Params.author $social.id }}
-              <li>
+              <li role="listitem">
 		{{- $authorValue := . -}}
 		{{ if or ( hasPrefix $authorValue "http://" ) ( hasPrefix $authorValue "https://" ) }}
-		  <a {{ if $social.rel }}rel="{{ $social.rel }} noopener noreferrer"{{ else }}rel="noopener noreferrer"{{ end }} href="{{ printf "%s" $authorValue }}" title="{{ $social.title }}">
+		  <a {{ if $social.rel }}rel="{{ $social.rel }} noopener noreferrer"{{ else }}rel="noopener noreferrer"{{ end }} href="{{ printf "%s" $authorValue }}" title="{{ $social.title }}" aria-label="{{ $social.title }}">
 		{{ else }}
-		  <a {{ if $social.rel }}rel="{{ $social.rel }} noopener noreferrer"{{ else }}rel="noopener noreferrer"{{ end }} href="{{ printf $social.url $authorValue }}" title="{{ $social.title }}">
+		  <a {{ if $social.rel }}rel="{{ $social.rel }} noopener noreferrer"{{ else }}rel="noopener noreferrer"{{ end }} href="{{ printf $social.url $authorValue }}" title="{{ $social.title }}" aria-label="{{ $social.title }}">
 		{{ end }}
                   <span class="fa-stack fa-lg">
                     <i class="fas fa-circle fa-stack-2x"></i>
-                    <i class="{{ $social.icon }} fa-stack-1x fa-inverse"></i>
+                    <i class="{{ $social.icon }} fa-stack-1x fa-inverse" aria-hidden="true"></i>
                   </span>
                 </a>
               </li>

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -6,10 +6,10 @@
     </button>
 
     <div class="collapse navbar-collapse" id="main-navbar">
-      <ul class="navbar-nav ms-auto">
+      <ul class="navbar-nav ms-auto" role="list">
         {{ range .Site.Menus.main.ByWeight }}
           {{ if .HasChildren }}
-            <li class="nav-item navlinks-container">
+            <li class="nav-item navlinks-container" role="listitem">
               <a class="nav-link navlinks-parent" role="button" tabindex="0" aria-expanded="false" aria-haspopup="true">{{ .Name }}</a>
               <div class="navlinks-children">
                 {{ range .Children }}
@@ -18,7 +18,7 @@
               </div>
             </li>
           {{ else }}
-            <li class="nav-item">
+            <li class="nav-item" role="listitem">
               <a class="nav-link" title="{{ .Name }}" href="{{ .URL  | relLangURL }}">{{ .Name }}</a>
             </li>
           {{ end }}
@@ -29,7 +29,7 @@
             {{ $siteLanguages := .Site.Home.AllTranslations }}
             {{ if ge (len $siteLanguages) 3 }}
               {{ if .IsTranslated }}
-                <li class="nav-item navlinks-container">
+                <li class="nav-item navlinks-container" role="listitem">
                   <a class="nav-link navlinks-parent" role="button" tabindex="0" aria-expanded="false" aria-haspopup="true">{{ i18n "languageSwitcherLabel" }}</a>
                   <div class="navlinks-children">
                     {{ range $pageTranslations }}
@@ -43,7 +43,7 @@
             {{ else }}
             {{ if .IsTranslated }}
               {{ range .Translations }}
-                <li class="nav-item">
+                <li class="nav-item" role="listitem">
                   <a class="nav-link" href="{{ .Permalink }}">{{ default .Lang .Site.Language.LanguageName }}</a>
                 </li>
               {{ end}}
@@ -52,9 +52,9 @@
         {{ end }}
 
         {{ with .Site.Params.gcse }}
-          <li class="nav-item">
+          <li class="nav-item" role="listitem">
             <a class="nav-link" href="#modalSearch" data-bs-toggle="modal" data-bs-target="#modalSearch" style="outline: none;">
-              <span class="d-md-none">{{ i18n "gcseLabelShort" }}</span> <span id="searchGlyph" class="fas fa-search"></span>
+              <span class="d-md-none">{{ i18n "gcseLabelShort" }}</span> <span id="searchGlyph" class="fas fa-search" aria-hidden="true"></span>
             </a>
           </li>
         {{ end }}

--- a/layouts/partials/share-links.html
+++ b/layouts/partials/share-links.html
@@ -1,53 +1,60 @@
 {{ if or .Params.socialShare (and .Site.Params.socialShare (ne .Params.socialShare false)) }}
 <!-- Social Share Button HTML -->
 <div class="share-box" role="region">
-    <ul class="share" aria-label="Social sharing">
+    <ul class="share" aria-label="Social sharing" role="list">
       <!-- Twitter -->
-      <li>
+      <li role="listitem">
         <a href="//twitter.com/share?url={{ .Permalink }}&amp;text={{ .Title }}&amp;via={{ .Site.Params.author.twitter }}" target="_blank" rel="noopener noreferrer" title="Share on Twitter">
           <i class="fab fa-twitter" aria-hidden="true"></i>
+          <span class="sr-only">Share on Twitter</span>
         </a>
       </li>
 
       <!-- Facebook -->
-      <li>
+      <li role="listitem">
         <a href="//www.facebook.com/sharer/sharer.php?u={{ .Permalink }}" target="_blank" rel="noopener noreferrer" title="Share on Facebook">
           <i class="fab fa-facebook" aria-hidden="true"></i>
+          <span class="sr-only">Share on Facebook</span>
         </a>
       </li>
 
       <!-- Reddit -->
-      <li>
+      <li role="listitem">
         <a href="//reddit.com/submit?url={{ .Permalink }}&amp;title={{ .Title }}" target="_blank" rel="noopener noreferrer" title="Share on Reddit">
           <i class="fab fa-reddit" aria-hidden="true"></i>
+          <span class="sr-only">Share on Reddit</span>
         </a>
       </li>
 
       <!-- LinkedIn -->
-      <li>
+      <li role="listitem">
         <a href="//www.linkedin.com/shareArticle?url={{ .Permalink }}&amp;title={{ .Title }}" target="_blank" rel="noopener noreferrer" title="Share on LinkedIn">
           <i class="fab fa-linkedin" aria-hidden="true"></i>
+          <span class="sr-only">Share on LinkedIn</span>
         </a>
       </li>
 
       <!-- StumbleUpon -->
-      <li>
+      <li role="listitem">
         <a href="//www.stumbleupon.com/submit?url={{ .Permalink }}&amp;title={{ .Title }}" target="_blank" rel="noopener noreferrer" title="Share on StumbleUpon">
           <i class="fab fa-stumbleupon" aria-hidden="true"></i>
+          <span class="sr-only">Share on StumbleUpon</span>
         </a>
       </li>
 
       <!-- Pinterest -->
-      <li>
+      <li role="listitem">
         <a href="//www.pinterest.com/pin/create/button/?url={{ .Permalink }}&amp;description={{ .Title }}" target="_blank" rel="noopener noreferrer" title="Share on Pinterest">
           <i class="fab fa-pinterest" aria-hidden="true"></i>
+          <span class="sr-only">Share on Pinterest</span>
         </a>
       </li>
 
       <!-- Email -->
-      <li>
+      <li role="listitem">
         <a href="mailto:?body={{ .Permalink }}&amp;subject={{ .Title }}" title="Share via email">
           <i class="fab fa-at" aria-hidden="true"></i>
+          <span class="sr-only">Share via email</span>
         </a>
       </li>
     </ul>


### PR DESCRIPTION
See #614

:robot: Enhance accessibility to better support screen readers and keyboard navigation:

**Navigation improvements**
- Add role="list" to navbar navigation (*.navbar-nav*)
- Add role="listitem" to all navigation items
- Add aria-hidden="true" to decorative search icon

**Social sharing improvements**
- Add role="list" and role="listitem" to share buttons list
- Add sr-only (screen reader only) text labels to each share button
- Add aria-hidden="true" to all decorative Font Awesome icons

**Footer social icons improvements**
- Add role="list" to footer social links container
- Add role="listitem" to each social link item
- Add aria-label attributes to all social icon links
- Add aria-hidden="true" to all decorative Font Awesome icons

These changes make the theme more accessible to users with screen readers
and keyboard-only navigation, following WCAG 2.1 guidelines.

Inspired by beautiful-jekyll theme (https://github.com/daattali/beautiful-jekyll).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
