### PR TITLE
feat: add CSS utilities and page params (nav-short, show-avatar, full-width)

### DIFF
--- a/exampleSite/content/post/2026-05-08-layout-examples.md
+++ b/exampleSite/content/post/2026-05-08-layout-examples.md
@@ -9,7 +9,7 @@ fullWidth: true
 comments: false
 ---
 
-This post demonstrates the page-level changes introduced here:
+This post demonstrates several new features:
 
 - `navShort` keeps the navigation bar compact.
 - `showAvatar: false` hides the avatar in the nav.
@@ -20,24 +20,49 @@ This post demonstrates the page-level changes introduced here:
 
 ## Utility classes
 
-<div class="box-note">
-This is a note box using the new content utility styles.
-</div>
+This is a `.box-note` using the new content utility styles.
+{.box-note}
 
-<div class="box-warning">
-This is a warning box to show the shared box styling.
-</div>
+This is a `.box-warning` to show the shared box styling.
+{.box-warning}
 
-<div class="box-error">
-This is an error box to show the shared box styling.
-</div>
+This is a `.box-error` to show the shared box styling.
+{.box-error}
 
-<div class="box-success">
-This is a success box to show the shared box styling.
-</div>
+This is a `.box-success` to show the shared box styling.
+{.box-success}
+
+This is what it looks like:
+
+```md
+This is a `.box-note` using the new content utility styles.
+{.box-note}
+```
+
+Remember to enable block attribuites in markdown:
+
+```yaml
+[markup.goldmark.parser.attribute]
+  block = true
+```
+
+You also might need to disable formatting if you use a tool (like prittier)
+that moves the attributes around.
+
+
+## Image example
+
+The `center` and `caption` classes.
 
 <img class="center" src="/img/triangle.jpg" alt="Triangle sample image" width="360">
 <div class="caption">A centered image with a caption beneath it.</div>
+
+(You might need to turn on unsafe rendering if you want to put these in as raw HTML tags)
+
+```toml
+[markup.goldmark.renderer]
+  unsafe = true
+```
 
 ## Example front matter
 

--- a/exampleSite/content/post/2026-05-08-layout-examples.md
+++ b/exampleSite/content/post/2026-05-08-layout-examples.md
@@ -1,0 +1,50 @@
+---
+title: Layout Examples
+subtitle: Showing the new page params and utilities
+date: 2026-05-08
+tags: ["example", "layout"]
+navShort: true
+showAvatar: false
+fullWidth: true
+comments: false
+---
+
+This post demonstrates the page-level changes introduced here:
+
+- `navShort` keeps the navigation bar compact.
+- `showAvatar: false` hides the avatar in the nav.
+- `fullWidth: true` expands the main content container.
+- The new utility classes style centered content and simple callout boxes.
+
+<!--more-->
+
+## Utility classes
+
+<div class="box-note">
+This is a note box using the new content utility styles.
+</div>
+
+<div class="box-warning">
+This is a warning box to show the shared box styling.
+</div>
+
+<div class="box-error">
+This is an error box to show the shared box styling.
+</div>
+
+<div class="box-success">
+This is a success box to show the shared box styling.
+</div>
+
+<img class="center" src="/img/triangle.jpg" alt="Triangle sample image" width="360">
+<div class="caption">A centered image with a caption beneath it.</div>
+
+## Example front matter
+
+```yaml
+---
+navShort: true
+showAvatar: false
+fullWidth: true
+---
+```

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -147,3 +147,6 @@ title = "Beautiful Hugo"
     name = "Tags"
     url = "tags"
     weight = 4
+
+[markup.goldmark.renderer]
+  unsafe = true

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -110,6 +110,12 @@ title = "Beautiful Hugo"
   orcid = "0000-0000-0000-0000"
   googlescholar = "XXXXXXXXXXXX"
 
+[markup.goldmark.parser.attribute]
+  block = true
+
+[markup.goldmark.renderer]
+  unsafe = true
+
 [[menu.main]]
     name = "Blog"
     url = ""
@@ -147,6 +153,3 @@ title = "Beautiful Hugo"
     name = "Tags"
     url = "tags"
     weight = 4
-
-[markup.goldmark.renderer]
-  unsafe = true

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -24,7 +24,7 @@
     {{- end -}}
     {{ partial "head.html" . }}
   </head>
-  <body>
+  <body{{ if or .Params.navShort .Site.Params.navShort }} class="nav-short-permanent"{{ end }}>
     {{ partial "nav.html" . }}
     {{ block "header" . }}{{ partial "header.html" . }}{{ end }}
     {{ block "main" . }}{{ end }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
   <div class="container{{ if .Params.fullWidth }}-fluid{{ end }}" role="main">
     <div class="row">
-      <div class="col-lg-8 offset-lg-2 col-md-10 offset-md-1">
+      <div class="{{ cond .Params.fullWidth "col-12" "col-lg-8 offset-lg-2 col-md-10 offset-md-1" }}">
         {{ with .Content }}
           <div class="well">
             {{.}}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-  <div class="container" role="main">
+  <div class="container{{ if .Params.fullWidth }}-fluid{{ end }}" role="main">
     <div class="row">
       <div class="col-lg-8 offset-lg-2 col-md-10 offset-md-1">
         {{ with .Content }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-<div class="container" role="main">
+<div class="container{{ if .Params.fullWidth }}-fluid{{ end }}" role="main">
   <div class="row">
     <div class="col-lg-8 offset-lg-2 col-md-10 offset-md-1">
       <article role="main" class="blog-post">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,9 +1,9 @@
 {{ define "main" }}
-<div class="container{{ if .Params.fullWidth }}-fluid{{ end }}" role="main">
-  <div class="row">
-    <div class="col-lg-8 offset-lg-2 col-md-10 offset-md-1">
-      <article role="main" class="blog-post">
-        {{ .Content }}
+  <div class="container{{ if .Params.fullWidth }}-fluid{{ end }}" role="main">
+    <div class="row">
+      <div class="{{ cond .Params.fullWidth "col-12" "col-lg-8 offset-lg-2 col-md-10 offset-md-1" }}">
+        <article role="main" class="blog-post">
+          {{ .Content }}
 
         {{ if .Params.tags }}
           <div class="blog-tags">

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -2,8 +2,9 @@
 
 {{ $data := .Data }}
 
-<div class="container" role="main">
-  <div class="col-lg-8 offset-lg-2 col-md-10 offset-md-1">
+<div class="container{{ if .Params.fullWidth }}-fluid{{ end }}" role="main">
+  <div class="row">
+    <div class="{{ cond .Params.fullWidth "col-12" "col-lg-8 offset-lg-2 col-md-10 offset-md-1" }}">
     <article class="post-preview">
       <div class="accordion" id="accordion">
         {{ range $key, $value := .Data.Terms.ByCount }}
@@ -31,6 +32,7 @@
         {{ end }}
       </div>
     </article>
+    </div>
   </div>
 </div>
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,6 +1,7 @@
 {{- $title := "" }}
 {{- $subtitle := "" }}
 {{- $bigimg := slice }}
+{{- $contentColClass := cond .Params.fullWidth "col-12" "col-lg-8 offset-lg-2 col-md-10 offset-md-1" }}
 {{ if .IsHome }}
   {{- $title = .Site.Params.homeTitle | default .Site.Title }}
   {{- $subtitle = .Site.Params.subtitle }}
@@ -27,10 +28,10 @@
   <header class="header-section {{ if $bigimg }}has-img{{ end }}">
     {{ if $bigimg }}
       {{- $firstimg := index $bigimg 0 }}
-      <div class="intro-header big-img" style="background-image: url('{{$firstimg.src}}');">
+    <div class="intro-header big-img" style="background-image: url('{{$firstimg.src}}');">
         <div class="container">
           <div class="row">
-            <div class="col-lg-8 offset-lg-2 col-md-10 offset-md-1">
+            <div class="{{$contentColClass}}">
               <div class="{{ .Type }}-heading">
                 <h1>{{ with $title }}{{.}}{{ else }}<br/>{{ end }}</h1>
                 {{ if ne .Type "post" }}
@@ -51,7 +52,7 @@
     <div class="intro-header no-img">
       <div class="container">
         <div class="row">
-          <div class="col-lg-8 offset-lg-2 col-md-10 offset-md-1">
+          <div class="{{$contentColClass}}">
             <div class="{{ .Type }}-heading">
               {{ if eq .Type "list" }}
                 <h1>{{ if .Data.Singular }}#{{ end }}{{ .Title }}</h1>

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -71,19 +71,21 @@
     </div>
 
     {{ $page := . }}
-    {{ with .Site.Params.logo }}
-      <div class="avatar-container">
-        <div class="avatar-img-border">
-          <a title="{{ $page.Site.Title }}" href="{{ "" | absLangURL }}">
-          {{- $image := resources.Get . -}}
-          {{ if $image }}
-            <img class="avatar-img" src="{{ ($image.Fit "300x300 webp q100").Permalink }}" alt="{{ $page.Site.Title }}" />
-          {{else}}
-            <img class="avatar-img" src="{{ . | absURL }}" alt="{{ $page.Site.Title }}" />
-           {{end}}
-          </a>
+    {{ if ne (.Params.showAvatar | default true) false }}
+      {{ with .Site.Params.logo }}
+        <div class="avatar-container">
+          <div class="avatar-img-border">
+            <a title="{{ $page.Site.Title }}" href="{{ "" | absLangURL }}">
+            {{- $image := resources.Get . -}}
+            {{ if $image }}
+              <img class="avatar-img" src="{{ ($image.Fit "300x300 webp q100").Permalink }}" alt="{{ $page.Site.Title }}" />
+            {{else}}
+              <img class="avatar-img" src="{{ . | absURL }}" alt="{{ $page.Site.Title }}" />
+             {{end}}
+            </a>
+          </div>
         </div>
-      </div>
+      {{ end }}
     {{ end }}
 
   </div>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -219,6 +219,10 @@ img {
   .navbar-custom.top-nav-short {
     padding: 0;
   }
+
+  body.nav-short-permanent .navbar-custom {
+    padding: 0;
+  }
 }
 
 @media only screen and (min-width: 768px) and (prefers-reduced-motion: reduce) {
@@ -954,4 +958,59 @@ h4.see-also {
 
 .copyCodeButton:hover {
   background-color: #e0e0e0;
+}
+
+/* --- Content Utilities --- */
+
+/* Center block element */
+.center {
+  display: block;
+  margin: 0 auto;
+}
+
+/* Image / content caption */
+.caption {
+  text-align: center;
+  font-size: 0.875rem;
+  font-style: italic;
+  color: #777;
+  margin-top: 10px;
+}
+
+/* --- Notification Boxes --- */
+
+.box-note,
+.box-warning,
+.box-error,
+.box-success {
+  padding: 15px 20px;
+  margin: 20px 0;
+  border-left: 4px solid;
+  background-color: #f8f8f8;
+  border-radius: 2px;
+}
+
+.box-note {
+  border-left-color: #2196F3;
+}
+
+.box-warning {
+  border-left-color: #ffc107;
+}
+
+.box-error {
+  border-left-color: #f44336;
+}
+
+.box-success {
+  border-left-color: #4CAF50;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .box-note,
+  .box-warning,
+  .box-error,
+  .box-success {
+    /* No animation/transition */
+  }
 }


### PR DESCRIPTION
See #614

:robot: Add three new features:

1. CSS Utility Classes (.caption, .center)
   - .caption: centered italic gray caption for images/content
   - .center: centered block element utility

2. Notification/Callout Box Classes (.box-note, .box-warning, .box-error, .box-success)
   - Styled with colored left borders
   - Ready for use in post content via inline HTML

3. Page Parameters
   - navShort: permanently use compact navbar on a page or site-wide
   - showAvatar: hide the navbar logo/avatar on specific pages
   - fullWidth: switch content to container-fluid (edge-to-edge) layout

All changes are backward-compatible.

Inspired by beautiful-jekyll theme (https://github.com/daattali/beautiful-jekyll).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
