### PR TITLE
feat: add utterances and giscus comment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,37 @@ comments:
 
 If you *don't* have the section `[Params.staticman]` in `hugo.toml`, you *won't* need the section `reCaptcha`  in `staticman.yml`
 
+### Utterances support
+
+Add this section in `hugo.toml`:
+
+```toml
+[Params.utterances]
+  repo = "owner/repo"
+  issueTerm = "pathname" # pathname, url, title, og:title
+  theme = "preferred-color-scheme"
+  # label = "comment"
+```
+
+### giscus support
+
+Add this section in `hugo.toml`:
+
+```toml
+[Params.giscus]
+  repo = "owner/repo"
+  repoId = "R_kgDO..."
+  category = "Announcements"
+  categoryId = "DIC_kwDO..."
+  mapping = "pathname"
+  reactionsEnabled = "1"
+  emitMetadata = "0"
+  inputPosition = "top"
+  theme = "preferred_color_scheme"
+  lang = "en"
+  lazyLoading = true
+```
+
 ### Site Disclaimer
 
 If you need to put a Disclaimer on your website (e.g. "My views are my own and not my employer's"), you can do so via the following:

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -31,6 +31,24 @@ theme = "beautifulhugo"
   delayDisqus = true
   showRelatedPosts = true
 #  cusdisID = "XXX" # Get your App id from cusdis.com
+#  [Params.utterances]
+#    repo = "owner/repo" # https://utteranc.es/
+#    issueTerm = "pathname"
+#    theme = "preferred-color-scheme"
+#    # label = "comment"
+#
+#  [Params.giscus]
+#    repo = "owner/repo" # https://giscus.app/
+#    repoId = "R_kgDO..."
+#    category = "Announcements"
+#    categoryId = "DIC_kwDO..."
+#    mapping = "pathname"
+#    reactionsEnabled = "1"
+#    emitMetadata = "0"
+#    inputPosition = "top"
+#    theme = "preferred_color_scheme"
+#    lang = "en"
+#    lazyLoading = true
 #  hideAuthor = true
 #  gcse = "012345678901234567890:abcdefghijk" # Get your code from google.com/cse. Make sure to go to "Look and Feel" and change Layout to "Full Width" and Theme to "Classic"
 #  disclaimerText = "The opinions expressed herein are my own personal opinions and do not represent my employer’s view in any way."

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -53,7 +53,14 @@
 
 
       {{ if and (ne .Type "page") (.Param "comments") }}
-      
+      {{ if .Site.Params.giscus }}
+        {{ partial "giscus-comments.html" . }}
+      {{ end }}
+
+      {{ if .Site.Params.utterances }}
+        {{ partial "utterances-comments.html" . }}
+      {{ end }}
+
       {{ if .Site.Params.cusdisID }}
 
         <div id="cusdis_thread"

--- a/layouts/partials/giscus-comments.html
+++ b/layouts/partials/giscus-comments.html
@@ -1,0 +1,21 @@
+{{ with .Site.Params.giscus }}
+  {{ $giscus := . }}
+  {{ if and $giscus.repo $giscus.repoId $giscus.category $giscus.categoryId }}
+    <script src="https://giscus.app/client.js"
+      data-repo="{{ $giscus.repo }}"
+      data-repo-id="{{ $giscus.repoId }}"
+      data-category="{{ $giscus.category }}"
+      data-category-id="{{ $giscus.categoryId }}"
+      data-mapping="{{ $giscus.mapping | default "pathname" }}"
+      data-strict="{{ $giscus.strict | default "0" }}"
+      data-reactions-enabled="{{ $giscus.reactionsEnabled | default "1" }}"
+      data-emit-metadata="{{ $giscus.emitMetadata | default "0" }}"
+      data-input-position="{{ $giscus.inputPosition | default "top" }}"
+      data-theme="{{ $giscus.theme | default "preferred_color_scheme" }}"
+      data-lang="{{ $giscus.lang | default $.Site.Language.Lang }}"
+      data-loading="{{ cond ($giscus.lazyLoading | default false) "lazy" "eager" }}"
+      crossorigin="anonymous"
+      async>
+    </script>
+  {{ end }}
+{{ end }}

--- a/layouts/partials/utterances-comments.html
+++ b/layouts/partials/utterances-comments.html
@@ -1,0 +1,13 @@
+{{ with .Site.Params.utterances }}
+  {{ $utterances := . }}
+  {{ with .repo }}
+    <script src="https://utteranc.es/client.js"
+      repo="{{ . }}"
+      issue-term="{{ $utterances.issueTerm | default "pathname" }}"
+      {{ with $utterances.label }}label="{{ . }}"{{ end }}
+      theme="{{ $utterances.theme | default "preferred-color-scheme" }}"
+      crossorigin="anonymous"
+      async>
+    </script>
+  {{ end }}
+{{ end }}


### PR DESCRIPTION
See #614.

:robot:

## Summary
- add optional Utterances comment embed support
- add optional giscus comment embed support
- wire both options into post comment rendering
- document config in README and exampleSite/hugo.toml

## Config
- Params.utterances with repo, issueTerm, theme, label
- Params.giscus with standard giscus keys (repo, repoId, category, categoryId, etc.)

## Notes
Existing Disqus, Cusdis, and Staticman support remains unchanged.