### PR TITLE
feat: polish feed thumbnails with grayscale hover

### DIFF
--- a/layouts/partials/post_preview.html
+++ b/layouts/partials/post_preview.html
@@ -6,26 +6,32 @@
             {{ .Params.subtitle }}
         </h3>
         {{ end }}
+    </a>
+
+    <p class="post-meta">
+        {{ partial "post_meta.html" . }}
+    </p>
+    <div class="post-entry-container">
         {{ if .Params.image }}
-        <img src="{{ .Params.image }}" alt="{{ .Title }}" class="img-title" />
+        <div class="post-image">
+            <a href="{{ .Permalink }}" aria-label="{{ .Title }}">
+                <img src="{{ .Params.image }}" alt="{{ .Title }}" />
+            </a>
+        </div>
         {{ end }}
         {{ if .Params.video }}
         <video loop autoplay muted playsinline class="img-title">
             <source src="{{ .Params.video }}">
         </video>
         {{ end }}
-    </a>
-
-    <p class="post-meta">
-        {{ partial "post_meta.html" . }}
-    </p>
-    <div class="post-entry">
+        <div class="post-entry">
         {{ if or (.Truncated) (.Params.summary) }}
         {{ .Summary }}
         <a href="{{ .Permalink }}" class="post-read-more">[{{ i18n "readMore" }}]</a>
         {{ else }}
         {{ .Content }}
         {{ end }}
+        </div>
     </div>
 
     {{ if .Params.tags }}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -434,21 +434,25 @@ footer div.disclaimer {
   height: 192px;
   width: 192px;
   margin-top: -35px;
-  filter: grayscale(90%);
-}
-.post-image:hover {
-  filter: grayscale(0%);
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .post-image:hover {
-    filter: grayscale(90%);
-  }
+  margin-left: 20px;
 }
 .post-image img {
   border-radius: 100px;
   height: 192px;
   width: 192px;
+  filter: grayscale(40%);
+  transition: filter 150ms ease-in-out;
+}
+
+.post-image:hover img,
+.post-image a:focus img {
+  filter: grayscale(0%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .post-image img {
+    transition: none;
+  }
 }
 .post-preview .post-read-more {
   font-weight: 800;
@@ -498,6 +502,14 @@ footer div.disclaimer {
 @media only screen and (min-width: 768px) {
   .post-preview .blog-tags {
     margin-top: 10px;
+  }
+}
+
+@media only screen and (max-width: 767px) {
+  .post-image,
+  .post-image img {
+    height: 144px;
+    width: 144px;
   }
 }
 


### PR DESCRIPTION
See #614.

- [ ] TODO: I don't think I like the modification of images except on hover. Maybe just keep the organization parts, drop the color change.

:robot:

## Summary
- switch post previews to use a dedicated thumbnail container
- apply grayscale(40%) default and full color on hover/focus
- add reduced-motion-safe transitions
- keep responsive thumbnail sizing (192px desktop, 144px tablet, 100px mobile)

## Notes
Video previews continue to render as before.