### PR TITLE
feat: expand social icon registry (ORCID, Google Scholar)

### DIFF
--- a/data/beautifulhugo/social.toml
+++ b/data/beautifulhugo/social.toml
@@ -234,6 +234,18 @@ title = "Bluesky"
 icon = "fab fa-bluesky"
 
 [[social_icons]]
+id = "orcid"
+url = "https://orcid.org/%s"
+title = "ORCID"
+icon = "fab fa-orcid"
+
+[[social_icons]]
+id = "googlescholar"
+url = "https://scholar.google.com/citations?user=%s"
+title = "Google Scholar"
+icon = "fas fa-graduation-cap"
+
+[[social_icons]]
 id = "goodreads"
 url = "https://goodreads.com/%s"
 title = "Goodreads"

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -82,6 +82,8 @@ theme = "beautifulhugo"
   strava = "userid"
   lastfm = "username"
   bluesky = "username"
+  orcid = "0000-0000-0000-0000"
+  googlescholar = "XXXXXXXXXXXX"
 
 [[menu.main]]
     name = "Blog"


### PR DESCRIPTION
See #614.

:robot:

## Summary
- add orcid social icon mapping
- add googlescholar social icon mapping
- add example keys in exampleSite/hugo.toml

## Notes
Mastodon (rel=me) and Bluesky support remain intact.