### PR TITLE
chore: better developer experience

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        hugo: [0.146.2, 0.147.2, 0.155.2, 0.161.1]
+        hugo: [0.146.2, 0.155.2, 0.161.1]
     steps:
       - name: Install Hugo CLI
         run: >
@@ -38,6 +38,6 @@ jobs:
         run: >
           hugo
           --minify
-          -s "./exampleSite/"
-          --themesDir "../../"
+          --gc
+          -s exampleSite
           --logLevel info

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -20,7 +20,6 @@ concurrency:
   group: "pages"
   cancel-in-progress: true
 
-
 jobs:
   # Build job
   build:
@@ -29,8 +28,9 @@ jobs:
       HUGO_VERSION: 0.146.2
     steps:
       - name: Install Hugo CLI
-        run: |
-          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+        run: >
+          wget -O ${{ runner.temp }}/hugo.deb
+          https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
       - name: Checkout
         uses: actions/checkout@v4
@@ -40,17 +40,13 @@ jobs:
         id: pages
         uses: actions/configure-pages@v5
       - name: Build with Hugo
-        env:
-          # For maximum backward compatibility with Hugo modules
-          HUGO_ENVIRONMENT: production
-          HUGO_ENV: production
-          # Can't use ${{ steps.pages.outputs.base_url }} as the "s" is missing in https
-        run: |
-          hugo \
-            --minify \
-            --baseURL "https://halogenica.net/beautifulhugo/" \
-            -s "./exampleSite/" \
-            --themesDir "../../"
+        # Can't use ${{ steps.pages.outputs.base_url }} as the "s" is missing in https
+        run: >
+          hugo
+          --gc
+          --minify
+          --baseURL "https://halogenica.net/beautifulhugo/"
+          -s "./exampleSite/"
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ Temporary Items
 # Hugo's lock
 .hugo_build.lock
 exampleSite/public/
+/public/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,13 +7,13 @@ This is a **Hugo theme**, not a standalone site. All changes are template-level 
 To preview changes locally, build the example site with the parent directory as the themes root:
 
 ```bash
-hugo --minify -s "./exampleSite/" --themesDir "../../"
+hugo --minify -s "./exampleSite/"
 ```
 
 If you want to see the site served, you can start a live server with:
 
 ```bash
-hugo serve -s exampleSite/ --themesDir ../..
+hugo serve -s exampleSite
 ```
 
 ## Hugo Version

--- a/exampleSite/go.mod
+++ b/exampleSite/go.mod
@@ -1,0 +1,7 @@
+module github.com/halogenica/beautifulhugo/exampleSite
+
+replace github.com/halogenica/beautifulhugo => ..
+
+go 1.20
+
+require github.com/halogenica/beautifulhugo v0.0.0-20260508145227-83f5d8f50cdc // indirect

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -1,8 +1,14 @@
-baseurl = "https://username.github.io"
+# This gets overridden when building for production
+baseurl = "http://localhost:1313/"
 DefaultContentLanguage = "en"
 title = "Beautiful Hugo"
-# Using theme as git submodule
-theme = "beautifulhugo"
+
+# If using theme as git submodule
+# theme = "beautifulhugo"
+#
+# If using modules (recommended):
+[[module.imports]]
+   path = "github.com/halogenica/beautifulhugo"
 
 [pagination]
   pagerSize = 5

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,7 @@
 [build]
   publish = "exampleSite/public"
-  command = "cd exampleSite && hugo --gc --themesDir ../.."
+  command = "cd exampleSite && hugo --gc --minify"
   
 [build.environment]
   HUGO_VERSION = "0.146.2"
-  HUGO_THEME = "repo"
   HUGO_BASEURL = "/"


### PR DESCRIPTION
There were several problems with the DX. Using `../..` trips up protection mechanisms in both Copilot and OpenCode. Even worse, when using git worktrees, it was grabbing the wrong theme, as it's going up twice, then looking for a theme folder named "beautifulhugo"! And it's annoying to have to remember to add that.

I looked for best practices using ChatGPT, and settled on this. Now you can build from inside the example folder, the example looks correct, and from the theme folder you can build specifying the example directory. The key thing I learned was the "replace" command in go modules.

Hugo has a `-e` flag now, but "production" seems to be the default for it unless using `hugo serve`.