### PR TITLE
feat: basic hidden=true support

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,9 @@ To avoid this, set the following param in hugo.toml:
   showPageDates = false # disables the dates below pages, can be controlled in page frontmatter, too
 ```
 
+### Hidden posts
+Set `hidden: true` in a page's front matter to remove it from the homepage and list pages while still building the page (so it remains accessible by direct URL).
+
 ### Extra shortcodes
 
 There are two extra shortcodes provided (along with the customized figure shortcode):

--- a/exampleSite/content/post/2026-05-08-layout-examples.md
+++ b/exampleSite/content/post/2026-05-08-layout-examples.md
@@ -73,3 +73,16 @@ showAvatar: false
 fullWidth: true
 ---
 ```
+
+## Hidden posts
+
+You can hide a post from the homepage and list pages by setting `hidden: true` in the page front matter. The page will still be built and accessible by direct URL, but it will not appear in any paginated view. Useful for a "draft" post that you also want to share via link.
+
+```yaml
+---
+title: Draft notes
+hidden: true
+---
+```
+
+That's not set on this page so you can find it. :)

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -8,7 +8,7 @@
           </div>
         {{ end }}
         <div class="posts-list">
-          {{ range .Paginator.Pages }}
+          {{ range where .Paginator.Pages "Params.hidden" "!=" true }}
             {{ partial "post_preview.html" .}}
           {{ end }}
         </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -9,7 +9,7 @@
         {{ end }}
 
         <div class="posts-list">
-          {{ $pag := .Paginate (where site.RegularPages "Type" "in" site.Params.mainSections) }}
+          {{ $pag := .Paginate (where (where site.RegularPages "Type" "in" site.Params.mainSections) "Params.hidden" "!=" true) }}
           {{ range $pag.Pages }}
             {{ partial "post_preview" . }}
           {{ end }}


### PR DESCRIPTION
Adding features from my branch. This is a `hidden: True` setting that lets you still share a post via URL or links.

Assisted-by: OpenCode:Kimi-K2.6
