### PR TITLE
feat: add white class

### DIFF
--- a/exampleSite/content/post/2026-05-08-figure-sample.md
+++ b/exampleSite/content/post/2026-05-08-figure-sample.md
@@ -73,3 +73,21 @@ Source:
 {{</* /gallery */>}}
 ```
 
+
+## White background in dark mode
+
+If you need a white background in dark mode for an image with transparency, add the `white` class:
+
+```markdown
+{{</* figure src="/img/hexagon.jpg" class="white" */>}}
+
+![](/img/hexagon.jpg)
+{.white}
+```
+
+Remember to enable block attribuites in markdown:
+
+```toml
+[markup.goldmark.parser.attribute]
+  block = true
+```

--- a/static/css/dark.css
+++ b/static/css/dark.css
@@ -18,8 +18,8 @@
         border-left: 5px solid #444;
       }
 
-  :root:not([data-theme="light"]) figure:not(.dark) img,
-  :root:not([data-theme="light"]) img.white {
+  :root:not([data-theme="light"]) figure.white img,
+  :root:not([data-theme="light"]) p.white img {
       background-color: white;
     }
 
@@ -177,9 +177,8 @@
       border-left: 5px solid #444;
     }
 
-[data-theme="dark"] figure:not(.dark) img,
-
-[data-theme="dark"] img.white {
+[data-theme="dark"] figure.white img,
+[data-theme="dark"] p.white img {
     background-color: white;
   }
 


### PR DESCRIPTION
Another feature from my fork. It also avoids `dark` having a special meaning, so we can add `light`/`dark` classes later.
