### PR TITLE
fix: cleanup for better bootstrap 5

### DIFF
--- a/exampleSite/content/_index.md
+++ b/exampleSite/content/_index.md
@@ -1,2 +1,2 @@
 ## Front Page Content
-`beautifulhugo` supports content on your front page. Edit `/content/_index.md` to change what appears here. Delete `/content/_index.md` if you don't want any content here.
+[Beautiful Hugo](https://github.com/halogenica/beautifulhugo) supports content on your front page. Edit `/content/_index.md` to change what appears here. Delete `/content/_index.md` if you don't want any content here.

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -3,7 +3,7 @@
     <div class="row">
       <div class="{{ cond .Params.fullWidth "col-12" "col-md-10 offset-md-1" }}">
         {{ with .Content }}
-          <div class="well">
+          <div class="content-section">
             {{.}}
           </div>
         {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -17,7 +17,7 @@
         {{ if $.Param "socialShare" }}
             <hr/>
             <section id="social-share">
-              <div class="list-inline footer-links">
+              <div class="footer-links">
                 {{ partial "share-links" . }}
               </div>
             </section>
@@ -38,14 +38,14 @@
       </article>
 
       {{ if ne .Type "page" }}
-        <ul class="pager blog-pager">
+        <ul class="post-pager blog-post-pager">
           {{ if .PrevInSection }}
-            <li class="previous">
+            <li class="pager-prev">
               <a href="{{ .PrevInSection.Permalink }}" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ .PrevInSection.Title }}">&larr; {{ i18n "previousPost" }}</a>
             </li>
           {{ end }}
           {{ if .NextInSection }}
-            <li class="next">
+            <li class="pager-next">
               <a href="{{ .NextInSection.Permalink }}" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ .NextInSection.Title }}">{{ i18n "nextPost" }} &rarr;</a>
             </li>
           {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -3,7 +3,7 @@
     <div class="row">
       <div class="col-md-10 offset-md-1">
         {{ with .Content }}
-          <div class="well">
+          <div class="content-section">
             {{.}}
           </div>
         {{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -16,7 +16,7 @@
           {{ range .Site.Data.beautifulhugo.social.social_icons }}
             {{- $social := . -}}
             {{- with index $.Site.Params.author $social.id }}
-              <li role="listitem">
+              <li class="list-inline-item" role="listitem">
 		{{- $authorValue := . -}}
 		{{ if or ( hasPrefix $authorValue "http://" ) ( hasPrefix $authorValue "https://" ) }}
 		  <a {{ if $social.rel }}rel="{{ $social.rel }} noopener noreferrer"{{ else }}rel="noopener noreferrer"{{ end }} href="{{ printf "%s" $authorValue }}" title="{{ $social.title }}" aria-label="{{ $social.title }}">
@@ -33,7 +33,7 @@
           {{ end }}
           {{ if .Site.Params.rss }}
           {{ with .OutputFormats.Get "RSS" }}
-          <li>
+          <li class="list-inline-item">
             <a href="{{ .RelPermalink }}" title="RSS">
               <span class="fa-stack fa-lg">
                 <i class="fas fa-circle fa-stack-2x"></i>

--- a/layouts/partials/paginator.html
+++ b/layouts/partials/paginator.html
@@ -1,12 +1,12 @@
 {{ if or (.Paginator.HasPrev) (.Paginator.HasNext) }}
-  <ul class="pager main-pager">
+  <ul class="post-pager">
     {{ if .Paginator.HasPrev }}
-      <li class="previous">
+      <li class="pager-prev">
         <a href="{{ .Permalink }}page/{{ .Paginator.Prev.PageNumber }}/">&larr; {{ i18n "newerPosts" }}</a>
       </li>
     {{ end }}
     {{ if .Paginator.HasNext }}
-      <li class="next">
+      <li class="pager-next">
         <a href="{{ .Permalink }}page/{{ .Paginator.Next.PageNumber }}/">{{ i18n "olderPosts" }} &rarr;</a>
       </li>
     {{ end }}

--- a/static/css/dark.css
+++ b/static/css/dark.css
@@ -56,9 +56,16 @@
   }
 
   /* --- Pager --- */
-  :root:not([data-theme="light"]) .pager li a {
+  :root:not([data-theme="light"]) .post-pager li a {
     background: #444;
     color: white;
+    border-color: #555;
+  }
+
+  :root:not([data-theme="light"]) .post-pager li a:hover,
+  :root:not([data-theme="light"]) .post-pager li a:focus {
+    background: #0085a1;
+    border-color: #0085a1;
   }
 
   /* --- Footer --- */
@@ -71,9 +78,10 @@
     color: #AAA;
   }
 
-  /* --- Well --- */
-  :root:not([data-theme="light"]) .well {
+  /* --- Content section --- */
+  :root:not([data-theme="light"]) .content-section {
     background-color: #444;
+    border-color: #555;
   }
 
   /* --- Tables --- */
@@ -215,9 +223,16 @@
 }
 
 /* --- Pager --- */
-[data-theme="dark"] .pager li a {
+[data-theme="dark"] .post-pager li a {
   background: #444;
   color: white;
+  border-color: #555;
+}
+
+[data-theme="dark"] .post-pager li a:hover,
+[data-theme="dark"] .post-pager li a:focus {
+  background: #0085a1;
+  border-color: #0085a1;
 }
 
 /* --- Footer --- */
@@ -230,9 +245,10 @@
   color: #AAA;
 }
 
-/* --- Well --- */
-[data-theme="dark"] .well {
+/* --- Content section --- */
+[data-theme="dark"] .content-section {
   background-color: #444;
+  border-color: #555;
 }
 
 /* --- Tables --- */

--- a/static/css/dark.css
+++ b/static/css/dark.css
@@ -81,7 +81,6 @@
   /* --- Content section --- */
   :root:not([data-theme="light"]) .content-section {
     background-color: #444;
-    border-color: #555;
   }
 
   /* --- Tables --- */
@@ -248,7 +247,6 @@
 /* --- Content section --- */
 [data-theme="dark"] .content-section {
   background-color: #444;
-  border-color: #555;
 }
 
 /* --- Tables --- */

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -632,32 +632,34 @@ img::selection {
 
 /* --- Pager --- */
 
-.pager {
+.post-pager {
   padding-left: 0;
   list-style: none;
   text-align: center;
   margin: 10px 0 0;
 }
 
-.pager.blog-pager {
+.post-pager.blog-post-pager {
   margin-top:10px;
+  display: flex;
+  justify-content: space-between;
 }
 
-.pager li {
+.post-pager li {
   display: inline;
 }
 
-.pager .previous > a,
-.pager .previous > span {
+.post-pager .pager-prev > a,
+.post-pager .pager-prev > span {
   float: left;
 }
 
-.pager .next > a,
-.pager .next > span {
+.post-pager .pager-next > a,
+.post-pager .pager-next > span {
   float: right;
 }
 
-.pager li a {
+.post-pager li a {
   font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   text-transform: uppercase;
   font-size: 14px;
@@ -665,25 +667,26 @@ img::selection {
   letter-spacing: 1px;
   padding: 10px 5px;
   background: #FFF;
+  border: 1px solid #e0e0e0;
   border-radius: 0;
   color: #404040;
 }
 
-.pager li a:hover,
-.pager li a:focus {
+.post-pager li a:hover,
+.post-pager li a:focus {
   color: #FFF;
   background: #0085a1;
-  border: 1px solid #0085a1;
+  border-color: #0085a1;
 }
 
 @media only screen and (min-width: 768px) {
-  .pager li a {
+  .post-pager li a {
     padding: 15px 25px;
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .pager.blog-pager  {
+  .post-pager.blog-post-pager  {
     margin-top: 40px;
   }
 }
@@ -708,8 +711,16 @@ footer .list-inline {
   padding: 0;
 }
 
-.list-inline > li {
-  display: inline-block;
+.footer-links {
+  --bs-list-inline-padding: 0.5rem;
+}
+
+.footer-links .list-inline-item {
+  padding-right: var(--bs-list-inline-padding);
+}
+
+.footer-links .list-inline-item:last-child {
+  padding-right: 0;
 }
 
 footer .copyright {
@@ -812,15 +823,15 @@ table tr td :last-child {
   margin-bottom: 0;
 }
 
-/* --- Well (Bootstrap 3 compatibility) --- */
+/* --- Content section --- */
 
-.well {
+.content-section {
   min-height: 20px;
-  padding: 19px;
   margin-bottom: 20px;
-  background-color: #f5f5f5;
-  border-radius: 4px;
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, .05);
+  padding: 1rem;
+  background-color: var(--bs-light-bg-subtle, #f8f9fa);
+  border: 1px solid var(--bs-border-color, #dee2e6);
+  border-radius: var(--bs-border-radius, 4px);
 }
 
 /* --- Notification Boxes --- */

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -158,9 +158,9 @@ img::selection {
 }
 
 @media only screen and (min-width: 768px) {
-  .navbar-custom .dropdown:hover > .dropdown-menu,
-  .navbar-custom .dropdown:focus-within > .dropdown-menu {
-    display: block;
+  .navbar-custom .dropdown-menu.dropdown-menu-end {
+    right: 0;
+    left: auto;
   }
 }
 
@@ -545,10 +545,10 @@ img::selection {
   .intro-header .page-heading h1,
   .intro-header .tags-heading h1,
   .intro-header .categories-heading h1 {
-    font-size: 80px;
+    font-size: 60px;
   }
   .intro-header .post-heading h1 {
-    font-size: 50px;
+    font-size: 40px;
   }
   .intro-header.big-img .img-desc {
     font-size: 14px;
@@ -826,12 +826,15 @@ table tr td :last-child {
 /* --- Content section --- */
 
 .content-section {
-  min-height: 20px;
-  margin-bottom: 20px;
-  padding: 1rem;
-  background-color: var(--bs-light-bg-subtle, #f8f9fa);
-  border: 1px solid var(--bs-border-color, #dee2e6);
-  border-radius: var(--bs-border-radius, 4px);
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  background-color: #f0f0f0;
+  border-radius: var(--bs-border-radius, 0.375rem);
+  font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
+
+.content-section a {
+  text-decoration: none;
 }
 
 /* --- Notification Boxes --- */


### PR DESCRIPTION
Some cleanup to better match bootstrap 5's defaults.


This restore's bootstrap 5's click to open for menus, because that's when it computes the placement. Adjusting a few more things to be more like before.
