### PR TITLE
fix: missing toggle for figure

### DIFF
--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -1,1 +1,5 @@
-{{ partial "shortcodes/figure.html" . }}
+{{- if .Site.Params.disableFigureOverride }}
+  {{ partial "shortcodes/figure.html" . }}
+{{- else }}
+  {{ partial "shortcodes/beautifulfigure.html" . }}
+{{- end }}


### PR DESCRIPTION
This was the original design, but somehow this ended up without the toggle. Without it the toggle doesn't do anyting! Fix #640.


Assisted-by: OpenCode:Kimi-K2.6
