### PR TITLE
fix: keep seo/opengraph.html for now

### DIFF
--- a/layouts/partials/seo/main.html
+++ b/layouts/partials/seo/main.html
@@ -1,3 +1,3 @@
 {{- partial "seo/schema" . }}
-{{ partial "opengraph.html" . }}
+{{- partial "opengraph.html" . }}
 {{- partial "seo/twitter" . }}

--- a/layouts/partials/seo/opengraph.html
+++ b/layouts/partials/seo/opengraph.html
@@ -1,0 +1,1 @@
+{{- partial "opengraph.html" . }}


### PR DESCRIPTION
Close #642.

The stuff in seo is also in hugo 0.146+.
