### PR TITLE
fix: standard columns format

### DIFF
--- a/exampleSite/content/_index.md
+++ b/exampleSite/content/_index.md
@@ -20,7 +20,7 @@ title: Beautiful Hugo
 - Mermaid diagrams
 - PhotoSwipe image lightbox
 - Select Chroma or Highlight.js syntax highlighting
-{{< endcolumns >}}
+{{< /columns >}}
 
 {{< columns >}}
 **Shortcodes**
@@ -37,6 +37,6 @@ title: Beautiful Hugo
 - GitHub buttons
 - SEO (schema.org, Open Graph, Twitter Cards)
 - 19 languages
-{{< endcolumns >}}
+{{< /columns >}}
 
 Browse the **Features** menu above for detailed documentation with live examples!

--- a/exampleSite/content/page/shortcodes.md
+++ b/exampleSite/content/page/shortcodes.md
@@ -34,15 +34,15 @@ This content is hidden by default. You can use **Markdown** here.
 {{</* /details */>}}
 ```
 
-## columns / column / endcolumns
+## columns / column
 
-The `columns`, `column`, and `endcolumns` shortcodes create a two-column layout using the `splitbox` CSS class.
+The `columns` and `column` shortcodes create a two-column layout using the `splitbox` CSS class. `columns` is a paired shortcode; `column` marks the boundary between the left and right column.
 
 | Shortcode | Purpose |
 |-----------|---------|
 | `{{</* columns */>}}` | Opens the two-column wrapper and starts the left column |
 | `{{</* column */>}}` | Closes the left column and starts the right column |
-| `{{</* endcolumns */>}}` | Closes the right column and the wrapper |
+| `{{</* /columns */>}}` | Closes the right column and the wrapper |
 
 **Live example:**
 
@@ -60,7 +60,7 @@ Right column content. Each column takes roughly 48% of the available width.
 [Params]
   colorScheme = "auto"
 ```
-{{< endcolumns >}}
+{{< /columns >}}
 
 **Source:**
 
@@ -69,7 +69,7 @@ Right column content. Each column takes roughly 48% of the available width.
 Left column content here.
 {{</* column */>}}
 Right column content here.
-{{</* endcolumns */>}}
+{{</* /columns */>}}
 ```
 
 ## tabs / tab

--- a/exampleSite/content/post/2026-05-11-v2-release.md
+++ b/exampleSite/content/post/2026-05-11-v2-release.md
@@ -32,7 +32,7 @@ See [Figures & Galleries](../../page/figures-and-galleries/) for details.
 - **`tabs` / `tab`**: Bootstrap 5 tabbed interface with optional synchronization across tab groups. See [Shortcodes](../../page/shortcodes/).
 - **`mermaid`** (revamped, not exaclty new): Mermaid diagram rendering with automatic dark mode support. See [Math & Diagrams](../../page/math-and-diagrams/).
 - **`details`**: Collapsible `<details>` element. See [Shortcodes](../../page/shortcodes/).
-- **`columns` / `column` / `endcolumns`**: Two-column layout. See [Shortcodes](../../page/shortcodes/).
+- **`columns` / `column`**: Two-column layout. See [Shortcodes](../../page/shortcodes/).
 
 ### GitHub Buttons
 

--- a/layouts/shortcodes/columns.html
+++ b/layouts/shortcodes/columns.html
@@ -1,1 +1,5 @@
-<div class="splitbox"><div class="left">
+{{ if .Inner }}<div class="splitbox"><div class="left">
+{{ .Inner }}
+</div><div style="clear:both"></div></div>
+{{ else }}{{ warnf "The unpaired {{< columns >}} / {{< endcolumns >}} syntax is deprecated. Use the paired {{< columns >}}...{{< /columns >}} syntax instead. See %s" .Position }}<div class="splitbox"><div class="left">
+{{ end }}

--- a/layouts/shortcodes/endcolumns.html
+++ b/layouts/shortcodes/endcolumns.html
@@ -1,1 +1,1 @@
-</div><div style="clear:both"></div></div>
+{{ warnf "The {{< endcolumns >}} shortcode is deprecated. Use {{< /columns >}} instead. See %s" .Position }}</div><div style="clear:both"></div></div>


### PR DESCRIPTION
Backward compatible, shows warning. More like all other shortcodes this way. I think there used to be an issue with nesting 8 years ago, but it's fine now.

Assisted-by: OpenCode:glm-5.1
