### PR TITLE
fix: ToC on main message

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -15,5 +15,6 @@
         {{ partial "paginator.html" . }}
       </div>
     </div>
+    {{ partial "toc.html" . }}
   </div>
 {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -18,5 +18,6 @@
         {{ partial "paginator.html" . }}
       </div>
     </div>
+    {{ partial "toc.html" . }}
   </div>
 {{ end }}

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -3,7 +3,7 @@
     <a class="navbar-brand" href="{{ "" | absLangURL }}">{{ .Site.Title }}</a>
     <div class="d-flex align-items-center">
       {{ if ne ($.Param "toc") false }}
-      {{ if .TableOfContents }}
+      {{ if or .TableOfContents (and (or .IsSection .IsHome) .Pages) }}
       <button class="theme-toggle" id="toc-toggle" aria-label="Table of contents" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Table of contents">
         <span class="fas fa-list"></span>
       </button>

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -1,13 +1,24 @@
 {{- if ne ($.Param "toc") false -}}
-{{- if .TableOfContents -}}
-<div class="toc-wrapper" id="toc-wrapper">
+{{- $isListPage := or .IsSection .IsHome -}}
+{{- if or .TableOfContents (and $isListPage .Pages) -}}
+<div class="toc-wrapper" id="toc-wrapper" data-toc-mode="{{ if $isListPage }}posts{{ else }}headings{{ end }}">
   <div class="toc-panel" id="toc-panel" role="dialog" aria-label="Table of contents">
     <div class="toc-header">
-      <span class="toc-title">Table of Contents</span>
+      <span class="toc-title">{{ if $isListPage }}Posts{{ else }}Table of Contents{{ end }}</span>
       <button class="toc-close" id="toc-close" aria-label="Close table of contents">&times;</button>
     </div>
     <nav class="toc-body">
+      {{- if $isListPage -}}
+      <ul class="toc-post-list">
+        {{- range .Paginator.Pages -}}
+        {{- if ne .Params.hidden true -}}
+        <li><a href="{{ .Permalink }}">{{ .Title }}</a></li>
+        {{- end -}}
+        {{- end -}}
+      </ul>
+      {{- else -}}
       {{ .TableOfContents }}
+      {{- end -}}
     </nav>
   </div>
   <div class="toc-backdrop" id="toc-backdrop"></div>

--- a/static/css/toc.css
+++ b/static/css/toc.css
@@ -112,6 +112,43 @@ body.toc-visible .toc-wrapper {
   background: rgba(0, 133, 161, 0.08);
 }
 
+.toc-post-list {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+
+.toc-post-list li {
+  margin: 0;
+}
+
+.toc-post-list a {
+  display: block;
+  padding: 0.5rem 0.5rem;
+  color: #666;
+  font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.4;
+  text-decoration: none;
+  border-left: 2px solid transparent;
+  border-radius: 0 4px 4px 0;
+  transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+}
+
+.toc-post-list a:hover {
+  color: #0085a1;
+  border-left-color: #0085a1;
+  background: rgba(0, 133, 161, 0.04);
+}
+
+.toc-post-list a.toc-active {
+  color: #0085a1;
+  font-weight: 600;
+  border-left-color: #0085a1;
+  background: rgba(0, 133, 161, 0.08);
+}
+
 .toc-backdrop {
   position: fixed;
   inset: 0;
@@ -165,6 +202,22 @@ body.toc-visible .toc-wrapper {
     border-left-color: #66bfff;
     background: rgba(102, 191, 255, 0.1);
   }
+
+  :root:not([data-theme="light"]) .toc-post-list a {
+    color: #aaa;
+  }
+
+  :root:not([data-theme="light"]) .toc-post-list a:hover {
+    color: #66bfff;
+    border-left-color: #66bfff;
+    background: rgba(102, 191, 255, 0.06);
+  }
+
+  :root:not([data-theme="light"]) .toc-post-list a.toc-active {
+    color: #66bfff;
+    border-left-color: #66bfff;
+    background: rgba(102, 191, 255, 0.1);
+  }
 }
 
 [data-theme="dark"] .toc-panel {
@@ -200,6 +253,22 @@ body.toc-visible .toc-wrapper {
 }
 
 [data-theme="dark"] .toc-body #TableOfContents a.toc-active {
+  color: #66bfff;
+  border-left-color: #66bfff;
+  background: rgba(102, 191, 255, 0.1);
+}
+
+[data-theme="dark"] .toc-post-list a {
+  color: #aaa;
+}
+
+[data-theme="dark"] .toc-post-list a:hover {
+  color: #66bfff;
+  border-left-color: #66bfff;
+  background: rgba(102, 191, 255, 0.06);
+}
+
+[data-theme="dark"] .toc-post-list a.toc-active {
   color: #66bfff;
   border-left-color: #66bfff;
   background: rgba(102, 191, 255, 0.1);

--- a/static/js/toc.js
+++ b/static/js/toc.js
@@ -2,13 +2,33 @@
   var wrapper = document.getElementById('toc-wrapper');
   if (!wrapper) return;
 
-  var tocNav = wrapper.querySelector('#TableOfContents');
-  var hasItems = tocNav && tocNav.querySelector('li');
-  if (!hasItems) {
-    wrapper.remove();
-    var navToggle = document.getElementById('toc-toggle');
-    if (navToggle) navToggle.remove();
-    return;
+  var mode = wrapper.getAttribute('data-toc-mode') || 'headings';
+
+  if (mode === 'posts') {
+    var postList = wrapper.querySelector('.toc-post-list');
+    var hasPosts = postList && postList.querySelector('li');
+    if (!hasPosts) {
+      wrapper.remove();
+      var navToggle = document.getElementById('toc-toggle');
+      if (navToggle) navToggle.remove();
+      return;
+    }
+  } else {
+    var tocNav = wrapper.querySelector('#TableOfContents');
+    var hasItems = tocNav && tocNav.querySelector('li');
+    if (!hasItems) {
+      wrapper.remove();
+      var navToggle = document.getElementById('toc-toggle');
+      if (navToggle) navToggle.remove();
+      return;
+    }
+    var allLinks = tocNav.querySelectorAll('a');
+    if (allLinks.length <= 1) {
+      wrapper.remove();
+      var navToggle2 = document.getElementById('toc-toggle');
+      if (navToggle2) navToggle2.remove();
+      return;
+    }
   }
 
   var toggle = document.getElementById('toc-toggle');
@@ -47,49 +67,98 @@
     if (e.key === 'Escape' && isOpen) closePanel();
   });
 
-  var tocLinks = panel.querySelectorAll('#TableOfContents a');
-  tocLinks.forEach(function (link) {
-    link.addEventListener('click', function () {
-      closePanel();
-    });
-  });
-
-  var headings = [];
-  document.querySelectorAll('.blog-post h2, .blog-post h3, .blog-post h4, .blog-post h5, .blog-post h6').forEach(function (h) {
-    if (h.id) headings.push(h);
-  });
-
-  if (headings.length === 0) return;
-
-  var activeLink = null;
-
-  function setActive(id) {
-    if (activeLink) activeLink.classList.remove('toc-active');
-    var link = panel.querySelector('a[href="#' + CSS.escape(id) + '"]');
-    if (link) {
-      link.classList.add('toc-active');
-      activeLink = link;
-      link.scrollIntoView({ block: 'nearest', behavior: 'instant' });
-    }
-  }
-
-  var observer = new IntersectionObserver(
-    function (entries) {
-      entries.forEach(function (entry) {
-        if (entry.isIntersecting) {
-          setActive(entry.target.id);
-        }
+  if (mode === 'posts') {
+    var postLinks = panel.querySelectorAll('.toc-post-list a');
+    postLinks.forEach(function (link) {
+      link.addEventListener('click', function () {
+        closePanel();
       });
-    },
-    {
-      rootMargin: '-80px 0px -70% 0px',
-      threshold: 0,
-    }
-  );
+    });
 
-  headings.forEach(function (h) {
-    observer.observe(h);
-  });
+    var postPreviews = document.querySelectorAll('.post-preview');
+    if (postPreviews.length === 0) {
+      document.body.classList.add('toc-visible');
+      return;
+    }
+
+    var activePostLink = null;
+
+    function setActivePost(index) {
+      if (activePostLink) activePostLink.classList.remove('toc-active');
+      var link = postLinks[index];
+      if (link) {
+        link.classList.add('toc-active');
+        activePostLink = link;
+        link.scrollIntoView({ block: 'nearest', behavior: 'instant' });
+      }
+    }
+
+    var postObserver = new IntersectionObserver(
+      function (entries) {
+        entries.forEach(function (entry) {
+          if (entry.isIntersecting) {
+            var idx = Array.prototype.indexOf.call(postPreviews, entry.target);
+            if (idx >= 0) setActivePost(idx);
+          }
+        });
+      },
+      {
+        rootMargin: '-80px 0px -70% 0px',
+        threshold: 0,
+      }
+    );
+
+    postPreviews.forEach(function (el) {
+      postObserver.observe(el);
+    });
+  } else {
+    var tocLinks = panel.querySelectorAll('#TableOfContents a');
+    tocLinks.forEach(function (link) {
+      link.addEventListener('click', function () {
+        closePanel();
+      });
+    });
+
+    var headings = [];
+    document.querySelectorAll('.blog-post h2, .blog-post h3, .blog-post h4, .blog-post h5, .blog-post h6').forEach(function (h) {
+      if (h.id) headings.push(h);
+    });
+
+    if (headings.length === 0) {
+      document.body.classList.add('toc-visible');
+      return;
+    }
+
+    var activeLink = null;
+
+    function setActive(id) {
+      if (activeLink) activeLink.classList.remove('toc-active');
+      var link = panel.querySelector('a[href="#' + CSS.escape(id) + '"]');
+      if (link) {
+        link.classList.add('toc-active');
+        activeLink = link;
+        link.scrollIntoView({ block: 'nearest', behavior: 'instant' });
+      }
+    }
+
+    var observer = new IntersectionObserver(
+      function (entries) {
+        entries.forEach(function (entry) {
+          if (entry.isIntersecting) {
+            setActive(entry.target.id);
+          }
+        });
+      },
+      {
+        rootMargin: '-80px 0px -70% 0px',
+        threshold: 0,
+      }
+    );
+
+    headings.forEach(function (h) {
+      observer.observe(h);
+    });
+  }
 
   document.body.classList.add('toc-visible');
 })();


### PR DESCRIPTION
Fixing some issues I found.

:robot:

All done. Here's a summary of the changes:

**`layouts/partials/nav.html`** - Show the TOC button on list/home pages too (when `or .IsSection .IsHome` has `.Pages`), not just when `.TableOfContents` exists.

**`layouts/partials/toc.html`** - On list/home pages, render a post list (`<ul class="toc-post-list">`) using `.Paginator.Pages` instead of `.TableOfContents`. Title shows "Posts" on list pages, "Table of Contents" on single pages. Adds `data-toc-mode` attribute for JS to distinguish modes.

**`layouts/_default/list.html`** & **`layouts/index.html`** - Added `{{ partial "toc.html" . }}` so the TOC panel HTML is rendered on list pages.

**`static/js/toc.js`** - Two key changes:
1. On single pages (`headings` mode): if the TOC has only 1 link or fewer, the button and panel are removed entirely
2. On list pages (`posts` mode): uses IntersectionObserver on `.post-preview` elements to highlight the currently visible post in the TOC panel, with scroll-spy similar to the headings mode

**`static/css/toc.css`** - Added `.toc-post-list` styles matching the existing `#TableOfContents` link styles, including dark mode variants for both `prefers-color-scheme` and `[data-theme="dark"]`.

Assisted-by: OpenCode:glm-5.1
