### PR TITLE
fix: validate the date format

### DIFF
--- a/exampleSite/content/page/configuration.md
+++ b/exampleSite/content/page/configuration.md
@@ -15,7 +15,7 @@ This page is a complete reference for every configuration option in Beautiful Hu
 | `mainSections` | list | — | Content sections treated as "posts" (e.g. `["post","posts"]`) |
 | `logo` | string | — | Path to a square avatar/logo image |
 | `favicon` | string | — | Path to favicon |
-| `dateFormat` | string | i18n default | Go date format string (e.g. `"January 2, 2006"`) |
+| `dateFormat` | string | i18n default | Go time layout string based on the reference time `Mon Jan 2 15:04:05 MST 2006` (e.g. `"January 2, 2006"` or `"2006-01-02"`). **Do not use an example date** like `"2023-10-15"` — the year must be `2006`, month `01`, and day `02`. |
 | `since` | int | — | Start year for copyright range (e.g. `2015 - 2026`) |
 
 ```toml

--- a/layouts/partials/page_meta.html
+++ b/layouts/partials/page_meta.html
@@ -2,6 +2,15 @@
   {{ $show := default .Site.Params.showPageDates .Params.showPageDates }}
   {{ if $show }}
     {{ $format := default (i18n "dateFormat") .Site.Params.dateformat }}
+    {{ if .Site.Params.dateformat }}
+      {{- $nowFmt := now.Format $format -}}
+      {{- $yearOK := or (not (findRE `2006` $format)) (findRE (now.Format "2006") $nowFmt) -}}
+      {{- $monthOK := or (findRE (now.Format "01") $nowFmt) (findRE (now.Format "January") $nowFmt) -}}
+      {{- $dayOK := or (findRE (now.Format "02") $nowFmt) (findRE (now.Format "2") $nowFmt) -}}
+      {{ if or (not $yearOK) (not $monthOK) (not $dayOK) }}
+        {{ errorf "beautifulhugo: Params.dateformat %q is not a valid Go time layout. Go uses the reference time Mon Jan 2 15:04:05 MST 2006 — use e.g. \"2006-01-02\" instead of \"2023-10-15\". See https://go.dev/src/time/format.go" .Site.Params.dateformat }}
+      {{ end }}
+    {{ end }}
     {{ $datestr := .Date.Format $format }}
     {{ $lastmodstr := .Lastmod.Format $format }}
     {{ if ne $datestr $lastmodstr }}

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -6,6 +6,15 @@
     {{- $data = .Site.Data -}}
   {{- end -}}
   {{ $format := default (i18n "dateFormat") .Site.Params.dateformat }}
+  {{ if .Site.Params.dateformat }}
+    {{- $nowFmt := now.Format $format -}}
+    {{- $yearOK := or (not (findRE `2006` $format)) (findRE (now.Format "2006") $nowFmt) -}}
+    {{- $monthOK := or (findRE (now.Format "01") $nowFmt) (findRE (now.Format "January") $nowFmt) -}}
+    {{- $dayOK := or (findRE (now.Format "02") $nowFmt) (findRE (now.Format "2") $nowFmt) -}}
+    {{ if or (not $yearOK) (not $monthOK) (not $dayOK) }}
+      {{ errorf "beautifulhugo: Params.dateformat %q is not a valid Go time layout. Go uses the reference time Mon Jan 2 15:04:05 MST 2006 — use e.g. \"2006-01-02\" instead of \"2023-10-15\". See https://go.dev/src/time/format.go" .Site.Params.dateformat }}
+    {{ end }}
+  {{ end }}
   {{ $datestr := .Date.Format $format }}
   {{ $lastmodstr := .Lastmod.Format $format }}
   <i class="fas fa-calendar"></i>&nbsp;{{ $datestr | i18n "postedOnDate"}}


### PR DESCRIPTION
Fix #552, now an error is shown if the date is not a valid date format for Go.

Assisted-by: OpenCode:glm-5.1
