### PR TITLE
fix: toc button showing up a few more places it shouldn't

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -3,7 +3,10 @@
     <a class="navbar-brand" href="{{ "" | absLangURL }}">{{ .Site.Title }}</a>
     <div class="d-flex align-items-center">
       {{ if ne ($.Param "toc") false }}
-      {{ if or .TableOfContents (and (or .IsSection .IsHome) .Pages) }}
+      {{ $hasToc := and .TableOfContents (findRE `<li>` .TableOfContents) }}
+      {{ $isListPage := or .IsSection .IsHome }}
+      {{ $hasListPages := and $isListPage (gt (len .Paginator.Pages) 0) }}
+      {{ if or $hasToc $hasListPages }}
       <button class="theme-toggle" id="toc-toggle" aria-label="Table of contents" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Table of contents">
         <span class="fas fa-list"></span>
       </button>

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -1,6 +1,8 @@
 {{- if ne ($.Param "toc") false -}}
 {{- $isListPage := or .IsSection .IsHome -}}
-{{- if or .TableOfContents (and $isListPage .Pages) -}}
+{{- $hasToc := and .TableOfContents (findRE `<li>` .TableOfContents) -}}
+{{- $hasListPages := and $isListPage (gt (len .Paginator.Pages) 0) -}}
+{{- if or $hasToc $hasListPages -}}
 <div class="toc-wrapper" id="toc-wrapper" data-toc-mode="{{ if $isListPage }}posts{{ else }}headings{{ end }}">
   <div class="toc-panel" id="toc-panel" role="dialog" aria-label="Table of contents">
     <div class="toc-header">


### PR DESCRIPTION
Things like tag lists should not have a toc button. This fixes it on listing pages.

Assisted-by: OpenCode:glm-5.1
