### PR TITLE
feat: add partial hooks for custom HTML injection (#685)

### DIFF
--- a/exampleSite/content/page/configuration.md
+++ b/exampleSite/content/page/configuration.md
@@ -283,6 +283,32 @@ Staticman adds comments as static data files via pull requests, with optional re
 
 When `gcse` is set, a search icon appears in the navbar that opens a search modal.
 
+## Custom HTML Hooks
+
+Beautiful Hugo provides partial "hooks" that let you inject custom HTML at specific points in the layout without forking the theme. To use a hook, create the corresponding file in your site's `layouts/partials/` directory — the theme's own copy is an empty stub.
+
+| Partial | Injects Near | Example Use |
+|---------|-------------|-------------|
+| `head_custom.html` | End of `<head>`, before `</head>` | Extra CSS, preconnect hints, meta tags |
+| `nav_custom.html` | Inside the navbar, after menu items | CTA button, search box, custom nav link |
+| `header_custom.html` | Inside the page header, after title/subtitle | Hero CTA button, banner |
+| `before_content.html` | Before `.Content` on single pages | Affiliate disclosure, reading-time banner |
+| `after_content.html` | After `.Content`, before tags/share/related | Newsletter signup, author bio, ad unit |
+| `footer_custom.html` | After `</footer>`, before scripts | Custom analytics, chat widget |
+| `scripts_custom.html` | After all theme JS, before `</body>` | Custom JS that depends on jQuery/Bootstrap |
+
+```text
+your-site/
+├── layouts/
+│   └── partials/
+│       ├── head_custom.html      ← your override
+│       ├── nav_custom.html       ← your override
+│       ├── header_custom.html    ← your override
+│       ├── before_content.html   ← your override
+│       ├── after_content.html    ← your override
+│       └── footer_custom.html    ← your override
+```
+
 ## Miscellaneous
 
 | Param | Type | Description |

--- a/exampleSite/layouts/partials/after_content.html
+++ b/exampleSite/layouts/partials/after_content.html
@@ -1,0 +1,7 @@
+<!--
+If you want to include any custom html just after the page content (but before tags, share buttons, and related posts), put it in this file.
+Or you can delete this file if you don't need it.
+-->
+<!-- for example, you could add a newsletter signup or author bio:
+<div class="alert alert-warning">Enjoyed this post? <a href="/subscribe/">Subscribe to the newsletter</a>.</div>
+-->

--- a/exampleSite/layouts/partials/before_content.html
+++ b/exampleSite/layouts/partials/before_content.html
@@ -1,0 +1,7 @@
+<!--
+If you want to include any custom html just before the page content, put it in this file.
+Or you can delete this file if you don't need it.
+-->
+<!-- for example, you could add a reading-time banner or affiliate disclosure:
+<div class="alert alert-info">Sponsored content — this post contains affiliate links.</div>
+-->

--- a/exampleSite/layouts/partials/header_custom.html
+++ b/exampleSite/layouts/partials/header_custom.html
@@ -1,0 +1,9 @@
+<!--
+If you want to include any custom html inside the page header (after title/subtitle, before </header>), put it in this file.
+Or you can delete this file if you don't need it.
+-->
+<!-- for example, you could add a call-to-action button in the hero:
+<div class="header-cta" style="margin-top: 1rem;">
+  <a class="btn btn-primary btn-lg" href="/get-started/">Get Started</a>
+</div>
+-->

--- a/exampleSite/layouts/partials/nav_custom.html
+++ b/exampleSite/layouts/partials/nav_custom.html
@@ -1,0 +1,9 @@
+<!--
+If you want to include any custom html inside the navbar (after the menu items), put it in this file.
+Or you can delete this file if you don't need it.
+-->
+<!-- for example, you could add a CTA button in the navbar:
+<span class="navbar-text ms-2">
+  <a class="btn btn-sm btn-primary" href="/download/">Download</a>
+</span>
+-->

--- a/exampleSite/layouts/partials/scripts_custom.html
+++ b/exampleSite/layouts/partials/scripts_custom.html
@@ -1,0 +1,12 @@
+<!--
+If you want to include any custom html just after all theme scripts have loaded (before </body>), put it in this file.
+This is the right place for custom JavaScript that depends on jQuery, Bootstrap, or other theme-loaded libraries.
+Or you can delete this file if you don't need it.
+-->
+<!-- for example, you could add a custom script that uses jQuery:
+<script>
+  $(document).ready(function() {
+    console.log("Custom script loaded after theme scripts");
+  });
+</script>
+-->

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,7 +4,9 @@
       <div class="{{ cond .Params.fullWidth "col-12" "col-md-10 offset-md-1" }}">
         <article role="main" class="blog-post">
           {{ partial "github-buttons" . }}
+          {{ partial "before_content.html" . }}
           {{ .Content }}
+          {{ partial "after_content.html" . }}
 
         {{ if .Params.tags }}
           <div class="blog-tags">

--- a/layouts/partials/after_content.html
+++ b/layouts/partials/after_content.html
@@ -1,0 +1,4 @@
+<!--
+If you want to include any custom html just after the page content (but before tags, share buttons, and related posts), put it in /layouts/partials/after_content.html
+Do not put anything in this file - it's only here so that hugo won't throw an error if /layouts/partials/after_content.html doesn't exist.
+-->

--- a/layouts/partials/before_content.html
+++ b/layouts/partials/before_content.html
@@ -1,0 +1,4 @@
+<!--
+If you want to include any custom html just before the page content, put it in /layouts/partials/before_content.html
+Do not put anything in this file - it's only here so that hugo won't throw an error if /layouts/partials/before_content.html doesn't exist.
+-->

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -79,6 +79,7 @@
       </div>
     </div>
   {{ end }}
+    {{ partial "header_custom.html" . }}
   </header>
 {{ else }}
   <div class="intro-header"></div>

--- a/layouts/partials/header_custom.html
+++ b/layouts/partials/header_custom.html
@@ -1,0 +1,4 @@
+<!--
+If you want to include any custom html inside the page header (after title/subtitle, before </header>), put it in /layouts/partials/header_custom.html
+Do not put anything in this file - it's only here so that hugo won't throw an error if /layouts/partials/header_custom.html doesn't exist.
+-->

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -82,6 +82,7 @@
           </li>
         {{ end }}
       </ul>
+      {{ partial "nav_custom.html" . }}
     </div>
 
     {{ $page := . }}

--- a/layouts/partials/nav_custom.html
+++ b/layouts/partials/nav_custom.html
@@ -1,0 +1,4 @@
+<!--
+If you want to include any custom html inside the navbar (after the menu items), put it in /layouts/partials/nav_custom.html
+Do not put anything in this file - it's only here so that hugo won't throw an error if /layouts/partials/nav_custom.html doesn't exist.
+-->

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -90,3 +90,5 @@ $(function(){
 </script>
 <script id="dsq-count-scr" src="//{{ .Site.Config.Services.Disqus.Shortname }}.disqus.com/count.js" async></script>
 {{ end }}
+
+{{ partial "scripts_custom.html" . }}

--- a/layouts/partials/scripts_custom.html
+++ b/layouts/partials/scripts_custom.html
@@ -1,0 +1,5 @@
+<!--
+If you want to include any custom html just after all theme scripts have loaded (before </body>), put it in /layouts/partials/scripts_custom.html
+This is the right place for custom JavaScript that depends on jQuery, Bootstrap, or other theme-loaded libraries.
+Do not put anything in this file - it's only here so that hugo won't throw an error if /layouts/partials/scripts_custom.html doesn't exist.
+-->


### PR DESCRIPTION
See #613. Close #540.

:robot:

Add five new partial hooks that let users inject custom HTML at precise
layout points without forking the theme, matching beautiful-jekyll's
flexibility:

- before_content.html: before page content on single pages
- after_content.html: after page content, before tags/share/related
- header_custom.html: inside page header, after title/subtitle
- nav_custom.html: inside navbar, after menu items
- scripts_custom.html: after all theme JS, before

Each hook has an empty stub in the theme, a commented-out example in the
exampleSite, and is documented in the configuration page.

Assisted-by: OpenCode:glm-5.1
