### PR TITLE
fix: RSS button always links to home feed instead of current page

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -38,7 +38,7 @@
             {{- end }}
           {{ end }}
           {{ if .Site.Params.rss }}
-          {{ with .OutputFormats.Get "RSS" }}
+          {{ with .Site.Home.OutputFormats.Get "RSS" }}
           <li class="list-inline-item">
             <a href="{{ .RelPermalink }}" title="RSS">
               <span class="fa-stack fa-lg">


### PR DESCRIPTION
Fix #339.

Assisted-by: OpenCode:glm-5.1
