### PR TITLE
fix: replace hardcoded URL construction with Hugo's GetPage and absURL

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -11,7 +11,10 @@
         {{ if .Params.tags }}
           <div class="blog-tags">
             {{ range .Params.tags }}
-              <a href="{{"tags" | absLangURL}}/{{ . | urlize }}/">{{ . }}</a>&nbsp;
+              {{- $tagName := . -}}
+              {{- with $.Site.GetPage (printf "/%s/%s" "tags" ($tagName | urlize)) -}}
+              <a href="{{ .Permalink }}">{{ $tagName }}</a>&nbsp;
+              {{- end -}}
             {{ end }}
           </div>
         {{ end }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -15,7 +15,7 @@
         {{ range $key, $value := $terms.Alphabetical }}
           <div class="terms-item">
             <div class="terms-item-header">
-              <a href="{{ $data.Plural | absLangURL }}/{{ $value.Name | urlize }}/">
+              <a href="{{ with $.Site.GetPage (printf "/%s/%s" $data.Plural ($value.Name | urlize)) }}{{ .Permalink }}{{ end }}">
                 {{ $value.Name }}
               </a>
               <span class="terms-item-count">{{ $value.Count }}</span>

--- a/layouts/partials/post_preview.html
+++ b/layouts/partials/post_preview.html
@@ -31,7 +31,10 @@
     {{ if .Params.tags }}
     <div class="blog-tags">
         {{ range .Params.tags }}
-       <a href="{{"tags" | absLangURL}}/{{ . | urlize }}/">{{ . }}</a>&nbsp;
+        {{- $tagName := . -}}
+        {{- with $.Site.GetPage (printf "/%s/%s" "tags" ($tagName | urlize)) -}}
+        <a href="{{ .Permalink }}">{{ $tagName }}</a>&nbsp;
+        {{- end -}}
         {{ end }} 
     </div>
     {{ end }}

--- a/layouts/partials/shortcodes/beautifulfigure.html
+++ b/layouts/partials/shortcodes/beautifulfigure.html
@@ -11,7 +11,7 @@ Based on hugo-easy-gallery by Li-Wen Yip: https://github.com/liwenyip/hugo-easy-
 {{- $size := .Get "size" }}
 <div class="box fancy-figure caption-position-{{ .Get "caption-position" | default "bottom" }}{{ with .Get "caption-effect" }} caption-effect-{{.}}{{end}}{{ with .Get "class" }} {{ . }}{{ end }}" {{ with .Get "width" }}style="max-width:{{.}}"{{end}}>
   <figure {{- with .Get "class" }} class="{{.}}"{{ end }} itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject">
-    <div class="img"{{ if .Parent }} style="background-image: url('{{ print .Site.BaseURL $thumb }}');"{{ end }}{{ with $size }} data-size="{{.}}"{{ end }}>
+    <div class="img"{{ if .Parent }} style="background-image: url('{{ $thumb | absURL }}');"{{ end }}{{ with $size }} data-size="{{.}}"{{ end }}>
       <img itemprop="thumbnail" src="{{ $thumb }}" {{ with .Get "alt" | default (.Get "caption") | default $thumb }}alt="{{.}}"{{ end }}/><!-- <img> hidden if in .gallery -->
     </div>
     {{- with $src }}

--- a/layouts/shortcodes/gallery.html
+++ b/layouts/shortcodes/gallery.html
@@ -5,22 +5,19 @@ Documentation and licence at https://github.com/liwenyip/hugo-easy-gallery/
 <!-- count how many times we've called this shortcode; load the css if it's the first time -->
 {{- if not ($.Page.Store.Get "figurecount") }}<link rel="stylesheet" href="{{ "css/hugo-easy-gallery.css" | absURL }}" />{{ end }}
 {{- $.Page.Store.Set "figurecount" (add ($.Page.Store.Get "figurecount" | default 0) 1) }}
-{{ $baseURL := .Site.BaseURL }}
 <div class="gallery caption-position-{{ with .Get "caption-position" | default "bottom" }}{{.}}{{end}} caption-effect-{{ with .Get "caption-effect" | default "slide" }}{{.}}{{end}} hover-effect-{{ with .Get "hover-effect" | default "zoom" }}{{.}}{{end}} {{ if ne (.Get "hover-transition") "none" }}hover-transition{{end}}" itemscope itemtype="http://schema.org/ImageGallery">
 	{{- with (.Get "dir") -}}
-		<!-- If a directory was specified, generate figures for all of the images in the directory -->
 		{{- $files := readDir (print "/static/" .) }}
 		{{- range $files -}}
-			<!-- skip files that aren't images, or that inlcude the thumb suffix in their name -->
 			{{- $thumbext := $.Get "thumb" | default "-thumb" }}
-			{{- $isthumb := .Name | findRE ($thumbext | printf "%s\\.") }}<!-- is the current file a thumbnail image? -->
-			{{- $isimg := lower .Name | findRE "\\.(gif|jpg|jpeg|tiff|png|bmp)" }}<!-- is the current file an image? -->
+			{{- $isthumb := .Name | findRE ($thumbext | printf "%s\\.") }}
+			{{- $isimg := lower .Name | findRE "\\.(gif|jpg|jpeg|tiff|png|bmp)" }}
 			{{- if and $isimg (not $isthumb) }}
-				{{- $caption :=  .Name | replaceRE "\\..*" "" | humanize }}<!-- humanized filename without extension -->
-				{{- $linkURL := print $baseURL ($.Get "dir") "/" .Name | absURL }}<!-- absolute URL to hi-res image -->
-				{{- $thumb := .Name | replaceRE "(\\.)" ($thumbext | printf "%s.") }}<!-- filename of thumbnail image -->
-				{{- $thumbexists := where $files "Name" $thumb }}<!-- does a thumbnail image exist? --> 
-				{{- $thumbURL := print $baseURL ($.Get "dir") "/" $thumb | absURL }}<!-- absolute URL to thumbnail image -->
+				{{- $caption :=  .Name | replaceRE "\\..*" "" | humanize }}
+				{{- $linkURL := print ($.Get "dir") "/" .Name | absURL }}
+				{{- $thumb := .Name | replaceRE "(\\.)" ($thumbext | printf "%s.") }}
+				{{- $thumbexists := where $files "Name" $thumb }}
+				{{- $thumbURL := print ($.Get "dir") "/" $thumb | absURL }}
 				<div class="box">
 				  <figure itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject">
 				    <div class="img" style="background-image: url('{{ if $thumbexists }}{{ $thumbURL }}{{ else }}{{ $linkURL }}{{ end }}');" >


### PR DESCRIPTION
:robot:

Avoid concatenating absLangURL/BaseURL with path segments, which breaks
when baseURL has a subpath. Use .Site.GetPage for taxonomy term links
and absURL for static asset paths instead.

Closes #339

Assisted-by: OpenCode:glm-5.1