### PR TITLE
fix: social share icons only on posts

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -19,7 +19,7 @@
           </div>
         {{ end }}
 
-        {{ if $.Param "socialShare" }}
+        {{ if and (ne .Type "page") ($.Param "socialShare") }}
             <hr/>
             <section id="social-share">
               <div class="footer-links">

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1161,6 +1161,7 @@ ul.share {
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
+  justify-content: center;
   list-style: none;
   margin: 0;
   padding: 0;


### PR DESCRIPTION
Fix #400. Only show on posts. We also lost centering at one point, returning it.

Assisted-by: OpenCode:glm-5.1
