### PR TITLE
fix: image crossfade issue with text

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -517,6 +517,7 @@ img::selection {
   position: absolute;
   width: 100%;
   height: 100%;
+  z-index: 0;
   opacity: 0;
   background: no-repeat center center;
   -webkit-background-size: cover;
@@ -540,6 +541,16 @@ img::selection {
 .intro-header .tags-heading,
 .intro-header .categories-heading {
   text-align: center;
+}
+
+.intro-header.big-img .container {
+  position: relative;
+  z-index: 1;
+}
+
+.intro-header.big-img .img-desc {
+  position: relative;
+  z-index: 1;
 }
 
 .intro-header.big-img .page-heading,


### PR DESCRIPTION
Noticed on our example site. Quite distracting once you see it.

Assisted-by: OpenCode:glm-5.1
