### PR TITLE
feat: add callouts

### DIFF
--- a/exampleSite/content/page/markdown-extensions.md
+++ b/exampleSite/content/page/markdown-extensions.md
@@ -1,10 +1,10 @@
 ---
 title: Markdown Extensions
-subtitle: Callout boxes, utility classes, and theme-dependent content
+subtitle: Utility classes and theme-dependent content
 comments: false
 ---
 
-Beautiful Hugo provides several CSS classes that extend standard Markdown with callout boxes, theme-dependent visibility, and layout utilities. There are two ways to use them:
+Beautiful Hugo provides several CSS classes that extend standard Markdown with theme-dependent visibility and layout utilities. There are two ways to use them:
 
 {{< tabs groupId="syntax" >}}
 {{< tab "Raw HTML" >}}
@@ -33,97 +33,9 @@ Both options can be enabled together. The examples below show each approach — 
 
 ## Callout Boxes
 
-Four callout box styles are available. Each has a colored left border and a distinct background.
+Callout boxes are now available as a `callout` shortcode supporting multiple paragraphs and an optional title. See [Shortcodes](../shortcodes/#callout) for full documentation and live examples.
 
-### box-note
-
-<div class="box-note">
-This is a <strong>note</strong> callout. Use it for informational asides, tips, or helpful context.
-</div>
-
-{{< tabs groupId="syntax" >}}
-{{< tab "Raw HTML" >}}
-```html
-<div class="box-note">
-This is a <strong>note</strong> callout. Use it for informational asides.
-</div>
-```
-{{< /tab >}}
-{{< tab "Block Attributes" >}}
-```markdown
-This is a **note** callout. Use it for informational asides.
-{.box-note}
-```
-{{< /tab >}}
-{{< /tabs >}}
-
-### box-warning
-
-<div class="box-warning">
-This is a <strong>warning</strong> callout. Use it to flag potential issues or important caveats.
-</div>
-
-{{< tabs groupId="syntax" >}}
-{{< tab "Raw HTML" >}}
-```html
-<div class="box-warning">
-This is a <strong>warning</strong> callout. Use it to flag potential issues.
-</div>
-```
-{{< /tab >}}
-{{< tab "Block Attributes" >}}
-```markdown
-This is a **warning** callout. Use it to flag potential issues.
-{.box-warning}
-```
-{{< /tab >}}
-{{< /tabs >}}
-
-### box-error
-
-<div class="box-error">
-This is an <strong>error</strong> callout. Use it for critical errors or dangerous actions.
-</div>
-
-{{< tabs groupId="syntax" >}}
-{{< tab "Raw HTML" >}}
-```html
-<div class="box-error">
-This is an <strong>error</strong> callout. Use it for critical errors.
-</div>
-```
-{{< /tab >}}
-{{< tab "Block Attributes" >}}
-```markdown
-This is an **error** callout. Use it for critical errors.
-{.box-error}
-```
-{{< /tab >}}
-{{< /tabs >}}
-
-### box-success
-
-<div class="box-success">
-This is a <strong>success</strong> callout. Use it for confirmation messages or completed actions.
-</div>
-
-{{< tabs groupId="syntax" >}}
-{{< tab "Raw HTML" >}}
-```html
-<div class="box-success">
-This is a <strong>success</strong> callout. Use it for confirmation messages.
-</div>
-```
-{{< /tab >}}
-{{< tab "Block Attributes" >}}
-```markdown
-This is a **success** callout. Use it for confirmation messages.
-{.box-success}
-```
-{{< /tab >}}
-{{< /tabs >}}
-
-All four boxes adapt automatically to dark mode — their backgrounds and borders shift to appropriate dark-mode colors.
+For backward compatibility, the legacy CSS classes (`.box-note`, `.box-warning`, `.box-error`, `.box-success`) still work with raw HTML or block attributes, but the shortcode is recommended.
 
 ## Content Section
 

--- a/exampleSite/content/page/shortcodes.md
+++ b/exampleSite/content/page/shortcodes.md
@@ -6,6 +6,68 @@ comments: false
 
 Beautiful Hugo ships with several shortcodes for common patterns like collapsible sections, multi-column layouts, tabbed content, image galleries, and diagrams.
 
+## callout
+
+The `callout` shortcode renders a Bootstrap alert-based callout box. It supports multiple paragraphs and an optional title. Five styles are available: `info` (default), `warning`, `danger`, `success`, and `note`.
+
+| Parameter | Position | Required | Description |
+|-----------|----------|----------|-------------|
+| type | 1 | no | Callout style: `info` (default), `warning`, `danger`, `success`, `note` |
+| title | 2 | no | Optional heading text (supports Markdown) |
+| (inner) | — | yes | The body content (supports Markdown, multiple paragraphs) |
+
+**Live examples:**
+
+{{< callout info "Information" >}}
+This is an **info** callout — the default style. Use it for helpful tips or informational asides.
+
+You can include multiple paragraphs, **formatted text**, and even code: `console.log("hello")`.
+{{< /callout >}}
+
+{{< callout warning "Caution" >}}
+This is a **warning** callout. Use it to flag potential issues or important caveats.
+{{< /callout >}}
+
+{{< callout danger "Critical" >}}
+This is a **danger** callout. Use it for critical errors or destructive actions.
+{{< /callout >}}
+
+{{< callout success "All good" >}}
+This is a **success** callout. Use it for confirmation messages or completed actions.
+{{< /callout >}}
+
+{{< callout note >}}
+This is a **note** callout — a neutral grey style for side remarks that don't fit the other categories.
+{{< /callout >}}
+
+**Source:**
+
+```markdown
+{{</* callout info "Information" */>}}
+This is an **info** callout — the default style.
+
+You can include multiple paragraphs.
+{{</* /callout */>}}
+
+{{</* callout warning "Caution" */>}}
+This is a **warning** callout.
+{{</* /callout */>}}
+
+{{</* callout danger "Critical" */>}}
+This is a **danger** callout.
+{{</* /callout */>}}
+
+{{</* callout success "All good" */>}}
+This is a **success** callout.
+{{</* /callout */>}}
+
+{{</* callout note */>}}
+This is a **note** callout (no title).
+{{</* /callout */>}}
+```
+
+The `type` parameter defaults to `info`, so `{{</* callout */>}}` is equivalent to `{{</* callout info */>}}`. The title parameter is optional — omit it for a title-less callout.
+
 ## details
 
 The `details` shortcode renders a collapsible `<details>` element. The first positional parameter is the summary text; the inner content is the body.
@@ -47,7 +109,9 @@ The `columns` and `column` shortcodes create a two-column layout using the `spli
 For historical reasons, you can also use
 `{{</* columns /*/>}} ... {{</* endcolumns */>}}`
 (note the required self-closing tag) as a backward compatibility shim.
-{.box-warning}
+{{< callout warning "Backward compatibility" >}}
+The `columns`/`endcolumns` self-closing syntax is deprecated and may be removed in a future release.
+{{< /callout >}}
 
 **Live example:**
 

--- a/exampleSite/content/post/2026-05-11-release.md
+++ b/exampleSite/content/post/2026-05-11-release.md
@@ -61,7 +61,7 @@ See [SEO & i18n](../../page/seo-and-i18n/), [Configuration](../../page/configura
 
 ### Callout Boxes
 
-Four styled callout classes (`.box-note`, `.box-warning`, `.box-error`, `.box-success`) with dark mode support. See [Markdown Extensions](../../page/markdown-extensions/).
+Five styled callout types (`info`, `warning`, `danger`, `success`, `note`) powered by Bootstrap alerts, with a new `callout` shortcode supporting multiple paragraphs and optional titles. The legacy `.box-*` CSS classes still work for backward compatibility. See [Shortcodes](../../page/shortcodes/#callout) and [Markdown Extensions](../../page/markdown-extensions/).
 
 ## Small things
 

--- a/layouts/shortcodes/callout.html
+++ b/layouts/shortcodes/callout.html
@@ -1,0 +1,10 @@
+{{- $type := .Get 0 | default "info" -}}
+{{- $title := .Get 1 -}}
+{{- $validTypes := slice "info" "warning" "danger" "success" "note" -}}
+{{- if not (in $validTypes $type) -}}
+  {{- $type = "info" -}}
+{{- end -}}
+<div class="alert alert-{{ $type }} callout" role="alert">
+{{- with $title }}<h5 class="alert-heading">{{ . | markdownify }}</h5>{{ end -}}
+{{ .Inner | markdownify }}
+</div>

--- a/static/css/dark.css
+++ b/static/css/dark.css
@@ -277,7 +277,22 @@
   background-color: var(--dark-list-bg);
 }
 
-/* --- Notification Boxes --- */
+/* --- Callout Boxes (dark mode) --- */
+[data-theme="dark"] .alert.callout {
+  border-color: var(--dark-surface);
+}
+
+[data-theme="dark"] .alert-note {
+  background-color: #2d2f31;
+  border-color: #495057;
+  color: #adb5bd;
+}
+
+[data-theme="dark"] .alert-note .alert-heading {
+  color: #ced4da;
+}
+
+/* Backward-compatible box-* dark aliases */
 [data-theme="dark"] .box-note,
 [data-theme="dark"] .box-warning,
 [data-theme="dark"] .box-error,
@@ -286,23 +301,27 @@
 }
 
 [data-theme="dark"] .box-note {
-  background-color: #152535;
-  border-left-color: #2980b9;
+  background-color: #2d2f31;
+  border-left-color: #6c757d;
+  color: #adb5bd;
 }
 
 [data-theme="dark"] .box-warning {
   background-color: #2d2515;
-  border-left-color: #f1c40f;
+  border-left-color: #ffc107;
+  color: #ffc107;
 }
 
 [data-theme="dark"] .box-error {
   background-color: #2d1515;
-  border-left-color: #c0392b;
+  border-left-color: #dc3545;
+  color: #f1aeb5;
 }
 
 [data-theme="dark"] .box-success {
   background-color: #142d14;
-  border-left-color: #3CB371;
+  border-left-color: #198754;
+  color: #a3cfbb;
 }
 
 /* Theme-dependent visibility (usable for mermaid diagrams, image pairs, etc.) */

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1064,47 +1064,76 @@ table tr td :last-child {
   font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 
-/* --- Notification Boxes --- */
+/* --- Callout Boxes (Bootstrap alert-based) --- */
 
+.alert.callout {
+  border-left-width: 5px;
+  border-radius: 5px 3px 3px 5px;
+  margin: 20px 0;
+}
+
+.alert.callout .alert-heading {
+  font-size: 1rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.alert-note {
+  color: #383d41;
+  background-color: #e2e3e5;
+  border-color: #d6d8db;
+}
+
+.alert-note .alert-heading {
+  color: #2b2f32;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .alert.callout {
+    /* No animation/transition */
+  }
+}
+
+/* Backward-compatible box-* aliases */
 .box-note,
 .box-warning,
 .box-error,
 .box-success {
-  padding: 15px 20px;
+  padding: 1rem 1.25rem;
   margin: 20px 0;
-  border: 1px solid #eee;
+  border: 1px solid transparent;
   border-left-width: 5px;
   border-radius: 5px 3px 3px 5px;
 }
 
 .box-note {
-  background-color: #eee;
-  border-left-color: #2980b9;
+  color: #383d41;
+  background-color: #e2e3e5;
+  border-color: #d6d8db;
+  border-left-color: #6c757d;
 }
 
 .box-warning {
-  background-color: #fdf5d4;
-  border-left-color: #f1c40f;
+  color: #664d03;
+  background-color: #fff3cd;
+  border-color: #ffc107;
+  border-left-color: #ffc107;
 }
 
 .box-error {
-  background-color: #f4dddb;
-  border-left-color: #c0392b;
+  color: #58151c;
+  background-color: #f8d7da;
+  border-color: #dc3545;
+  border-left-color: #dc3545;
 }
 
 .box-success {
-  background-color: #98FB98;
-  border-left-color: #3CB371;
+  color: #0a3622;
+  background-color: #d1e7dd;
+  border-color: #198754;
+  border-left-color: #198754;
 }
-
-@media (prefers-reduced-motion: reduce) {
-  .box-note,
-  .box-warning,
-  .box-error,
-  .box-success {
-    /* No animation/transition */
-  }
-}
+.box-success { composes: alert alert-success callout; }
 
 /* --- Card / Accordion --- */
 


### PR DESCRIPTION
The box- classes could not easily be applied to multiple items. Adding a shortcode and using the built-in callouts instead of custom classes (mostly).

Assisted-by: OpenCode:glm-5.1
