### PR TITLE
fix: make TOML a bit more colorful

### DIFF
--- a/exampleSite/content/page/code-blocks.md
+++ b/exampleSite/content/page/code-blocks.md
@@ -81,7 +81,7 @@ def fibonacci(n):
 ```
 
 ```go
-# go
+// go
 package main
 
 import "fmt"

--- a/static/css/syntax-dark.css
+++ b/static/css/syntax-dark.css
@@ -19,6 +19,7 @@
   --syn-name-builtin: #ffa657;
   --syn-name-variable: #79c0ff;
   --syn-name-function: #d2a8ff;
+  --syn-name-other: #d2a8ff;
   --syn-string: #a5d6ff;
   --syn-string-interpol: #a5d6ff;
   --syn-string-other: #a5d6ff;

--- a/static/css/syntax.css
+++ b/static/css/syntax.css
@@ -19,6 +19,7 @@
   --syn-name-builtin: #e36209;
   --syn-name-variable: #005cc5;
   --syn-name-function: #6f42c1;
+  --syn-name-other: #6f42c1;
   --syn-string: #032f62;
   --syn-string-interpol: #032f62;
   --syn-string-other: #032f62;
@@ -115,3 +116,8 @@
 /* GenericTraceback */ .chroma .gt { color:var(--syn-traceback) }
 /* GenericUnderline */ .chroma .gl { text-decoration:underline }
 /* TextWhitespace */ .chroma .w { color:var(--syn-whitespace) }
+/* Error */ .chroma .err { color:var(--syn-error) }
+/* NameOther */ .chroma .nx { color:var(--syn-name-other) }
+/* NameProperty */ .chroma .py { color:var(--syn-name-attr) }
+/* Punctuation */ .chroma .p { color:var(--syn-fg) }
+/* OperatorReserved */ .chroma .or { color:var(--syn-operator) }


### PR DESCRIPTION
Chroma doesn't break up headers in TOML, so this is halfway closer to github's coloring.

Assisted-by: OpenCode:glm-5.1
