### PR TITLE
fix: support multiple authors properly

### DIFF
--- a/exampleSite/content/post/2015-01-04-first-post.md
+++ b/exampleSite/content/post/2015-01-04-first-post.md
@@ -1,5 +1,6 @@
 ---
 title: First post!
+author: "[Michael Henderson](https://example.com)"
 date: 2015-01-05
 categories: ["personal"]
 tags: ["personal", "intro", "tutorial"]

--- a/exampleSite/content/post/2015-02-13-hamlet-monologue.md
+++ b/exampleSite/content/post/2015-02-13-hamlet-monologue.md
@@ -1,6 +1,7 @@
 ---
 title: To be
 subtitle: ... or not to be?
+author: "William Shakespeare"
 date: 2015-02-13
 categories: ["literature"]
 tags: ["literature", "history"]

--- a/exampleSite/content/post/2015-02-20-test-markdown.md
+++ b/exampleSite/content/post/2015-02-20-test-markdown.md
@@ -1,6 +1,9 @@
 ---
 title: Test markdown
 subtitle: Each post also has a subtitle
+author:
+  - "[Michael Henderson](https://example.com)"
+  - "[Jane Doe](https://example.com)"
 date: 2015-02-20
 categories: ["tutorial"]
 tags: ["example", "markdown", "tutorial"]

--- a/exampleSite/content/post/2015-02-26-flake-it-till-you-make-it.md
+++ b/exampleSite/content/post/2015-02-26-flake-it-till-you-make-it.md
@@ -1,6 +1,7 @@
 ---
 title: Flake it till you make it
 subtitle: Excerpt from Soulshaping by Jeff Brown
+author: "Jeff Brown"
 date: 2015-02-26
 categories: ["personal"]
 tags: ["literature", "personal"]

--- a/exampleSite/content/post/2026-05-11-release.md
+++ b/exampleSite/content/post/2026-05-11-release.md
@@ -1,6 +1,10 @@
 ---
 title: Beautiful Hugo Bootstrap 5 upgrade!
 subtitle: Dark mode toggle, PhotoSwipe 5, AI summary limits, new shortcodes, and more
+author:
+  - "[Michael Henderson](https://example.com)"
+  - "[Jane Doe](https://example.com)"
+  - "[John Smith](https://example.com)"
 date: 2026-05-11
 categories: ["release"]
 tags: ["release", "hugo", "theme"]

--- a/layouts/partials/author_list.html
+++ b/layouts/partials/author_list.html
@@ -1,0 +1,24 @@
+{{- $authors := slice -}}
+{{- if .Params.author -}}
+  {{- if reflect.IsSlice .Params.author -}}
+    {{- range .Params.author -}}
+      {{- $name := . | markdownify | plainify -}}
+      {{- $url := "" -}}
+      {{- with findRE `href="([^"]+)"` (. | markdownify) -}}
+        {{- $url = replaceRE `href="([^"]+)"` "$1" (index . 0) -}}
+      {{- end -}}
+      {{- $authors = $authors | append (dict "name" $name "url" $url) -}}
+    {{- end -}}
+  {{- else -}}
+    {{- $name := .Params.author | markdownify | plainify -}}
+    {{- $url := "" -}}
+    {{- with findRE `href="([^"]+)"` (.Params.author | markdownify) -}}
+      {{- $url = replaceRE `href="([^"]+)"` "$1" (index . 0) -}}
+    {{- end -}}
+    {{- $authors = $authors | append (dict "name" $name "url" $url) -}}
+  {{- end -}}
+{{- else if .Site.Params.author.name -}}
+  {{- $url := .Site.Params.author.website | default "" -}}
+  {{- $authors = $authors | append (dict "name" (.Site.Params.author.name | markdownify | plainify) "url" $url) -}}
+{{- end -}}
+{{- return $authors -}}

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -28,17 +28,10 @@
     &nbsp;|&nbsp;<i class="fas fa-book"></i>&nbsp;{{ .WordCount }}&nbsp;{{ i18n "words" }}
   {{ end }}
   {{ if not .Site.Params.hideAuthor }}
-    {{ if .Params.author }}
-      {{ if reflect.IsSlice .Params.author }}
-        {{ range .Params.author }}
-          &nbsp;|&nbsp;<i class="fas fa-user"></i>&nbsp;{{ . | safeHTML }}
-	{{ end }}
-      {{ else }}
-        &nbsp;|&nbsp;<i class="fas fa-user"></i>&nbsp;{{ .Params.author | safeHTML }}
-      {{ end }}
-    {{ else }}
-      &nbsp;|&nbsp;<i class="fas fa-user"></i>&nbsp;{{ .Site.Params.author.name | safeHTML }}
-    {{ end }}
+    {{- $authors := partial "author_list.html" . -}}
+    {{- range $authors -}}
+      &nbsp;|&nbsp;<i class="fas fa-user"></i>&nbsp;{{ if .url }}<a href="{{ .url }}">{{ .name }}</a>{{ else }}{{ .name }}{{ end }}
+    {{- end -}}
   {{ end }}
   {{- if .Site.Params.staticman -}}
     &nbsp;|&nbsp;<i class="fas fa-comment"></i>&nbsp;

--- a/layouts/partials/seo/structured/article.html
+++ b/layouts/partials/seo/structured/article.html
@@ -10,16 +10,27 @@
   {{- $keywords = $keywords | append . -}}
 {{- end -}}
 
+{{- $authors := partial "author_list.html" . -}}
+{{- $authorSchema := slice -}}
+{{- range $authors -}}
+  {{- $a := dict
+    "@type" "Person"
+    "name" .name
+    "url" (or .url $.Site.BaseURL)
+    "@id" (printf "%s#author" $.Site.BaseURL)
+  -}}
+  {{- $authorSchema = $authorSchema | append $a -}}
+{{- end -}}
+{{- if eq (len $authorSchema) 1 -}}
+  {{- $authorSchema = index $authorSchema 0 -}}
+{{- end -}}
+
 {{- $schema := dict
   "@context" "https://schema.org"
   "@type" "Article"
   "@id" (printf "%s#article" .Permalink)
   "isPartOf" (dict "@id" .Permalink)
-  "author" (dict
-    "name" (.Params.author | default .Site.Params.author.name)
-    "url" .Site.BaseURL
-    "@id" (printf "%s#author" .Site.BaseURL)
-  )
+  "author" $authorSchema
   "headline" .Title
   "description" $description
   "inLanguage" .Lang

--- a/layouts/partials/seo/structured/post.html
+++ b/layouts/partials/seo/structured/post.html
@@ -10,17 +10,31 @@
   },
   "description" : "{{ if .Description }}{{ .Description | plainify }}{{ else }}{{if .IsPage}}{{ .Summary | plainify  }}{{ end }}{{ end }}",
   "inLanguage" : "{{ .Lang }}",
-  {{ if .Params.author -}}
-    "author": {
-      "@type": "Person",
-      "name": "{{ .Params.author }}"
-  },
-  {{- else if .Site.Params.author.name -}}
-    "author": {
-      "@type": "Person",
-      "name": "{{ .Site.Params.author.name }}"
-  },
-  {{- end }}
+  {{- $authors := partial "author_list.html" . -}}
+  {{- if $authors -}}
+    {{- if gt (len $authors) 1 -}}
+      "author": [
+        {{- range $i, $a := $authors -}}
+          {{- if gt $i 0 }},{{ end -}}
+          {
+            "@type": "Person",
+            "name": "{{ $a.name | safeJS }}"
+            {{- with $a.url -}},
+            "url": "{{ . | safeJS }}"
+            {{- end -}}
+          }
+        {{- end -}}
+      ],
+    {{- else -}}
+      "author": {
+        "@type": "Person",
+        "name": "{{ (index $authors 0).name | safeJS }}"
+        {{- with (index $authors 0).url -}},
+        "url": "{{ . | safeJS }}"
+        {{- end -}}
+      },
+    {{- end -}}
+  {{- end -}}
   "copyrightYear" : "{{ .Site.Params.since }} - {{ .Site.Lastmod.Format "2006" }}",
   {{ if not .PublishDate.IsZero -}}
     "datePublished": "{{ .PublishDate.Format "2006-01-02T15:04:05-07:00" | safeHTML }}",

--- a/layouts/partials/seo/structured/recipe.html
+++ b/layouts/partials/seo/structured/recipe.html
@@ -27,16 +27,27 @@
   {{- $instructions = $instructions | append $s -}}
 {{- end -}}
 
+{{- $authors := partial "author_list.html" . -}}
+{{- $authorSchema := slice -}}
+{{- range $authors -}}
+  {{- $a := dict
+    "@type" "Person"
+    "name" .name
+    "url" (or .url $.Site.BaseURL)
+    "@id" (printf "%s#author" $.Site.BaseURL)
+  -}}
+  {{- $authorSchema = $authorSchema | append $a -}}
+{{- end -}}
+{{- if eq (len $authorSchema) 1 -}}
+  {{- $authorSchema = index $authorSchema 0 -}}
+{{- end -}}
+
 {{- $schema := dict
   "@context" "https://schema.org"
   "@type" (slice "Article" "Recipe")
   "@id" (printf "%s#recipe" .Permalink)
   "isPartOf" (dict "@id" .Permalink)
-  "author" (dict
-    "name" (.Params.author | default .Site.Params.author.name)
-    "url" .Site.BaseURL
-    "@id" (printf "%s#author" .Site.BaseURL)
-  )
+  "author" $authorSchema
   "headline" .Title
   "description" $description
   "inLanguage" .Lang


### PR DESCRIPTION
Also supports using markdown links in author feilds

Close #454. Adding author pages (close #678) is a much bigger change, and has some decisions (like if using `content/authors`, the taximony has issues, if using data, then it's harder to add a custom body). Just improving the existing feature (which didn't handle lists correctly in SEO) is better for now.

Assisted-by: OpenCode:glm-5.1
Signed-off-by: Henry Schreiner <henryfs@princeton.edu>
