### PR TITLE
feat: include code shortcode

### DIFF
--- a/exampleSite/content/page/code-blocks.md
+++ b/exampleSite/content/page/code-blocks.md
@@ -177,6 +177,32 @@ def process(data):
 
 Every code block automatically gets a **copy-to-clipboard** button in the top-right corner. Hover over any code block on this page to see it. The button strips line numbers before copying.
 
+## Including External Files
+
+The `include-code` shortcode reads a source file from your project and renders it with syntax highlighting. It respects the same Chroma/HLJS setting as fenced code blocks.
+
+```
+{{</* include-code file="hugo.toml" */>}}
+```
+
+With explicit language and line options (Chroma only):
+
+```
+{{</* include-code file="hugo.toml" language="toml" linenos="table" hl_lines="3-5" */>}}
+```
+
+### Live example
+
+This page includes the example site's own `hugo.toml`:
+
+{{< include-code file="hugo.toml" >}}
+
+With line numbers and highlighted lines:
+
+{{< include-code file="hugo.toml" linenos="table" hl_lines="7 23-28" >}}
+
+The `file` path is relative to the Hugo project root. If `language` is omitted, it is auto-detected from the file extension. See [Configuration](../configuration/#including-external-files) for the full parameter reference.
+
 ## Inline Code
 
 Use backticks for inline code: `hugo serve -D` or `console.log("hello")`.

--- a/exampleSite/content/page/configuration.md
+++ b/exampleSite/content/page/configuration.md
@@ -188,6 +188,26 @@ When `useHLJS = true`, Highlight.js is loaded from CDN (or `static/js/highlight.
 
 See [Code Blocks](../code-blocks/) for details and examples.
 
+### Including External Files
+
+The `include-code` shortcode reads a source file from disk and renders it with syntax highlighting. It works with both Chroma and Highlight.js.
+
+```
+{{</* include-code file="content/scripts/example.py" */>}}
+{{</* include-code file="config.toml" language="toml" */>}}
+{{</* include-code file="src/main.go" linenos="table" hl_lines="2 5-8" */>}}
+```
+
+| Param | Required | Description |
+|-------|----------|-------------|
+| `file` | yes | Path relative to the Hugo project root |
+| `language` | no | Highlighting language (auto-detected from file extension if omitted; falls back to plain text) |
+| `linenos` | no | `"table"` or `"inline"` — Chroma only; ignored with a warning when `useHLJS = true` |
+| `hl_lines` | no | Lines to highlight, e.g. `"2 5-8"` — Chroma only |
+| `linenostart` | no | Starting line number — Chroma only |
+
+**Supported auto-detect extensions:** `.bash`, `.c`, `.cpp`, `.css`, `.go`, `.html`, `.java`, `.js`, `.json`, `.jsx`, `.lua`, `.md`, `.php`, `.pl`, `.py`, `.r`, `.rb`, `.rs`, `.scss`, `.sh`, `.sql`, `.svg`, `.toml`, `.ts`, `.tsx`, `.xml`, `.yaml`, `.yml`, `.zig`
+
 ## Comment Systems
 
 Beautiful Hugo supports five comment systems. Each is enabled per-page with `comments: true` in front matter.

--- a/exampleSite/content/page/shortcodes.md
+++ b/exampleSite/content/page/shortcodes.md
@@ -420,3 +420,37 @@ This text is wrapped in `data-nosnippet` and should not appear in search engine 
 ```
 
 See [SEO & i18n](../seo-and-i18n/) for the full robot meta tags and AI summary limit configuration.
+
+## include-code
+
+The `include-code` shortcode reads a source file from disk and renders it with syntax highlighting. It works with both Chroma (default) and Highlight.js.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `file` | string | yes | Path relative to the Hugo project root |
+| `language` | string | no | Highlighting language (auto-detected from file extension if omitted) |
+| `linenos` | string | no | `"table"` or `"inline"` — Chroma only |
+| `hl_lines` | string | no | Lines to highlight, e.g. `"2 5-8"` — Chroma only |
+| `linenostart` | string | no | Starting line number — Chroma only |
+
+**Live example — auto-detected TOML:**
+
+{{< include-code file="hugo.toml" >}}
+
+**Live example — with line numbers and highlighted lines:**
+
+{{< include-code file="hugo.toml" linenos="table" hl_lines="7 23-28" >}}
+
+**Source:**
+
+```markdown
+{{</* include-code file="hugo.toml" */>}}
+
+{{</* include-code file="hugo.toml" linenos="table" hl_lines="7 23-28" */>}}
+```
+
+When `useHLJS = true`, the shortcode emits `<pre><code class="language-xxx">` for client-side highlighting; `linenos`, `hl_lines`, and `linenostart` are ignored with a build warning.
+
+**Supported auto-detect extensions:** `.bash`, `.c`, `.cpp`, `.css`, `.go`, `.html`, `.java`, `.js`, `.json`, `.jsx`, `.lua`, `.md`, `.php`, `.pl`, `.py`, `.r`, `.rb`, `.rs`, `.scss`, `.sh`, `.sql`, `.svg`, `.toml`, `.ts`, `.tsx`, `.xml`, `.yaml`, `.yml`, `.zig`
+
+See [Code Blocks](../code-blocks/) for more syntax highlighting examples.

--- a/layouts/shortcodes/include-code.html
+++ b/layouts/shortcodes/include-code.html
@@ -1,0 +1,73 @@
+{{- $file := .Get "file" -}}
+{{- if not $file -}}
+  {{- errorf "include-code: missing required 'file' parameter" -}}
+{{- end -}}
+
+{{- $lang := .Get "language" -}}
+{{- if not $lang -}}
+  {{- $ext := path.Ext $file -}}
+  {{- $extMap := dict
+    ".bash" "bash"
+    ".c" "c"
+    ".cpp" "cpp"
+    ".css" "css"
+    ".go" "go"
+    ".html" "html"
+    ".java" "java"
+    ".js" "javascript"
+    ".json" "json"
+    ".jsx" "jsx"
+    ".lua" "lua"
+    ".md" "markdown"
+    ".php" "php"
+    ".pl" "perl"
+    ".py" "python"
+    ".r" "r"
+    ".rb" "ruby"
+    ".rs" "rust"
+    ".scss" "scss"
+    ".sh" "bash"
+    ".sql" "sql"
+    ".svg" "xml"
+    ".toml" "toml"
+    ".ts" "typescript"
+    ".tsx" "tsx"
+    ".xml" "xml"
+    ".yaml" "yaml"
+    ".yml" "yaml"
+    ".zig" "zig"
+  -}}
+  {{- $lang = index $extMap $ext | default "" -}}
+{{- end -}}
+
+{{- $content := readFile $file -}}
+{{- if not $content -}}
+  {{- errorf "include-code: file '%s' not found or empty" $file -}}
+{{- end -}}
+
+{{- $useHLJS := .Page.Site.Params.useHLJS | default false -}}
+
+{{- if $useHLJS -}}
+  {{- with .Get "linenos" -}}
+    {{- warnf "include-code: 'linenos' is not supported when useHLJS=true (file: %s)" $file -}}
+  {{- end -}}
+  {{- with .Get "hl_lines" -}}
+    {{- warnf "include-code: 'hl_lines' is not supported when useHLJS=true (file: %s)" $file -}}
+  {{- end -}}
+  {{- with .Get "linenostart" -}}
+    {{- warnf "include-code: 'linenostart' is not supported when useHLJS=true (file: %s)" $file -}}
+  {{- end -}}
+  <pre><code{{ with $lang }} class="language-{{ . }}"{{ end }}>{{ $content }}</code></pre>
+{{- else -}}
+  {{- $opts := dict -}}
+  {{- with .Get "linenos" -}}
+    {{- $opts = merge $opts (dict "linenos" .) -}}
+  {{- end -}}
+  {{- with .Get "hl_lines" -}}
+    {{- $opts = merge $opts (dict "hl_lines" .) -}}
+  {{- end -}}
+  {{- with .Get "linenostart" -}}
+    {{- $opts = merge $opts (dict "linenostart" (int .)) -}}
+  {{- end -}}
+  {{- highlight $content $lang $opts -}}
+{{- end -}}


### PR DESCRIPTION
Adding an include-code shortcode. Supports both formatters.

Assisted-by: OpenCode:glm-5.1
