### PR TITLE
fix: staticman comment alignment and rendering

### DIFF
--- a/layouts/partials/staticman-comments.html
+++ b/layouts/partials/staticman-comments.html
@@ -33,7 +33,7 @@
           <h4 class="comment-author">{{ .name }}</h4>
           {{ end }}
           <div class="comment-timestamp"><a href="#comment-{{ $.Store.Get "hasComments" }}" title="Permalink to this comment"><time datetime="{{ .date }}">{{ time.Format (default (i18n "shortdateFormat") .Site.Params.dateformat) .date }}</time></a></div>
-          <div class="comment-content"><p>{{ .comment | markdownify }}</p></div>
+          <div class="comment-content">{{ .comment | markdownify }}</div>
         </article>
       {{ end }}
     {{ end }}

--- a/static/css/staticman.css
+++ b/static/css/staticman.css
@@ -7,7 +7,7 @@
   padding: 4px 0px 30px 0px;
 }
 
-.staticman-comments .comment-content p {
+.staticman-comments .comment-content * {
   padding: 5px 0px 5px 0px;
   margin: 5px 58px 0px 58px;
 }


### PR DESCRIPTION
🤖

## Summary

Fix Staticman comment display issues: alignment mismatch for non-`<p>` HTML elements and broken rendering when `markdownify` produces block-level content.

## Changes

- **CSS**: Changed `.staticman-comments .comment-content p` to `.comment-content *` so all child elements (lists, headings, etc.) get consistent padding/margin, not just `<p>` tags.
- **Template**: Removed wrapping `<p>` around `{{ .comment | markdownify }}` in `staticman-comments.html`. Since `markdownify` can produce block-level elements, nesting them inside `<p>` is invalid HTML and causes browsers to break element nesting, losing the `.comment-content` styling.

Closes #221, Closes #254

Assisted-by: OpenCode:GLM-5