### PR TITLE
feat: add i18n support for navbar menu items

### DIFF
--- a/exampleSite/content/page/seo-and-i18n.md
+++ b/exampleSite/content/page/seo-and-i18n.md
@@ -172,7 +172,7 @@ A language switcher appears in the navbar:
 
 ### Supported Languages
 
-Beautiful Hugo ships with translations for 19 languages:
+Beautiful Hugo ships with translations for 20 languages:
 
 | Code | Language |
 |------|----------|
@@ -191,6 +191,8 @@ Beautiful Hugo ships with translations for 19 languages:
 | `nb` | Norwegian Bokmål |
 | `nl` | Dutch |
 | `pl` | Polish |
+| `pt` | Portuguese |
+| `pt-br` | Portuguese (Brazil) |
 | `ru` | Russian |
 | `tr` | Turkish |
 | `zh-CN` | Chinese (Simplified) |
@@ -214,6 +216,37 @@ The i18n files provide translations for common UI strings:
 | `seeAlso` | "See also" related posts heading |
 
 To add a new language, create a new file in `i18n/` (e.g. `i18n/pt.yaml` for Portuguese) with translations for these keys.
+
+### Navbar Menu Translations
+
+Navbar menu items are automatically translated when the menu entry has an `identifier` that matches an i18n key with the `menu_` prefix. If no matching translation key exists, the menu `name` from `hugo.toml` is used as a fallback.
+
+For example, given this menu config:
+
+```toml
+[[menu.main]]
+    identifier = "blog"
+    name = "Blog"
+    weight = 1
+
+[[menu.main]]
+    parent = "blog"
+    name = "Posts"
+    identifier = "post"
+    url = "post/"
+    weight = 1
+```
+
+The theme looks up `menu_blog` and `menu_post` in the current language's i18n file. In French (`i18n/fr.yaml`):
+
+```yaml
+- id: menu_blog
+  translation: "Blog"
+- id: menu_post
+  translation: "Articles"
+```
+
+The theme ships with pre-built translations for common menu items (blog, posts, tags, categories, archives, about, and the example-site section names). You can add your own `menu_*` keys to your site's i18n overrides to translate custom menu items.
 
 ## RSS
 

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -101,6 +101,47 @@
 # View source
 - id: viewSource
   translation: "Quelltext anzeigen"
+
+# Menu items / Menüpunkte
+- id: menu_setup
+  translation: "Einrichtung"
+- id: menu_configuration
+  translation: "Konfiguration"
+- id: menu_layout-options
+  translation: "Layout-Optionen"
+- id: menu_theming
+  translation: "Theming"
+- id: menu_seo-and-i18n
+  translation: "SEO & i18n"
+- id: menu_comments-and-social
+  translation: "Kommentare & Social"
+- id: menu_features
+  translation: "Funktionen"
+- id: menu_pages-and-layouts
+  translation: "Seiten & Layouts"
+- id: menu_shortcodes
+  translation: "Shortcodes"
+- id: menu_code-blocks
+  translation: "Code-Blöcke"
+- id: menu_markdown-extensions
+  translation: "Markdown-Erweiterungen"
+- id: menu_figures-and-galleries
+  translation: "Abbildungen & Galerien"
+- id: menu_math-and-diagrams
+  translation: "Mathe & Diagramme"
+- id: menu_blog
+  translation: "Blog"
+- id: menu_post
+  translation: "Beiträge"
+- id: menu_tags
+  translation: "Tags"
+- id: menu_categories
+  translation: "Kategorien"
+- id: menu_archives
+  translation: "Archiv"
+- id: menu_about
+  translation: "Über"
+
 # Recipe / Rezept
 - id: recipePrepTime
   translation: "Vorbereitungszeit"

--- a/i18n/dk.yaml
+++ b/i18n/dk.yaml
@@ -101,6 +101,47 @@
 # View source
 - id: viewSource
   translation: "Vis kilde"
+
+# Menu items / Menupunkter
+- id: menu_setup
+  translation: "Opsætning"
+- id: menu_configuration
+  translation: "Konfiguration"
+- id: menu_layout-options
+  translation: "Layoutindstillinger"
+- id: menu_theming
+  translation: "Temaer"
+- id: menu_seo-and-i18n
+  translation: "SEO og i18n"
+- id: menu_comments-and-social
+  translation: "Kommentarer og sociale"
+- id: menu_features
+  translation: "Funktioner"
+- id: menu_pages-and-layouts
+  translation: "Sider og layout"
+- id: menu_shortcodes
+  translation: "Shortcodes"
+- id: menu_code-blocks
+  translation: "Kodeblokke"
+- id: menu_markdown-extensions
+  translation: "Markdown-udvidelser"
+- id: menu_figures-and-galleries
+  translation: "Figurer og gallerier"
+- id: menu_math-and-diagrams
+  translation: "Matematik og diagrammer"
+- id: menu_blog
+  translation: "Blog"
+- id: menu_post
+  translation: "Indlæg"
+- id: menu_tags
+  translation: "Tags"
+- id: menu_categories
+  translation: "Kategorier"
+- id: menu_archives
+  translation: "Arkiv"
+- id: menu_about
+  translation: "Om"
+
 # Recipe / Opskrift
 - id: recipePrepTime
   translation: "Forberedelsestid"

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -101,6 +101,46 @@
 # View source
 - id: viewSource
   translation: "View source"
+# Menu items
+- id: menu_setup
+  translation: "Setup"
+- id: menu_configuration
+  translation: "Configuration"
+- id: menu_layout-options
+  translation: "Layout Options"
+- id: menu_theming
+  translation: "Theming"
+- id: menu_seo-and-i18n
+  translation: "SEO & i18n"
+- id: menu_comments-and-social
+  translation: "Comments & Social"
+- id: menu_features
+  translation: "Features"
+- id: menu_pages-and-layouts
+  translation: "Pages & Layouts"
+- id: menu_shortcodes
+  translation: "Shortcodes"
+- id: menu_code-blocks
+  translation: "Code Blocks"
+- id: menu_markdown-extensions
+  translation: "Markdown Extensions"
+- id: menu_figures-and-galleries
+  translation: "Figures & Galleries"
+- id: menu_math-and-diagrams
+  translation: "Math & Diagrams"
+- id: menu_blog
+  translation: "Blog"
+- id: menu_post
+  translation: "Posts"
+- id: menu_tags
+  translation: "Tags"
+- id: menu_categories
+  translation: "Categories"
+- id: menu_archives
+  translation: "Archives"
+- id: menu_about
+  translation: "About"
+
 # Recipe
 - id: recipePrepTime
   translation: "Prep Time"

--- a/i18n/eo.yaml
+++ b/i18n/eo.yaml
@@ -101,6 +101,46 @@
 # View source
 - id: viewSource
   translation: "Vidi fonton"
+# Menu items / Menueroj
+- id: menu_setup
+  translation: "Agordo"
+- id: menu_configuration
+  translation: "Konfiguracio"
+- id: menu_layout-options
+  translation: "Aranĝaj opcioj"
+- id: menu_theming
+  translation: "Temoj"
+- id: menu_seo-and-i18n
+  translation: "SEO kaj i18n"
+- id: menu_comments-and-social
+  translation: "Komentoj kaj sociaj"
+- id: menu_features
+  translation: "Funkcioj"
+- id: menu_pages-and-layouts
+  translation: "Paĝoj kaj aranĝoj"
+- id: menu_shortcodes
+  translation: "Mallongaj kodoj"
+- id: menu_code-blocks
+  translation: "Kodblokoj"
+- id: menu_markdown-extensions
+  translation: "Markdown-kromaĵoj"
+- id: menu_figures-and-galleries
+  translation: "Figuroj kaj galerioj"
+- id: menu_math-and-diagrams
+  translation: "Matematiko kaj diagramoj"
+- id: menu_blog
+  translation: "Blogo"
+- id: menu_post
+  translation: "Afiŝoj"
+- id: menu_tags
+  translation: "Etikedoj"
+- id: menu_categories
+  translation: "Kategorioj"
+- id: menu_archives
+  translation: "Arĥivo"
+- id: menu_about
+  translation: "Pri"
+
 # Recipe / Recepto
 - id: recipePrepTime
   translation: "Prepara tempo"

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -101,6 +101,47 @@
 # View source
 - id: viewSource
   translation: "Ver fuente"
+
+# Menu items / Elementos del menú
+- id: menu_setup
+  translation: "Configuración"
+- id: menu_configuration
+  translation: "Configuración del sitio"
+- id: menu_layout-options
+  translation: "Opciones de diseño"
+- id: menu_theming
+  translation: "Temas"
+- id: menu_seo-and-i18n
+  translation: "SEO e i18n"
+- id: menu_comments-and-social
+  translation: "Comentarios y redes"
+- id: menu_features
+  translation: "Características"
+- id: menu_pages-and-layouts
+  translation: "Páginas y diseños"
+- id: menu_shortcodes
+  translation: "Shortcodes"
+- id: menu_code-blocks
+  translation: "Bloques de código"
+- id: menu_markdown-extensions
+  translation: "Extensiones de Markdown"
+- id: menu_figures-and-galleries
+  translation: "Figuras y galerías"
+- id: menu_math-and-diagrams
+  translation: "Matemáticas y diagramas"
+- id: menu_blog
+  translation: "Blog"
+- id: menu_post
+  translation: "Artículos"
+- id: menu_tags
+  translation: "Etiquetas"
+- id: menu_categories
+  translation: "Categorías"
+- id: menu_archives
+  translation: "Archivo"
+- id: menu_about
+  translation: "Acerca de"
+
 # Recipe / Receta
 - id: recipePrepTime
   translation: "Tiempo de preparación"

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -101,6 +101,46 @@
 # View source
 - id: viewSource
   translation: "Voir la source"
+# Menu items / Éléments du menu
+- id: menu_setup
+  translation: "Installation"
+- id: menu_configuration
+  translation: "Configuration"
+- id: menu_layout-options
+  translation: "Options de mise en page"
+- id: menu_theming
+  translation: "Thèmes"
+- id: menu_seo-and-i18n
+  translation: "SEO et i18n"
+- id: menu_comments-and-social
+  translation: "Commentaires et réseaux"
+- id: menu_features
+  translation: "Fonctionnalités"
+- id: menu_pages-and-layouts
+  translation: "Pages et mises en page"
+- id: menu_shortcodes
+  translation: "Shortcodes"
+- id: menu_code-blocks
+  translation: "Blocs de code"
+- id: menu_markdown-extensions
+  translation: "Extensions Markdown"
+- id: menu_figures-and-galleries
+  translation: "Figures et galeries"
+- id: menu_math-and-diagrams
+  translation: "Maths et diagrammes"
+- id: menu_blog
+  translation: "Blog"
+- id: menu_post
+  translation: "Articles"
+- id: menu_tags
+  translation: "Tags"
+- id: menu_categories
+  translation: "Catégories"
+- id: menu_archives
+  translation: "Archives"
+- id: menu_about
+  translation: "À propos"
+
 # Recipe / Recette
 - id: recipePrepTime
   translation: "Préparation"

--- a/i18n/hr.yaml
+++ b/i18n/hr.yaml
@@ -101,6 +101,46 @@
 # View source
 - id: viewSource
   translation: "Prikaži izvor"
+# Menu items / Stavke izbornika
+- id: menu_setup
+  translation: "Postavljanje"
+- id: menu_configuration
+  translation: "Konfiguracija"
+- id: menu_layout-options
+  translation: "Opcije izgleda"
+- id: menu_theming
+  translation: "Teme"
+- id: menu_seo-and-i18n
+  translation: "SEO i i18n"
+- id: menu_comments-and-social
+  translation: "Komentari i društvene mreže"
+- id: menu_features
+  translation: "Značajke"
+- id: menu_pages-and-layouts
+  translation: "Stranice i izgledi"
+- id: menu_shortcodes
+  translation: "Shortcodeovi"
+- id: menu_code-blocks
+  translation: "Blokovi koda"
+- id: menu_markdown-extensions
+  translation: "Markdown proširenja"
+- id: menu_figures-and-galleries
+  translation: "Slike i galerije"
+- id: menu_math-and-diagrams
+  translation: "Matematika i dijagrami"
+- id: menu_blog
+  translation: "Blog"
+- id: menu_post
+  translation: "Objave"
+- id: menu_tags
+  translation: "Oznake"
+- id: menu_categories
+  translation: "Kategorije"
+- id: menu_archives
+  translation: "Arhiva"
+- id: menu_about
+  translation: "O nama"
+
 # Recipe / Recept
 - id: recipePrepTime
   translation: "Vrijeme pripreme"

--- a/i18n/it.yaml
+++ b/i18n/it.yaml
@@ -101,6 +101,46 @@
 # View source
 - id: viewSource
   translation: "Vedi sorgente"
+# Menu items / Voci di menu
+- id: menu_setup
+  translation: "Configurazione"
+- id: menu_configuration
+  translation: "Impostazioni"
+- id: menu_layout-options
+  translation: "Opzioni di layout"
+- id: menu_theming
+  translation: "Temi"
+- id: menu_seo-and-i18n
+  translation: "SEO e i18n"
+- id: menu_comments-and-social
+  translation: "Commenti e social"
+- id: menu_features
+  translation: "Funzionalità"
+- id: menu_pages-and-layouts
+  translation: "Pagine e layout"
+- id: menu_shortcodes
+  translation: "Shortcode"
+- id: menu_code-blocks
+  translation: "Blocchi di codice"
+- id: menu_markdown-extensions
+  translation: "Estensioni Markdown"
+- id: menu_figures-and-galleries
+  translation: "Figure e gallerie"
+- id: menu_math-and-diagrams
+  translation: "Matematica e diagrammi"
+- id: menu_blog
+  translation: "Blog"
+- id: menu_post
+  translation: "Articoli"
+- id: menu_tags
+  translation: "Tag"
+- id: menu_categories
+  translation: "Categorie"
+- id: menu_archives
+  translation: "Archivio"
+- id: menu_about
+  translation: "Chi siamo"
+
 # Recipe / Ricetta
 - id: recipePrepTime
   translation: "Preparazione"

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -101,6 +101,46 @@
 # View source
 - id: viewSource
   translation: "ソースを見る"
+# Menu items / メニュー項目
+- id: menu_setup
+  translation: "セットアップ"
+- id: menu_configuration
+  translation: "設定"
+- id: menu_layout-options
+  translation: "レイアウトオプション"
+- id: menu_theming
+  translation: "テーマ設定"
+- id: menu_seo-and-i18n
+  translation: "SEO & i18n"
+- id: menu_comments-and-social
+  translation: "コメント & ソーシャル"
+- id: menu_features
+  translation: "機能"
+- id: menu_pages-and-layouts
+  translation: "ページ & レイアウト"
+- id: menu_shortcodes
+  translation: "ショートコード"
+- id: menu_code-blocks
+  translation: "コードブロック"
+- id: menu_markdown-extensions
+  translation: "Markdown拡張"
+- id: menu_figures-and-galleries
+  translation: "図表 & ギャラリー"
+- id: menu_math-and-diagrams
+  translation: "数式 & 図解"
+- id: menu_blog
+  translation: "ブログ"
+- id: menu_post
+  translation: "投稿"
+- id: menu_tags
+  translation: "タグ"
+- id: menu_categories
+  translation: "カテゴリー"
+- id: menu_archives
+  translation: "アーカイブ"
+- id: menu_about
+  translation: "概要"
+
 # Recipe / レシピ
 - id: recipePrepTime
   translation: "準備時間"

--- a/i18n/ko.yaml
+++ b/i18n/ko.yaml
@@ -101,6 +101,47 @@
 # View source
 - id: viewSource
   translation: "소스 보기"
+
+# Menu items / 메뉴 항목
+- id: menu_setup
+  translation: "설정"
+- id: menu_configuration
+  translation: "구성"
+- id: menu_layout-options
+  translation: "레이아웃 옵션"
+- id: menu_theming
+  translation: "테마 설정"
+- id: menu_seo-and-i18n
+  translation: "SEO & i18n"
+- id: menu_comments-and-social
+  translation: "댓글 & 소셜"
+- id: menu_features
+  translation: "기능"
+- id: menu_pages-and-layouts
+  translation: "페이지 & 레이아웃"
+- id: menu_shortcodes
+  translation: "숏코드"
+- id: menu_code-blocks
+  translation: "코드 블록"
+- id: menu_markdown-extensions
+  translation: "마크다운 확장"
+- id: menu_figures-and-galleries
+  translation: "그림 & 갤러리"
+- id: menu_math-and-diagrams
+  translation: "수식 & 다이어그램"
+- id: menu_blog
+  translation: "블로그"
+- id: menu_post
+  translation: "게시물"
+- id: menu_tags
+  translation: "태그"
+- id: menu_categories
+  translation: "카테고리"
+- id: menu_archives
+  translation: "아카이브"
+- id: menu_about
+  translation: "소개"
+
 # Recipe / 레시피
 - id: recipePrepTime
   translation: "준비 시간"

--- a/i18n/lmo.yaml
+++ b/i18n/lmo.yaml
@@ -197,6 +197,84 @@
 # View source
 - id: viewSource
   translation: "Varda surgaent"
+# Menu items / Vos del menu
+
+- id: menu_setup
+
+  translation: "Configurazion"
+
+- id: menu_configuration
+
+  translation: "Impostazion"
+
+- id: menu_layout-options
+
+  translation: "Opzion de layout"
+
+- id: menu_theming
+
+  translation: "Temi"
+
+- id: menu_seo-and-i18n
+
+  translation: "SEO e i18n"
+
+- id: menu_comments-and-social
+
+  translation: "Comment e sociai"
+
+- id: menu_features
+
+  translation: "Funzion"
+
+- id: menu_pages-and-layouts
+
+  translation: "Pagine e layout"
+
+- id: menu_shortcodes
+
+  translation: "Shortcode"
+
+- id: menu_code-blocks
+
+  translation: "Bloch de codes"
+
+- id: menu_markdown-extensions
+
+  translation: "Estension Markdown"
+
+- id: menu_figures-and-galleries
+
+  translation: "Figure e gallerij"
+
+- id: menu_math-and-diagrams
+
+  translation: "Matematega e diagram"
+
+- id: menu_blog
+
+  translation: "Blog"
+
+- id: menu_post
+
+  translation: "Articoi"
+
+- id: menu_tags
+
+  translation: "Tag"
+
+- id: menu_categories
+
+  translation: "Categurij"
+
+- id: menu_archives
+
+  translation: "Archivi"
+
+- id: menu_about
+
+  translation: "Informazion"
+
 # Recipe / Ricetta
 - id: recipePrepTime
   translation: "Temp de preparazzion"

--- a/i18n/nb.yaml
+++ b/i18n/nb.yaml
@@ -101,6 +101,46 @@
 # View source
 - id: viewSource
   translation: "Vis kilde"
+# Menu items / Menyelementer
+- id: menu_setup
+  translation: "Oppsett"
+- id: menu_configuration
+  translation: "Konfigurasjon"
+- id: menu_layout-options
+  translation: "Layoutalternativer"
+- id: menu_theming
+  translation: "Temaer"
+- id: menu_seo-and-i18n
+  translation: "SEO og i18n"
+- id: menu_comments-and-social
+  translation: "Kommentarer og sosialt"
+- id: menu_features
+  translation: "Funksjoner"
+- id: menu_pages-and-layouts
+  translation: "Sider og layout"
+- id: menu_shortcodes
+  translation: "Shortcodes"
+- id: menu_code-blocks
+  translation: "Kodeblokker"
+- id: menu_markdown-extensions
+  translation: "Markdown-utvidelser"
+- id: menu_figures-and-galleries
+  translation: "Figurer og gallerier"
+- id: menu_math-and-diagrams
+  translation: "Matte og diagrammer"
+- id: menu_blog
+  translation: "Blogg"
+- id: menu_post
+  translation: "Innlegg"
+- id: menu_tags
+  translation: "Tags"
+- id: menu_categories
+  translation: "Kategorier"
+- id: menu_archives
+  translation: "Arkiv"
+- id: menu_about
+  translation: "Om"
+
 # Recipe / Oppskrift
 - id: recipePrepTime
   translation: "Forberedelsestid"

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -101,6 +101,47 @@
 # View source
 - id: viewSource
   translation: "Bron bekijken"
+
+# Menu items / Menu-items
+- id: menu_setup
+  translation: "Installatie"
+- id: menu_configuration
+  translation: "Configuratie"
+- id: menu_layout-options
+  translation: "Indelingsopties"
+- id: menu_theming
+  translation: "Thema's"
+- id: menu_seo-and-i18n
+  translation: "SEO en i18n"
+- id: menu_comments-and-social
+  translation: "Reacties en sociaal"
+- id: menu_features
+  translation: "Functies"
+- id: menu_pages-and-layouts
+  translation: "Pagina's en indelingen"
+- id: menu_shortcodes
+  translation: "Shortcodes"
+- id: menu_code-blocks
+  translation: "Codeblokken"
+- id: menu_markdown-extensions
+  translation: "Markdown-extensies"
+- id: menu_figures-and-galleries
+  translation: "Afbeeldingen en galerijen"
+- id: menu_math-and-diagrams
+  translation: "Wiskunde en diagrammen"
+- id: menu_blog
+  translation: "Blog"
+- id: menu_post
+  translation: "Berichten"
+- id: menu_tags
+  translation: "Tags"
+- id: menu_categories
+  translation: "Categorieën"
+- id: menu_archives
+  translation: "Archief"
+- id: menu_about
+  translation: "Over"
+
 # Recipe / Recept
 - id: recipePrepTime
   translation: "Voorbereidingstijd"

--- a/i18n/pl.yaml
+++ b/i18n/pl.yaml
@@ -101,6 +101,47 @@
 # View source
 - id: viewSource
   translation: "Pokaż źródło"
+
+# Menu items / Pozycje menu
+- id: menu_setup
+  translation: "Konfiguracja"
+- id: menu_configuration
+  translation: "Ustawienia"
+- id: menu_layout-options
+  translation: "Opcje układu"
+- id: menu_theming
+  translation: "Motywy"
+- id: menu_seo-and-i18n
+  translation: "SEO i i18n"
+- id: menu_comments-and-social
+  translation: "Komentarze i społeczność"
+- id: menu_features
+  translation: "Funkcje"
+- id: menu_pages-and-layouts
+  translation: "Strony i układy"
+- id: menu_shortcodes
+  translation: "Shortcodes"
+- id: menu_code-blocks
+  translation: "Bloki kodu"
+- id: menu_markdown-extensions
+  translation: "Rozszerzenia Markdown"
+- id: menu_figures-and-galleries
+  translation: "Ilustracje i galerie"
+- id: menu_math-and-diagrams
+  translation: "Matematyka i diagramy"
+- id: menu_blog
+  translation: "Blog"
+- id: menu_post
+  translation: "Wpisy"
+- id: menu_tags
+  translation: "Tagi"
+- id: menu_categories
+  translation: "Kategorie"
+- id: menu_archives
+  translation: "Archiwum"
+- id: menu_about
+  translation: "O nas"
+
 # Recipe / Przepis
 - id: recipePrepTime
   translation: "Czas przygotowania"

--- a/i18n/pt-br.yaml
+++ b/i18n/pt-br.yaml
@@ -101,6 +101,46 @@
 # View source
 - id: viewSource
   translation: "Ver fonte"
+# Menu items / Itens do menu
+- id: menu_setup
+  translation: "Configuração"
+- id: menu_configuration
+  translation: "Configuração do site"
+- id: menu_layout-options
+  translation: "Opções de layout"
+- id: menu_theming
+  translation: "Temas"
+- id: menu_seo-and-i18n
+  translation: "SEO e i18n"
+- id: menu_comments-and-social
+  translation: "Comentários e social"
+- id: menu_features
+  translation: "Funcionalidades"
+- id: menu_pages-and-layouts
+  translation: "Páginas e layouts"
+- id: menu_shortcodes
+  translation: "Shortcodes"
+- id: menu_code-blocks
+  translation: "Blocos de código"
+- id: menu_markdown-extensions
+  translation: "Extensões Markdown"
+- id: menu_figures-and-galleries
+  translation: "Figuras e galerias"
+- id: menu_math-and-diagrams
+  translation: "Matemática e diagramas"
+- id: menu_blog
+  translation: "Blog"
+- id: menu_post
+  translation: "Postagens"
+- id: menu_tags
+  translation: "Tags"
+- id: menu_categories
+  translation: "Categorias"
+- id: menu_archives
+  translation: "Arquivo"
+- id: menu_about
+  translation: "Sobre"
+
 # Recipe / Receita
 - id: recipePrepTime
   translation: "Tempo de preparo"

--- a/i18n/pt.yaml
+++ b/i18n/pt.yaml
@@ -101,6 +101,46 @@
 # View source
 - id: viewSource
   translation: "Ver fonte"
+# Menu items / Itens do menu
+- id: menu_setup
+  translation: "Configuração"
+- id: menu_configuration
+  translation: "Configuração do site"
+- id: menu_layout-options
+  translation: "Opções de layout"
+- id: menu_theming
+  translation: "Temas"
+- id: menu_seo-and-i18n
+  translation: "SEO e i18n"
+- id: menu_comments-and-social
+  translation: "Comentários e social"
+- id: menu_features
+  translation: "Funcionalidades"
+- id: menu_pages-and-layouts
+  translation: "Páginas e layouts"
+- id: menu_shortcodes
+  translation: "Shortcodes"
+- id: menu_code-blocks
+  translation: "Blocos de código"
+- id: menu_markdown-extensions
+  translation: "Extensões Markdown"
+- id: menu_figures-and-galleries
+  translation: "Figuras e galerias"
+- id: menu_math-and-diagrams
+  translation: "Matemática e diagramas"
+- id: menu_blog
+  translation: "Blog"
+- id: menu_post
+  translation: "Artigos"
+- id: menu_tags
+  translation: "Etiquetas"
+- id: menu_categories
+  translation: "Categorias"
+- id: menu_archives
+  translation: "Arquivo"
+- id: menu_about
+  translation: "Sobre"
+
 # Recipe / Receita
 - id: recipePrepTime
   translation: "Tempo de preparação"

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -101,6 +101,46 @@
 # View source
 - id: viewSource
   translation: "Посмотреть исходник"
+# Menu items / Пункты меню
+- id: menu_setup
+  translation: "Настройка"
+- id: menu_configuration
+  translation: "Конфигурация"
+- id: menu_layout-options
+  translation: "Параметры макета"
+- id: menu_theming
+  translation: "Темы"
+- id: menu_seo-and-i18n
+  translation: "SEO и i18n"
+- id: menu_comments-and-social
+  translation: "Комментарии и соцсети"
+- id: menu_features
+  translation: "Возможности"
+- id: menu_pages-and-layouts
+  translation: "Страницы и макеты"
+- id: menu_shortcodes
+  translation: "Шорткоды"
+- id: menu_code-blocks
+  translation: "Блоки кода"
+- id: menu_markdown-extensions
+  translation: "Расширения Markdown"
+- id: menu_figures-and-galleries
+  translation: "Иллюстрации и галереи"
+- id: menu_math-and-diagrams
+  translation: "Математика и диаграммы"
+- id: menu_blog
+  translation: "Блог"
+- id: menu_post
+  translation: "Записи"
+- id: menu_tags
+  translation: "Теги"
+- id: menu_categories
+  translation: "Категории"
+- id: menu_archives
+  translation: "Архив"
+- id: menu_about
+  translation: "О сайте"
+
 # Recipe / Рецепт
 - id: recipePrepTime
   translation: "Время подготовки"

--- a/i18n/tr.yaml
+++ b/i18n/tr.yaml
@@ -101,6 +101,46 @@
 # View source
 - id: viewSource
   translation: "Kaynağı görüntüle"
+# Menu items / Menü öğeleri
+- id: menu_setup
+  translation: "Kurulum"
+- id: menu_configuration
+  translation: "Yapılandırma"
+- id: menu_layout-options
+  translation: "Düzen seçenekleri"
+- id: menu_theming
+  translation: "Temalar"
+- id: menu_seo-and-i18n
+  translation: "SEO ve i18n"
+- id: menu_comments-and-social
+  translation: "Yorumlar ve sosyal"
+- id: menu_features
+  translation: "Özellikler"
+- id: menu_pages-and-layouts
+  translation: "Sayfalar ve düzenler"
+- id: menu_shortcodes
+  translation: "Kısa kodlar"
+- id: menu_code-blocks
+  translation: "Kod blokları"
+- id: menu_markdown-extensions
+  translation: "Markdown uzantıları"
+- id: menu_figures-and-galleries
+  translation: "Şekiller ve galeriler"
+- id: menu_math-and-diagrams
+  translation: "Matematik ve diyagramlar"
+- id: menu_blog
+  translation: "Blog"
+- id: menu_post
+  translation: "Yazılar"
+- id: menu_tags
+  translation: "Etiketler"
+- id: menu_categories
+  translation: "Kategoriler"
+- id: menu_archives
+  translation: "Arşiv"
+- id: menu_about
+  translation: "Hakkında"
+
 # Recipe / Tarif
 - id: recipePrepTime
   translation: "Hazırlık süresi"

--- a/i18n/zh-CN.yaml
+++ b/i18n/zh-CN.yaml
@@ -101,6 +101,46 @@
 # View source
 - id: viewSource
   translation: "查看源文件"
+
+# Menu items / 菜单项
+- id: menu_setup
+  translation: "设置"
+- id: menu_configuration
+  translation: "配置"
+- id: menu_layout-options
+  translation: "布局选项"
+- id: menu_theming
+  translation: "主题"
+- id: menu_seo-and-i18n
+  translation: "SEO 与国际化"
+- id: menu_comments-and-social
+  translation: "评论与社交"
+- id: menu_features
+  translation: "功能"
+- id: menu_pages-and-layouts
+  translation: "页面与布局"
+- id: menu_shortcodes
+  translation: "短代码"
+- id: menu_code-blocks
+  translation: "代码块"
+- id: menu_markdown-extensions
+  translation: "Markdown 扩展"
+- id: menu_figures-and-galleries
+  translation: "图片与画廊"
+- id: menu_math-and-diagrams
+  translation: "数学与图表"
+- id: menu_blog
+  translation: "博客"
+- id: menu_post
+  translation: "文章"
+- id: menu_tags
+  translation: "标签"
+- id: menu_categories
+  translation: "分类"
+- id: menu_archives
+  translation: "归档"
+- id: menu_about
+  translation: "关于"
 # Recipe / 食谱
 - id: recipePrepTime
   translation: "准备时间"

--- a/i18n/zh-TW.yaml
+++ b/i18n/zh-TW.yaml
@@ -101,6 +101,47 @@
 # View source
 - id: viewSource
   translation: "檢視原始檔案"
+
+# Menu items / 選單項目
+- id: menu_setup
+  translation: "設定"
+- id: menu_configuration
+  translation: "配置"
+- id: menu_layout-options
+  translation: "版面選項"
+- id: menu_theming
+  translation: "主題"
+- id: menu_seo-and-i18n
+  translation: "SEO 與國際化"
+- id: menu_comments-and-social
+  translation: "留言與社交"
+- id: menu_features
+  translation: "功能"
+- id: menu_pages-and-layouts
+  translation: "頁面與版面"
+- id: menu_shortcodes
+  translation: "短代碼"
+- id: menu_code-blocks
+  translation: "程式碼區塊"
+- id: menu_markdown-extensions
+  translation: "Markdown 擴展"
+- id: menu_figures-and-galleries
+  translation: "圖片與畫廊"
+- id: menu_math-and-diagrams
+  translation: "數學與圖表"
+- id: menu_blog
+  translation: "部落格"
+- id: menu_post
+  translation: "文章"
+- id: menu_tags
+  translation: "標籤"
+- id: menu_categories
+  translation: "分類"
+- id: menu_archives
+  translation: "歸檔"
+- id: menu_about
+  translation: "關於"
+
 # Recipe / 食譜
 - id: recipePrepTime
   translation: "準備時間"

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -36,20 +36,36 @@
     <div class="collapse navbar-collapse" id="main-navbar">
       <ul class="navbar-nav ms-auto">
         {{ range .Site.Menus.main.ByWeight }}
+          {{ $name := .Name }}
+          {{ with .Identifier }}
+            {{ $key := printf "menu_%s" . }}
+            {{ $translated := i18n $key }}
+            {{ if ne $translated $key }}
+              {{ $name = $translated }}
+            {{ end }}
+          {{ end }}
           {{ if .HasChildren }}
             <li class="nav-item dropdown" >
               <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                {{ .Name }}
+                {{ $name }}
               </a>
               <ul class="dropdown-menu dropdown-menu-end">
                 {{ range .Children }}
-                  <li><a class="dropdown-item" href="{{ .URL | relLangURL }}">{{ .Name }}</a></li>
+                  {{ $childName := .Name }}
+                  {{ with .Identifier }}
+                    {{ $key := printf "menu_%s" . }}
+                    {{ $translated := i18n $key }}
+                    {{ if ne $translated $key }}
+                      {{ $childName = $translated }}
+                    {{ end }}
+                  {{ end }}
+                  <li><a class="dropdown-item" href="{{ .URL | relLangURL }}">{{ $childName }}</a></li>
                 {{ end }}
               </ul>
             </li>
           {{ else }}
             <li class="nav-item" >
-              <a class="nav-link" title="{{ .Name }}" href="{{ .URL  | relLangURL }}">{{ .Name }}</a>
+              <a class="nav-link" title="{{ $name }}" href="{{ .URL  | relLangURL }}">{{ $name }}</a>
             </li>
           {{ end }}
         {{ end }}


### PR DESCRIPTION
:robot:

## Summary

Adds multilingual translation support for navbar menu items, closing #319.

The navbar now looks up `menu_<identifier>` i18n keys for each menu entry that has an `identifier` field. If a translation exists in the current language's i18n file, it replaces the configured menu `name`; otherwise the `name` is used as a fallback. This works for both top-level and dropdown child items.

## Changes

- **`layouts/partials/nav.html`** — When rendering menu items, looks up `menu_<identifier>` i18n key. Falls back to `.Name` if no translation found.
- **`i18n/*.yaml`** (all 20 language files) — Added `menu_*` translation keys for common items: `blog`, `post`, `tags`, `categories`, `archives`, `about`, and the example-site section names (`setup`, `configuration`, `layout-options`, `theming`, `seo-and-i18n`, `comments-and-social`, `features`, `pages-and-layouts`, `shortcodes`, `code-blocks`, `markdown-extensions`, `figures-and-galleries`, `math-and-diagrams`).
- **`exampleSite/content/page/seo-and-i18n.md`** — Added "Navbar Menu Translations" section documenting how `identifier` fields map to `menu_*` i18n keys. Also added `pt-br` to the supported languages table (now 20 total).

## Usage

Set `identifier` on menu entries and add matching `menu_*` keys to i18n files:

```toml
[[menu.main]]
    identifier = "blog"
    name = "Blog"
    weight = 1
```

```yaml
# i18n/fr.yaml
- id: menu_blog
  translation: "Blog"
- id: menu_post
  translation: "Articles"
```

Assisted-by: OpenCode:GLM-5