### PR TITLE
fix: fallback to .Name when menu i18n key is missing

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -40,7 +40,7 @@
           {{ with .Identifier }}
             {{ $key := printf "menu_%s" . }}
             {{ $translated := i18n $key }}
-            {{ if ne $translated $key }}
+            {{ if and $translated (ne $translated $key) }}
               {{ $name = $translated }}
             {{ end }}
           {{ end }}
@@ -55,7 +55,7 @@
                   {{ with .Identifier }}
                     {{ $key := printf "menu_%s" . }}
                     {{ $translated := i18n $key }}
-                    {{ if ne $translated $key }}
+                    {{ if and $translated (ne $translated $key) }}
                       {{ $childName = $translated }}
                     {{ end }}
                   {{ end }}


### PR DESCRIPTION
:robot: *Human triggerd, AI assisted PR. AI text below.* :robot:

## Summary

When Hugo's `i18n` function can't find a translation key, it returns an empty string rather than the key itself. The existing check (`ne $translated $key`) evaluated to `true` for empty strings, causing untranslated menu items to display as blank instead of falling back to the original `.Name` value.

## Changes

- Added `and $translated` guard to both the top-level menu item and child menu item i18n checks in `layouts/partials/nav.html`
- Empty translations are now rejected, so `.Name` is used as the fallback when no i18n key exists

Fixes the regression introduced in #720.

Assisted-by: OpenCode:GLM-5