### PR TITLE
fix: resolve page-relative paths in figure shortcodes

### DIFF
--- a/layouts/partials/shortcodes/beautifulfigure.html
+++ b/layouts/partials/shortcodes/beautifulfigure.html
@@ -9,6 +9,9 @@ Based on hugo-easy-gallery by Li-Wen Yip: https://github.com/liwenyip/hugo-easy-
 {{- $thumb := .Get "src" | default (printf "%s." (.Get "thumb") | replace (.Get "link") ".") }}
 {{- $src := .Get "link" | default (.Get "src") }}
 {{- $size := .Get "size" }}
+{{- $pageRel := .Page.RelPermalink }}
+{{- $thumb = cond (or (strings.HasPrefix $thumb "/") (strings.HasPrefix $thumb "http")) $thumb (print $pageRel $thumb) }}
+{{- $src = cond (or (strings.HasPrefix $src "/") (strings.HasPrefix $src "http")) $src (print $pageRel $src) }}
 <div class="box fancy-figure caption-position-{{ .Get "caption-position" | default "bottom" }}{{ with .Get "caption-effect" }} caption-effect-{{.}}{{end}}{{ with .Get "class" }} {{ . }}{{ end }}" {{ with .Get "width" }}style="max-width:{{.}}"{{end}}>
   <figure {{- with .Get "class" }} class="{{.}}"{{ end }} itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject">
     <div class="img"{{ if .Parent }} style="background-image: url('{{ $thumb | relURL }}');"{{ end }}{{ with $size }} data-size="{{.}}"{{ end }}>

--- a/layouts/partials/shortcodes/figure.html
+++ b/layouts/partials/shortcodes/figure.html
@@ -2,6 +2,8 @@
 <figure{{ with .Get "class" }} class="{{ . }}"{{ end }}>
   {{- $src := .Get "src" }}
   {{- $thumb := .Get "link" | default $src }}
+  {{- $pageRel := .Page.RelPermalink }}
+  {{- $thumb = cond (or (strings.HasPrefix $thumb "/") (strings.HasPrefix $thumb "http")) $thumb (print $pageRel $thumb) }}
   <img src="{{ $thumb | relURL }}"
        {{- with .Get "alt" }} alt="{{ . }}"{{ end }}
        {{- with .Get "title" }} title="{{ . }}"{{ end }}


### PR DESCRIPTION
:robot: *Human triggered, AI assisted PR. AI text below.* :robot:

## Summary

Relative image paths in figure shortcodes (e.g. `images/fig.png` without a leading `/`) are broken. This regressed when `print .Site.BaseURL` was replaced with `relURL` in #688/#710/#711.

## Problem

`relURL` treats all paths as site-root-relative, so `images/fig.png` becomes `/images/fig.png`. For page bundles, the image actually lives at `/post/name-of-post/images/fig.png`.

## Fix

Prepend `.Page.RelPermalink` to paths that don't start with `/` or `http`, restoring correct page-bundle image resolution. This applies to both `beautifulfigure` and the plain `figure` shortcode.

Assisted-by: OpenCode:glm-5