### PR TITLE
fix: add intro-header spacer to 404 page for navbar clearance

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,5 +1,6 @@
 {{ define "header" }}<!-- No header on 404 pages -->{{ end }}
 {{ define "main" }}
+  <div class="intro-header"></div>
   <div role="main" class="container main-content">
     <div class="text-center">
       <h1 class="error-emoji"></h1>


### PR DESCRIPTION
:robot: *Human triggerd, AI assisted PR. AI text below.* :robot:

## Summary

- The 404 template skips the header partial, so it lacked the `intro-header` div that provides `margin-top` to push content below the fixed navbar.
- On narrow/mobile viewports the navbar overlapped the 404 text.
- Adding an empty `intro-header` div matches the fallback output of the header partial (line 88 of `header.html`) and restores proper spacing.

Assisted-by: OpenCode:GLM-5