### PR TITLE
docs: fix noimageindex typo and document undocumented features

### DIFF
--- a/exampleSite/content/_index.md
+++ b/exampleSite/content/_index.md
@@ -36,7 +36,7 @@ title: Beautiful Hugo
 - 42 social icon links
 - GitHub buttons
 - SEO (schema.org, Open Graph, Twitter Cards)
-- 19 languages
+- 20 languages
 {{< /columns >}}
 
 Browse the **Features** menu above for detailed documentation with live examples!

--- a/exampleSite/content/page/comments-and-social.md
+++ b/exampleSite/content/page/comments-and-social.md
@@ -130,11 +130,19 @@ ghCount: true
 
 | Param | Type | Default | Description |
 |-------|------|---------|-------------|
-| `ghRepo` | string | — | GitHub repo in `owner/repo` format |
-| `ghBadge` | list | — | Which buttons to show: `star`, `watch`, `fork`, `follow` |
-| `ghCount` | bool | `true` | Show count numbers on buttons |
+| `ghRepo` | string | — | GitHub repo in `owner/repo` format (per-page front matter only) |
+| `ghBadge` | list | — | Which buttons to show: `star`, `watch`, `fork`, `follow`. Can be set per-page or site-wide via `Params.ghBadge` |
+| `ghCount` | bool | `true` | Show count numbers on buttons. Can be set per-page or site-wide via `Params.ghCount` |
 
 The buttons are loaded from [ghbtns.com](https://ghbtns.com) via lightweight iframes.
+
+You can also set `ghBadge` and `ghCount` site-wide so they apply to every page that has a `ghRepo`:
+
+```toml
+[Params]
+  ghBadge = ["star", "fork"]
+  ghCount = true
+```
 
 ## Footer Social Icons
 

--- a/exampleSite/content/page/configuration.md
+++ b/exampleSite/content/page/configuration.md
@@ -13,9 +13,9 @@ This page is a complete reference for every configuration option in Beautiful Hu
 | `homeTitle` | string | site title | Separate title for the home page header |
 | `subtitle` | string | `""` | Site subtitle shown under the home page title |
 | `mainSections` | list | `["post", "posts"]` | Content sections treated as "posts" on the home page and archive page |
-| `logo` | string | — | Path to a square avatar/logo image |
+| `logo` | string | — | Path to a square avatar/logo image. When the file is found via Hugo's asset pipeline (`resources.Get`), it is automatically processed into WebP format (300×300, quality 100) for optimal loading. If the file is not found as a resource, the raw path is used as-is. |
 | `favicon` | string | — | Path to favicon |
-| `dateFormat` | string | i18n default | Date format string. Accepts Hugo locale tokens (e.g. `":date_long"`, `":date_medium"`, `":date_short"`) for automatic localization, or a Go time layout string based on the reference time `Mon Jan 2 15:04:05 MST 2006` (e.g. `"January 2, 2006"` or `"2006-01-02"`). **Do not use an example date** like `"2023-10-15"` — the year must be `2006`, month `01`, and day `02`. Locale tokens are recommended for multilingual sites. |
+| `dateFormat` | string | i18n default | Date format string. Accepts Hugo locale tokens (e.g. `":date_long"`, `":date_medium"`, `":date_short"`) for automatic localization, or a Go time layout string based on the reference time `Mon Jan 2 15:04:05 MST 2006` (e.g. `"January 2, 2006"` or `"2006-01-02"`). **Do not use an example date** like `"2023-10-15"` — the year must be `2006`, month `01`, and day `02`. Locale tokens are recommended for multilingual sites. The theme validates `dateFormat` at build time and will emit a build error if it detects an invalid format (e.g. a date that doesn't use Go's reference time). |
 | `since` | int | — | Start year for copyright range (e.g. `2015 - 2026`) |
 
 ```toml
@@ -137,6 +137,16 @@ When `selfHosted = true`, the following assets are served from `static/` instead
   showSource = true
   sourceRepo = "https://github.com/user/repo/blob/main/"
 ```
+
+### Table of Contents Panel
+
+When `toc = true` (the default), a list-style button appears in the navbar on pages that have headings or list pages that have posts. Clicking it opens a slide-out panel on the left side of the viewport.
+
+**On single pages** (posts, regular pages), the panel shows the page's heading hierarchy extracted from the Table of Contents. An `IntersectionObserver` tracks which heading is currently in view and highlights the corresponding link in the panel.
+
+**On list and home pages**, the panel shows a list of post titles instead of headings. Scrolling through the post previews automatically highlights the currently visible post in the panel.
+
+The panel can be closed by clicking the close button, clicking the backdrop overlay, or pressing `Escape`.
 
 ## Big Image Header
 
@@ -394,7 +404,9 @@ These options can be set in the front matter of any page or post:
 | `image` | string | Post preview image (circular, shown in list pages) |
 | `video` | string | Post preview video (loop, autoplay, muted) |
 | `summary` | string | Custom summary text |
-| `author` | string/list | Per-page author(s) (string or list of strings) |
+| `description` | string | Page description for meta tags and structured data (see [SEO & i18n — Description Cascade](../seo-and-i18n/#description-cascade)) |
+| `type` | string | Content type that determines template behavior: `"page"`, `"post"`, or `"recipe"` (see [Pages & Layouts](../pages-and-layouts/)) |
+| `author` | string/list | Per-page author(s) (string or list of strings; supports Markdown links, e.g. `"[Jane Doe](https://example.com)"`) |
 | `tags` | list | Tags for categorization |
 | `categories` | list | Categories for grouping posts |
 | `share_img` | string | Social sharing image (falls back to `image` then `logo`) |

--- a/exampleSite/content/page/pages-and-layouts.md
+++ b/exampleSite/content/page/pages-and-layouts.md
@@ -173,6 +173,19 @@ The `layout` key in front matter selects an alternative template from `layouts/_
 | `list` | `list.html` — force the list template on a page |
 | `terms` | `terms.html` — force the taxonomy terms template |
 
+## Archetypes
+
+Beautiful Hugo ships with archetypes (content templates) that pre-fill front matter when you create new content with `hugo new`:
+
+| Command | Archetype | Front Matter Included |
+|---------|-----------|-----------------------|
+| `hugo new post/my-post.md` | `post.md` | `title`, `subtitle`, `date`, `draft`, `author`, `description`, `categories`, `tags`, `bigimg`, `comments` |
+| `hugo new page/my-page.md` | `page.md` | `title`, `subtitle`, `date`, `draft`, `description`, `comments`, `fullWidth` |
+| `hugo new recipe/my-recipe.md` | `recipe.md` | `title`, `type: recipe`, `date`, `subtitle`, `image`, `tags`, `recipe` map |
+| `hugo new <section>/foo.md` | `default.md` | `title`, `date`, `draft` |
+
+Hugo selects the archetype based on the content section. If the section directory matches an archetype name (e.g. `post/`, `page/`, `recipe/`), that archetype is used. Otherwise the `default.md` archetype is used.
+
 ## Layout Options
 
 Several front matter options affect how a page looks regardless of its kind. See [Layout Options](../layout-options/) for the full reference.

--- a/exampleSite/content/page/seo-and-i18n.md
+++ b/exampleSite/content/page/seo-and-i18n.md
@@ -18,7 +18,25 @@ The theme automatically generates JSON-LD structured data for every page:
 | `Article` | Blog posts | Headline, author, datePublished, dateModified, publisher, wordCount, timeRequired |
 | `BreadcrumbList` | All pages | Navigation hierarchy |
 
-No configuration is required — the structured data is generated from your existing `hugo.toml` settings and page front matter.
+No configuration is required — the structured data is generated from your existing `hugo.toml` settings and page front matter. You can optionally customize the structured data output with the following params:
+
+### Custom Structured Data Params
+
+| Param | Schema Type | Description |
+|-------|------------|-------------|
+| `organizationName` | `Organization` | Organization name (defaults to `Params.author.name`) |
+| `organizationLogo` | `Organization` | URL of the organization logo |
+| `organizationAddress` | `Organization` | Organization address (string or structured value) |
+| `socialProfiles` | `Organization` | List of social profile URLs for the `sameAs` field |
+| `alternatePageName` | `WebSite` | Alternate name for the site (used as `alternateName`) |
+
+```toml
+[Params]
+  organizationName = "My Company"
+  organizationLogo = "https://example.com/logo.png"
+  socialProfiles = ["https://twitter.com/example", "https://github.com/example"]
+  alternatePageName = "My Company Blog"
+```
 
 ## Open Graph
 
@@ -177,7 +195,6 @@ Beautiful Hugo ships with translations for 20 languages:
 | Code | Language |
 |------|----------|
 | `en` | English |
-| `br` | Breton |
 | `de` | German |
 | `dk` | Danish |
 | `eo` | Esperanto |

--- a/exampleSite/content/page/theming.md
+++ b/exampleSite/content/page/theming.md
@@ -152,3 +152,40 @@ Because your custom partial loads last, its rules win on equal specificity. For 
 ### Overriding dark.css entirely
 
 If you want complete control over dark mode styles, you can copy `static/css/dark.css` into your site's `static/` directory and modify it. Hugo will use your version instead of the theme's.
+
+## Print Stylesheet
+
+Beautiful Hugo includes a print stylesheet (`static/css/print.css`) that is automatically applied when a user prints a page (or uses the browser's "Save as PDF" feature). It provides a clean, printer-friendly layout:
+
+- **Hidden elements**: navbar, TOC panel, comments, social share buttons, GitHub buttons, copy-code buttons, search modal, theme toggle, and big image transition animations are all hidden.
+- **Link URLs shown inline**: non-anchor, non-JavaScript links display their URL in parentheses after the link text (e.g. "Visit Hugo \[https://gohugo.io\]").
+- **Full-width layout**: container and column constraints are removed so content uses the full page width.
+- **Typography**: body text is set to 12pt with 1.5 line height; headings and paragraphs respect orphans/widows rules.
+- **Page breaks**: images, blockquotes, code blocks, and headings avoid being split across pages.
+- **Code blocks**: overflow is made visible and text wraps to avoid clipping.
+- **Dark mode reset**: dark mode backgrounds and colors are overridden to black-on-white for printing.
+- **Tab content**: tab navigation is hidden; all tab panes are displayed in sequence.
+
+No configuration is needed — the print stylesheet is loaded automatically.
+
+## Accessibility: Reduced Motion
+
+Beautiful Hugo respects the `prefers-reduced-motion` media query. When a user has enabled "Reduce motion" in their operating system settings:
+
+- **Big image cycling** is disabled — the first header image is shown without animation.
+- **CSS transitions** (fade effects, hover transitions, slide animations) are disabled.
+- **Hover effects** that rely on motion are suppressed.
+
+This behavior is automatic and requires no configuration. The theme checks `prefers-reduced-motion: reduce` in both CSS and JavaScript to provide a comfortable experience for users who are sensitive to motion.
+
+## Bootstrap Tooltips
+
+Beautiful Hugo initializes Bootstrap 5 tooltips on any element with the `data-bs-toggle="tooltip"` attribute. The theme uses tooltips internally on the navbar TOC toggle and theme toggle buttons. You can add tooltips to your own custom HTML in content or partials:
+
+```html
+<button data-bs-toggle="tooltip" data-bs-placement="top" title="Tooltip text">
+  Hover me
+</button>
+```
+
+Supported `data-bs-placement` values: `top`, `bottom`, `left`, `right`.

--- a/layouts/partials/seo/meta/meta-robots.html
+++ b/layouts/partials/seo/meta/meta-robots.html
@@ -4,7 +4,7 @@
       For tags which take values, a seperate partial will need to be created
 */}}
 {{- $robots_boolean_tags := slice "noindex" "nofollow" "none" "nosnippet" "notranslate" -}}
-{{- $robots_boolean_tags = $robots_boolean_tags | append "noimageinde" "noarchive" "nocache" "noai" "noimageai" -}}
+{{- $robots_boolean_tags = $robots_boolean_tags | append "noimageindex" "noarchive" "nocache" "noai" "noimageai" -}}
 
 {{- $site_seo := dict -}}
 {{/* Only get this value is the pae is part of a mainSection */}}


### PR DESCRIPTION
:robot: *Human triggerd, AI assisted PR. AI text below.* :robot:

## Summary

- **Bug fix**: Corrected `"noimageinde"` → `"noimageindex"` typo in `layouts/partials/seo/meta/meta-robots.html` that prevented the `noimageindex` robots meta tag from working.

## Documentation additions

A comprehensive audit of theme features vs. example site docs revealed several undocumented features. This PR documents all high and medium severity gaps:

### High severity (previously missing from docs)
- **5 SEO structured-data params**: `organizationName`, `organizationLogo`, `organizationAddress`, `socialProfiles`, `alternatePageName` — these customize JSON-LD output but users had no way to discover them
- **TOC panel UX**: the `toc` param was listed but the rich behavior (slide-out panel, IntersectionObserver scroll tracking, list-page post mode, keyboard/Escape/backdrop close) was never described
- **Print stylesheet**: `static/css/print.css` provides comprehensive print-friendly output but was never mentioned
- **`prefers-reduced-motion` support**: extensive accessibility feature was undocumented

### Medium severity (previously incomplete)
- **Language count errors**: `_index.md` said "19 languages" (should be 20), and `seo-and-i18n.md` listed a phantom "br" (Breton) entry with no corresponding `i18n/br.yaml`
- **`description` and `type`** added to per-page front matter table in `configuration.md`
- **GitHub buttons site-level defaults** (`Params.ghBadge`, `Params.ghCount`) — only per-page usage was documented
- **`author` front matter** now documents Markdown link syntax (`[Name](URL)`)
- **Avatar WebP auto-processing** in navbar documented
- **Bootstrap 5 tooltips** initialization documented
- **Archetypes** (`post.md`, `page.md`, `default.md`) — only `recipe.md` was mentioned
- **Date format validation** — build-time `errorf` safety feature documented

## Files changed

| File | Change |
|------|--------|
| `layouts/partials/seo/meta/meta-robots.html` | Fix `noimageinde` → `noimageindex` typo |
| `exampleSite/content/page/seo-and-i18n.md` | Add structured-data params section, remove phantom Breton |
| `exampleSite/content/page/configuration.md` | Add TOC panel section, `description`/`type` rows, author Markdown links, WebP processing, date validation |
| `exampleSite/content/page/theming.md` | Add print stylesheet, reduced motion, Bootstrap tooltips sections |
| `exampleSite/content/page/comments-and-social.md` | Document site-level GitHub button defaults |
| `exampleSite/content/page/pages-and-layouts.md` | Add archetypes section |
| `exampleSite/content/_index.md` | Fix language count 19 → 20 |

Assisted-by: OpenCode:GLM-5