### PR TITLE
feat: side-arrow post navigation for wide screens

### DIFF
--- a/exampleSite/content/page/configuration.md
+++ b/exampleSite/content/page/configuration.md
@@ -125,6 +125,7 @@ When `selfHosted = true`, the following assets are served from `static/` instead
 | `showPageDates` | bool | `false` | Show dates on "page" type pages |
 | `toc` | bool | `true` | Show a floating table-of-contents button on pages with headings |
 | `showSource` | bool | `false` | Show a "View source" button linking to the page's source file in the repository |
+| `showPostNav` | bool | `true` | Show previous/next post navigation (side arrows on wide screens, bottom pager on narrow screens) |
 | `sourceRepo` | string | — | Base URL for the repository source browser (e.g. `https://github.com/user/repo/blob/main/`). The page's `.File.Path` is appended automatically. When `enableGitInfo = true` is set, the branch in the URL is replaced with the current commit hash, so the link always points to the exact version of the file |
 
 ```toml
@@ -135,6 +136,7 @@ When `selfHosted = true`, the following assets are served from `static/` instead
   showRelatedPosts = true
   disableFigureOverride = true
   showSource = true
+  showPostNav = true
   sourceRepo = "https://github.com/user/repo/blob/main/"
 ```
 
@@ -419,6 +421,7 @@ These options can be set in the front matter of any page or post:
 | `navShort` | bool | Make navbar short on this page |
 | `toc` | bool | Show/hide table of contents for this page (overrides site-level `toc`) |
 | `showSource` | bool | Override site-level `showSource` for this page |
+| `showPostNav` | bool | Override site-level `showPostNav` for this page |
 | `mathEngine` | string | Override site-level `mathEngine` for this page (`"katex"`, `"mathjax"`, or `"none"`) |
 | `colorScheme` | string | Override site-level `colorScheme` for this page (`"auto"`, `"dark"`, or `"light"`) |
 | `useHLJS` | bool | Override site-level `useHLJS` for this page |
@@ -481,7 +484,7 @@ recipe:
 - **Structured data**: Pages with `type: recipe` and a `recipe` param emit a combined `Article` + `Recipe` JSON-LD block (as recommended by Google for recipe blog posts). Other pages continue to emit the standard `Article` schema.
 - **Visual rendering**: A recipe card is automatically rendered below the page body content, displaying metadata (prep time, cook time, yield, etc.), an ingredients list, and numbered instructions.
 - **Archetype**: Use `hugo new recipe/my-recipe.md` to get a pre-filled recipe front matter scaffold.
-- **Page behavior**: Recipe pages behave like blog posts (showing post meta, pager, and comments) since they are not `type: page`.
+- **Page behavior**: Recipe pages behave like blog posts (showing post meta, post navigation, and comments) since they are not `type: page`.
 
 ### ISO 8601 duration format
 

--- a/exampleSite/content/page/pages-and-layouts.md
+++ b/exampleSite/content/page/pages-and-layouts.md
@@ -44,7 +44,7 @@ Blog posts live under `content/post/` (or any directory listed in `mainSections`
 
 - Post metadata in the header (date, reading time, word count, author)
 - Subtitle rendered as an `<h2>`
-- Previous/next post pager
+- Previous/next post navigation (side arrows on wide screens, bottom pager on narrow screens; disable with `showPostNav = false`)
 - Comments (if `comments: true`)
 - Social sharing buttons
 - Related posts section
@@ -67,7 +67,7 @@ Pages under `content/page/` have type `page`. They use the same `single.html` te
 
 - No post metadata in the header
 - Subtitle rendered as a `<span>` (not a heading)
-- No previous/next pager
+- No previous/next post navigation
 - No comments (even if `comments: true`, unless the type is not `page`)
 - Dates hidden unless `showPageDates: true`
 

--- a/exampleSite/content/post/2015-01-15-pirates.md
+++ b/exampleSite/content/post/2015-01-15-pirates.md
@@ -3,6 +3,9 @@ title: Pirates arrrr
 date: 2015-01-15
 categories: ["history"]
 tags: ["humor", "history"]
+showPostNav: false
 ---
 
 Piracy is typically an act of robbery or criminal violence at sea. The term can include acts committed on land, in the air, or in other major bodies of water or on a shore. It does not normally include crimes committed against persons traveling on the same vessel as the perpetrator (e.g. one passenger stealing from others on the same vessel). The term has been used throughout history to refer to raids across land borders by non-state agents.
+
+This post has the previous/next post navigation hidden by setting `showPostNav: false` in its front matter.

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -60,7 +60,7 @@
         {{ end }}
       </article>
 
-      {{ if ne .Type "page" }}
+      {{ if and (ne .Type "page") (default true ($.Param "showPostNav")) }}
         {{ if .PrevInSection }}
           <a href="{{ .PrevInSection.Permalink }}" class="nav-side-arrow nav-side-prev" title="{{ .PrevInSection.Title }}" aria-label="{{ i18n "previousPost" }}: {{ .PrevInSection.Title }}">
             <i class="fas fa-chevron-left"></i>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -10,7 +10,6 @@
             {{ partial "recipe.html" . }}
           {{ end }}
           {{ partial "after_content.html" . }}
-          {{ partial "show-source" . }}
 
         {{ if .Params.categories }}
           <div class="blog-categories">
@@ -62,16 +61,33 @@
       </article>
 
       {{ if ne .Type "page" }}
+        {{ if .PrevInSection }}
+          <a href="{{ .PrevInSection.Permalink }}" class="nav-side-arrow nav-side-prev" title="{{ .PrevInSection.Title }}" aria-label="{{ i18n "previousPost" }}: {{ .PrevInSection.Title }}">
+            <i class="fas fa-chevron-left"></i>
+          </a>
+        {{ end }}
+        {{ if .NextInSection }}
+          <a href="{{ .NextInSection.Permalink }}" class="nav-side-arrow nav-side-next" title="{{ .NextInSection.Title }}" aria-label="{{ i18n "nextPost" }}: {{ .NextInSection.Title }}">
+            <i class="fas fa-chevron-right"></i>
+          </a>
+        {{ end }}
         <ul class="post-pager blog-post-pager">
           {{ if .PrevInSection }}
             <li class="pager-prev">
-              <a href="{{ .PrevInSection.Permalink }}" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ .PrevInSection.Title }}">&larr; {{ i18n "previousPost" }}</a>
+              <a href="{{ .PrevInSection.Permalink }}" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ .PrevInSection.Title }}"><i class="fas fa-chevron-left"></i> {{ i18n "previousPost" }}</a>
             </li>
+          {{ else }}
+            <li class="pager-prev"></li>
           {{ end }}
+          <li class="pager-center">
+            {{ partial "show-source" . }}
+          </li>
           {{ if .NextInSection }}
             <li class="pager-next">
-              <a href="{{ .NextInSection.Permalink }}" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ .NextInSection.Title }}">{{ i18n "nextPost" }} &rarr;</a>
+              <a href="{{ .NextInSection.Permalink }}" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ .NextInSection.Title }}">{{ i18n "nextPost" }} <i class="fas fa-chevron-right"></i></a>
             </li>
+          {{ else }}
+            <li class="pager-next"></li>
           {{ end }}
         </ul>
       {{ end }}

--- a/static/css/dark.css
+++ b/static/css/dark.css
@@ -95,6 +95,16 @@
 }
 
 /* --- Pager --- */
+[data-theme="dark"] .nav-side-arrow {
+  color: var(--dark-muted);
+}
+
+[data-theme="dark"] .nav-side-arrow:hover,
+[data-theme="dark"] .nav-side-arrow:focus {
+  color: var(--dark-fg);
+  background-color: rgba(255, 255, 255, 0.04);
+}
+
 [data-theme="dark"] .post-pager li a {
   background: var(--dark-surface);
   color: var(--dark-fg);

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -145,6 +145,10 @@ img::selection {
   }
 }
 
+[role="main"] {
+  padding-bottom: 2rem;
+}
+
 .main-explain-area {
   font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   padding: 15px inherit;
@@ -802,7 +806,6 @@ img::selection {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 2rem;
 }
 
 .post-pager li {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -741,7 +741,54 @@ img::selection {
   }
 }
 
-/* --- Pager --- */
+/* --- Side navigation arrows (wide screens) --- */
+
+.nav-side-arrow {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  align-content: center;
+  flex-direction: column;
+  width: 90px;
+  max-width: 150px;
+  font-size: 2.5em;
+  text-align: center;
+  text-decoration: none;
+  color: #999;
+  z-index: 50;
+  transition: color 0.2s ease, background-color 0.2s ease;
+}
+
+.nav-side-arrow:hover,
+.nav-side-arrow:focus {
+  color: #404040;
+  background-color: rgba(0, 0, 0, 0.03);
+  text-decoration: none;
+}
+
+.nav-side-prev {
+  left: 0;
+}
+
+.nav-side-next {
+  right: 0;
+}
+
+@media only screen and (min-width: 768px) {
+  .post-pager.blog-post-pager {
+    display: none;
+  }
+}
+
+@media only screen and (max-width: 767px) {
+  .nav-side-arrow {
+    display: none;
+  }
+}
+
+/* --- Pager (narrow screens) --- */
 
 .post-pager {
   padding-left: 0;
@@ -751,9 +798,33 @@ img::selection {
 }
 
 .post-pager.blog-post-pager {
-  margin-top:10px;
+  margin-top: 10px;
   display: flex;
   justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+}
+
+.post-pager li {
+  display: inline;
+}
+
+.post-pager .pager-prev > a,
+.post-pager .pager-prev > span {
+  float: left;
+}
+
+.post-pager .pager-next > a,
+.post-pager .pager-next > span {
+  float: right;
+}
+
+.post-pager .pager-center {
+  flex: 0 0 auto;
+}
+
+.post-pager .pager-center .view-source {
+  margin-top: 0;
 }
 
 .post-pager li {
@@ -810,6 +881,8 @@ footer {
   border-top: 1px #EAEAEA solid;
   margin-top: auto;
   font-size: 14px;
+  position: relative;
+  z-index: 51;
 }
 
 footer a {


### PR DESCRIPTION
:robot: *Human triggered, AI assisted PR ([using this skill](https://github.com/henryiii/skills/blob/main/branch-and-pr/SKILL.md)). AI text below.* :robot:

## Summary

Replaces the bottom-of-page prev/next pager with fixed side arrows on wide screens, inspired by the mdBook/WIT documentation style (e.g., [bytecodealliance WIT docs](https://component-model.bytecodealliance.org/design/wit.html)). On narrow screens, a bottom pager with prev/next labels is shown instead.

## Changes

- **Side arrows on wide screens (≥768px):** Fixed-position chevron arrows on the left/right edges of the viewport, vertically centered. Hover shows a subtle background highlight. Post title shown on hover via native `title` tooltip.
- **Bottom pager on narrow screens (<768px):** Three-column layout with prev/next buttons (showing "Previous"/"Next" labels with post titles as tooltips) and the view-source button centered between them.
- **View-source button moved** from inside the article to the center of the pager row.
- **Footer z-index raised** to 51 so it renders above the side arrows (z-index 50).
- **Dark mode support** for the new side arrow elements.

Assisted-by: OpenCode:glm-5