### PR TITLE
feat(layouts): allow custom home title in navbar

### DIFF
--- a/exampleSite/content/page/configuration.md
+++ b/exampleSite/content/page/configuration.md
@@ -10,7 +10,7 @@ This page is a complete reference for every configuration option in Beautiful Hu
 
 | Param | Type | Default | Description |
 |-------|------|---------|-------------|
-| `homeTitle` | string | site title | Separate title for the home page header |
+| `homeTitle` | string | site title | Brand name shown in the navbar, home page header, and footer link. Falls back to the site title when unset |
 | `subtitle` | string | `""` | Site subtitle shown under the home page title |
 | `mainSections` | list | `["post", "posts"]` | Content sections treated as "posts" on the home page and archive page |
 | `logo` | string | — | Path to a square avatar/logo image. When the file is found via Hugo's asset pipeline (`resources.Get`), it is automatically processed into WebP format (300×300, quality 100) for optimal loading. If the file is not found as a resource, the raw path is used as-is. |

--- a/exampleSite/content/page/pages-and-layouts.md
+++ b/exampleSite/content/page/pages-and-layouts.md
@@ -25,7 +25,7 @@ Additionally, the **`archive`** layout is available via front matter for any con
 
 The home page is defined by `content/_index.md` and rendered by `layouts/index.html`. It shows the site content at the top, followed by a paginated list of posts from `mainSections`.
 
-Title comes from `homeTitle` (or the site title). Subtitle comes from `Params.subtitle`. Big images from `[[Params.bigimg]]` cycle in the header.
+Title comes from `homeTitle` (or the site title); `homeTitle` also controls the navbar brand text and footer link. Subtitle comes from `Params.subtitle`. Big images from `[[Params.bigimg]]` cycle in the header.
 
 ```toml
 [Params]

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -69,11 +69,12 @@
             {{ .Site.Lastmod.Format "2006" }}
           {{ end }}
 
-          {{ if and .Site.Params.author.name .Site.Title }}
+          {{ if and .Site.Params.author.name .Site.Params.homeTitle | default .Site.Title }}
             &nbsp;&bull;&nbsp;
           {{ end }}
           {{ if .Site.Title }}
-            <a href="{{ "" | absLangURL }}">{{ .Site.Title }}</a>
+            <a href="{{ "" | absLangURL }}">{{ .Site.Params.homeTitle | default .Site.Title }}
+</a>
           {{ end }}
         </p>
         <!-- Please don't remove this, keep my open source work credited :) -->

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -69,12 +69,11 @@
             {{ .Site.Lastmod.Format "2006" }}
           {{ end }}
 
-          {{ if and .Site.Params.author.name .Site.Params.homeTitle | default .Site.Title }}
+          {{ if and .Site.Params.author.name (or .Site.Params.homeTitle .Site.Title) }}
             &nbsp;&bull;&nbsp;
           {{ end }}
-          {{ if .Site.Title }}
-            <a href="{{ "" | absLangURL }}">{{ .Site.Params.homeTitle | default .Site.Title }}
-</a>
+          {{ if or .Site.Params.homeTitle .Site.Title }}
+            <a href="{{ "" | absLangURL }}">{{ .Site.Params.homeTitle | default .Site.Title }}</a>
           {{ end }}
         </p>
         <!-- Please don't remove this, keep my open source work credited :) -->

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-expand-md navbar-light navbar-custom fixed-top">
   <div class="container-fluid">
-    <a class="navbar-brand" href="{{ "" | absLangURL }}">{{ .Site.Title }}</a>
+    <a class="navbar-brand" href="{{ "" | absLangURL }}">{{ .Site.Params.homeTitle | default .Site.Title }}</a>
     <div class="d-flex align-items-center">
       {{ if ne ($.Param "toc") false }}
       {{ $hasToc := and .TableOfContents (findRE `<li>` .TableOfContents) }}


### PR DESCRIPTION
Update the navigation bar to use `homeTitle` from site parameters if defined, falling back to the default site title. This provides more flexibility in controlling the brand name displayed in the header.