### PR TITLE
feat(seo): add canonical link to main SEO partial

### DIFF
--- a/layouts/partials/seo/main.html
+++ b/layouts/partials/seo/main.html
@@ -1,3 +1,4 @@
 {{- partial "seo/schema" . }}
 {{- partial "opengraph.html" . }}
+<link rel="canonical" href="{{ .Permalink }}" />
 {{- partial "seo/twitter" . }}


### PR DESCRIPTION
Add a canonical link tag using the page's permalink to improve search engine optimization and prevent duplicate content issues.