### PR TITLE
style(post-meta): add text-reset class to author links

### DIFF
--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -30,7 +30,7 @@
   {{ if not ($.Param "hideAuthor") }}
     {{- $authors := partial "author_list.html" . -}}
     {{- range $authors -}}
-      &nbsp;|&nbsp;<i class="fas fa-user"></i>&nbsp;{{ if .url }}<a href="{{ .url }}">{{ .name }}</a>{{ else }}{{ .name }}{{ end }}
+      &nbsp;|&nbsp;<i class="fas fa-user"></i>&nbsp;{{ if .url }}<a href="{{ .url }}" class="text-reset">{{ .name }}</a>{{ else }}{{ .name }}{{ end }}
     {{- end -}}
   {{ end }}
   {{- if .Site.Params.staticman -}}


### PR DESCRIPTION
Add the `text-reset` CSS class to author links in the post metadata partial to ensure they inherit the surrounding text color and maintain visual consistency.