### PR TITLE
fix: only show TOC panel shadow when open

### DIFF
--- a/static/css/toc.css
+++ b/static/css/toc.css
@@ -16,7 +16,6 @@ body.toc-visible .toc-wrapper {
   height: 100vh;
   background: #fff;
   border-right: 1px solid #e0e0e0;
-  box-shadow: 4px 0 20px rgba(0, 0, 0, 0.08);
   transform: translateX(-100%);
   transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   display: flex;
@@ -26,6 +25,11 @@ body.toc-visible .toc-wrapper {
 
 .toc-panel.toc-open {
   transform: translateX(0);
+  box-shadow: 4px 0 20px rgba(0, 0, 0, 0.2);
+}
+
+[data-theme="dark"] .toc-panel.toc-open {
+  box-shadow: 4px 0 20px rgba(0, 0, 0, 0.5);
 }
 
 .toc-header {
@@ -167,7 +171,6 @@ body.toc-visible .toc-wrapper {
 [data-theme="dark"] .toc-panel {
   background: #222;
   border-right-color: #444;
-  box-shadow: 4px 0 20px rgba(0, 0, 0, 0.4);
 }
 
 [data-theme="dark"] .toc-header {


### PR DESCRIPTION
:robot: *Human guided, AI assisted PR ([using this skill](https://github.com/henryiii/skills/blob/main/branch-and-pr/SKILL.md)). AI text below.* :robot:

## Summary

The `box-shadow` on `.toc-panel` was bleeding out from the off-screen (`translateX(-100%)`) panel, creating a visible gradient/shadow on the far left edge of the page — especially noticeable in dark mode.

This moves the shadow to `.toc-panel.toc-open` so it only appears when the panel is actually visible/open, and removes it from the base `.toc-panel` and dark-mode overrides.

Assisted-by: OpenCode:glm-5