### PR TITLE
fix: Humanize recipe times

### DIFF
--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -189,3 +189,19 @@
   translation: "Zutaten"
 - id: recipeInstructions
   translation: "Zubereitung"
+- id: recipeDay
+  translation:
+    one: "{{ .Count }} Tag"
+    other: "{{ .Count }} Tage"
+- id: recipeHour
+  translation:
+    one: "{{ .Count }} Std."
+    other: "{{ .Count }} Std."
+- id: recipeMinute
+  translation:
+    one: "{{ .Count }} Min."
+    other: "{{ .Count }} Min."
+- id: recipeSecond
+  translation:
+    one: "{{ .Count }} Sek."
+    other: "{{ .Count }} Sek."

--- a/i18n/dk.yaml
+++ b/i18n/dk.yaml
@@ -189,3 +189,19 @@
   translation: "Ingredienser"
 - id: recipeInstructions
   translation: "Fremgangsmåde"
+- id: recipeDay
+  translation:
+    one: "{{ .Count }} dag"
+    other: "{{ .Count }} dage"
+- id: recipeHour
+  translation:
+    one: "{{ .Count }} time"
+    other: "{{ .Count }} timer"
+- id: recipeMinute
+  translation:
+    one: "{{ .Count }} min."
+    other: "{{ .Count }} min."
+- id: recipeSecond
+  translation:
+    one: "{{ .Count }} sek."
+    other: "{{ .Count }} sek."

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -188,3 +188,19 @@
   translation: "Ingredients"
 - id: recipeInstructions
   translation: "Instructions"
+- id: recipeDay
+  translation:
+    one: "{{ .Count }} Day"
+    other: "{{ .Count }} Days"
+- id: recipeHour
+  translation:
+    one: "{{ .Count }} Hr"
+    other: "{{ .Count }} Hrs"
+- id: recipeMinute
+  translation:
+    one: "{{ .Count }} Min"
+    other: "{{ .Count }} Mins"
+- id: recipeSecond
+  translation:
+    one: "{{ .Count }} Sec"
+    other: "{{ .Count }} Secs"

--- a/i18n/eo.yaml
+++ b/i18n/eo.yaml
@@ -188,3 +188,19 @@
   translation: "Ingrediencoj"
 - id: recipeInstructions
   translation: "Instrukcioj"
+- id: recipeDay
+  translation:
+    one: "{{ .Count }} tago"
+    other: "{{ .Count }} tagoj"
+- id: recipeHour
+  translation:
+    one: "{{ .Count }} horo"
+    other: "{{ .Count }} horoj"
+- id: recipeMinute
+  translation:
+    one: "{{ .Count }} minuto"
+    other: "{{ .Count }} minutoj"
+- id: recipeSecond
+  translation:
+    one: "{{ .Count }} sekundo"
+    other: "{{ .Count }} sekundoj"

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -189,3 +189,19 @@
   translation: "Ingredientes"
 - id: recipeInstructions
   translation: "Instrucciones"
+- id: recipeDay
+  translation:
+    one: "{{ .Count }} día"
+    other: "{{ .Count }} días"
+- id: recipeHour
+  translation:
+    one: "{{ .Count }} hora"
+    other: "{{ .Count }} horas"
+- id: recipeMinute
+  translation:
+    one: "{{ .Count }} minuto"
+    other: "{{ .Count }} minutos"
+- id: recipeSecond
+  translation:
+    one: "{{ .Count }} segundo"
+    other: "{{ .Count }} segundos"

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -188,3 +188,19 @@
   translation: "Ingrédients"
 - id: recipeInstructions
   translation: "Instructions"
+- id: recipeDay
+  translation:
+    one: "{{ .Count }} jour"
+    other: "{{ .Count }} jours"
+- id: recipeHour
+  translation:
+    one: "{{ .Count }} h"
+    other: "{{ .Count }} h"
+- id: recipeMinute
+  translation:
+    one: "{{ .Count }} min"
+    other: "{{ .Count }} min"
+- id: recipeSecond
+  translation:
+    one: "{{ .Count }} s"
+    other: "{{ .Count }} s"

--- a/i18n/hr.yaml
+++ b/i18n/hr.yaml
@@ -188,3 +188,19 @@
   translation: "Sastojci"
 - id: recipeInstructions
   translation: "Upute"
+- id: recipeDay
+  translation:
+    one: "{{ .Count }} dan"
+    other: "{{ .Count }} dana"
+- id: recipeHour
+  translation:
+    one: "{{ .Count }} sat"
+    other: "{{ .Count }} sati"
+- id: recipeMinute
+  translation:
+    one: "{{ .Count }} min"
+    other: "{{ .Count }} min"
+- id: recipeSecond
+  translation:
+    one: "{{ .Count }} sek"
+    other: "{{ .Count }} sek"

--- a/i18n/it.yaml
+++ b/i18n/it.yaml
@@ -188,3 +188,19 @@
   translation: "Ingredienti"
 - id: recipeInstructions
   translation: "Istruzioni"
+- id: recipeDay
+  translation:
+    one: "{{ .Count }} giorno"
+    other: "{{ .Count }} giorni"
+- id: recipeHour
+  translation:
+    one: "{{ .Count }} ora"
+    other: "{{ .Count }} ore"
+- id: recipeMinute
+  translation:
+    one: "{{ .Count }} minuto"
+    other: "{{ .Count }} minuti"
+- id: recipeSecond
+  translation:
+    one: "{{ .Count }} secondo"
+    other: "{{ .Count }} secondi"

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -188,3 +188,15 @@
   translation: "材料"
 - id: recipeInstructions
   translation: "作り方"
+- id: recipeDay
+  translation:
+    other: "{{ .Count }}日"
+- id: recipeHour
+  translation:
+    other: "{{ .Count }}時間"
+- id: recipeMinute
+  translation:
+    other: "{{ .Count }}分"
+- id: recipeSecond
+  translation:
+    other: "{{ .Count }}秒"

--- a/i18n/ko.yaml
+++ b/i18n/ko.yaml
@@ -189,3 +189,15 @@
   translation: "재료"
 - id: recipeInstructions
   translation: "조리법"
+- id: recipeDay
+  translation:
+    other: "{{ .Count }}일"
+- id: recipeHour
+  translation:
+    other: "{{ .Count }}시간"
+- id: recipeMinute
+  translation:
+    other: "{{ .Count }}분"
+- id: recipeSecond
+  translation:
+    other: "{{ .Count }}초"

--- a/i18n/lmo.yaml
+++ b/i18n/lmo.yaml
@@ -323,3 +323,19 @@
   translation: "Ingredient"
 - id: recipeInstructions
   translation: "Istruzzion"
+- id: recipeDay
+  translation:
+    one: "{{ .Count }} dì"
+    other: "{{ .Count }} dì"
+- id: recipeHour
+  translation:
+    one: "{{ .Count }} ora"
+    other: "{{ .Count }} or"
+- id: recipeMinute
+  translation:
+    one: "{{ .Count }} minut"
+    other: "{{ .Count }} minüt"
+- id: recipeSecond
+  translation:
+    one: "{{ .Count }} segond"
+    other: "{{ .Count }} segond"

--- a/i18n/nb.yaml
+++ b/i18n/nb.yaml
@@ -188,3 +188,19 @@
   translation: "Ingredienser"
 - id: recipeInstructions
   translation: "Fremgangsmåte"
+- id: recipeDay
+  translation:
+    one: "{{ .Count }} dag"
+    other: "{{ .Count }} dager"
+- id: recipeHour
+  translation:
+    one: "{{ .Count }} time"
+    other: "{{ .Count }} timer"
+- id: recipeMinute
+  translation:
+    one: "{{ .Count }} minutt"
+    other: "{{ .Count }} minutter"
+- id: recipeSecond
+  translation:
+    one: "{{ .Count }} sekund"
+    other: "{{ .Count }} sekunder"

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -189,3 +189,19 @@
   translation: "Ingrediënten"
 - id: recipeInstructions
   translation: "Instructies"
+- id: recipeDay
+  translation:
+    one: "{{ .Count }} dag"
+    other: "{{ .Count }} dagen"
+- id: recipeHour
+  translation:
+    one: "{{ .Count }} uur"
+    other: "{{ .Count }} uur"
+- id: recipeMinute
+  translation:
+    one: "{{ .Count }} minuut"
+    other: "{{ .Count }} minuten"
+- id: recipeSecond
+  translation:
+    one: "{{ .Count }} seconde"
+    other: "{{ .Count }} seconden"

--- a/i18n/pl.yaml
+++ b/i18n/pl.yaml
@@ -189,3 +189,27 @@
   translation: "Składniki"
 - id: recipeInstructions
   translation: "Instrukcje"
+- id: recipeDay
+  translation:
+    one: "{{ .Count }} dzień"
+    few: "{{ .Count }} dni"
+    many: "{{ .Count }} dni"
+    other: "{{ .Count }} dnia"
+- id: recipeHour
+  translation:
+    one: "{{ .Count }} godzina"
+    few: "{{ .Count }} godziny"
+    many: "{{ .Count }} godzin"
+    other: "{{ .Count }} godziny"
+- id: recipeMinute
+  translation:
+    one: "{{ .Count }} minuta"
+    few: "{{ .Count }} minuty"
+    many: "{{ .Count }} minut"
+    other: "{{ .Count }} minuty"
+- id: recipeSecond
+  translation:
+    one: "{{ .Count }} sekunda"
+    few: "{{ .Count }} sekundy"
+    many: "{{ .Count }} sekund"
+    other: "{{ .Count }} sekundy"

--- a/i18n/pt-br.yaml
+++ b/i18n/pt-br.yaml
@@ -188,3 +188,19 @@
   translation: "Ingredientes"
 - id: recipeInstructions
   translation: "Modo de preparo"
+- id: recipeDay
+  translation:
+    one: "{{ .Count }} dia"
+    other: "{{ .Count }} dias"
+- id: recipeHour
+  translation:
+    one: "{{ .Count }} hora"
+    other: "{{ .Count }} horas"
+- id: recipeMinute
+  translation:
+    one: "{{ .Count }} minuto"
+    other: "{{ .Count }} minutos"
+- id: recipeSecond
+  translation:
+    one: "{{ .Count }} segundo"
+    other: "{{ .Count }} segundos"

--- a/i18n/pt.yaml
+++ b/i18n/pt.yaml
@@ -188,3 +188,19 @@
   translation: "Ingredientes"
 - id: recipeInstructions
   translation: "Instruções"
+- id: recipeDay
+  translation:
+    one: "{{ .Count }} dia"
+    other: "{{ .Count }} dias"
+- id: recipeHour
+  translation:
+    one: "{{ .Count }} hora"
+    other: "{{ .Count }} horas"
+- id: recipeMinute
+  translation:
+    one: "{{ .Count }} minuto"
+    other: "{{ .Count }} minutos"
+- id: recipeSecond
+  translation:
+    one: "{{ .Count }} segundo"
+    other: "{{ .Count }} segundos"

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -188,3 +188,27 @@
   translation: "Ингредиенты"
 - id: recipeInstructions
   translation: "Инструкции"
+- id: recipeDay
+  translation:
+    one: "{{ .Count }} день"
+    few: "{{ .Count }} дня"
+    many: "{{ .Count }} дней"
+    other: "{{ .Count }} дня"
+- id: recipeHour
+  translation:
+    one: "{{ .Count }} час"
+    few: "{{ .Count }} часа"
+    many: "{{ .Count }} часов"
+    other: "{{ .Count }} часа"
+- id: recipeMinute
+  translation:
+    one: "{{ .Count }} минута"
+    few: "{{ .Count }} минуты"
+    many: "{{ .Count }} минут"
+    other: "{{ .Count }} минуты"
+- id: recipeSecond
+  translation:
+    one: "{{ .Count }} секунда"
+    few: "{{ .Count }} секунды"
+    many: "{{ .Count }} секунд"
+    other: "{{ .Count }} секунды"

--- a/i18n/tr.yaml
+++ b/i18n/tr.yaml
@@ -188,3 +188,19 @@
   translation: "Malzemeler"
 - id: recipeInstructions
   translation: "Talimatlar"
+- id: recipeDay
+  translation:
+    one: "{{ .Count }} gün"
+    other: "{{ .Count }} gün"
+- id: recipeHour
+  translation:
+    one: "{{ .Count }} saat"
+    other: "{{ .Count }} saat"
+- id: recipeMinute
+  translation:
+    one: "{{ .Count }} dakika"
+    other: "{{ .Count }} dakika"
+- id: recipeSecond
+  translation:
+    one: "{{ .Count }} saniye"
+    other: "{{ .Count }} saniye"

--- a/i18n/zh-CN.yaml
+++ b/i18n/zh-CN.yaml
@@ -188,3 +188,15 @@
   translation: "食材"
 - id: recipeInstructions
   translation: "做法"
+- id: recipeDay
+  translation:
+    other: "{{ .Count }}天"
+- id: recipeHour
+  translation:
+    other: "{{ .Count }}小时"
+- id: recipeMinute
+  translation:
+    other: "{{ .Count }}分钟"
+- id: recipeSecond
+  translation:
+    other: "{{ .Count }}秒"

--- a/i18n/zh-TW.yaml
+++ b/i18n/zh-TW.yaml
@@ -189,3 +189,15 @@
   translation: "食材"
 - id: recipeInstructions
   translation: "做法"
+- id: recipeDay
+  translation:
+    other: "{{ .Count }}天"
+- id: recipeHour
+  translation:
+    other: "{{ .Count }}小時"
+- id: recipeMinute
+  translation:
+    other: "{{ .Count }}分鐘"
+- id: recipeSecond
+  translation:
+    other: "{{ .Count }}秒"

--- a/layouts/partials/recipe.html
+++ b/layouts/partials/recipe.html
@@ -6,19 +6,19 @@
     {{- with $r.prepTime -}}
       <span class="recipe-meta-item">
         <span class="recipe-meta-label">{{ i18n "recipePrepTime" }}</span>
-        <span class="recipe-meta-value">{{ . }}</span>
+        <span class="recipe-meta-value">{{ partial "recipe/humanize-time.html" . }}</span>
       </span>
     {{- end -}}
     {{- with $r.cookTime -}}
       <span class="recipe-meta-item">
         <span class="recipe-meta-label">{{ i18n "recipeCookTime" }}</span>
-        <span class="recipe-meta-value">{{ . }}</span>
+        <span class="recipe-meta-value">{{ partial "recipe/humanize-time.html" . }}</span>
       </span>
     {{- end -}}
     {{- with $r.totalTime -}}
       <span class="recipe-meta-item">
         <span class="recipe-meta-label">{{ i18n "recipeTotalTime" }}</span>
-        <span class="recipe-meta-value">{{ . }}</span>
+        <span class="recipe-meta-value">{{ partial "recipe/humanize-time.html" . }}</span>
       </span>
     {{- end -}}
     {{- with $r.yield -}}

--- a/layouts/partials/recipe/humanize-time.html
+++ b/layouts/partials/recipe/humanize-time.html
@@ -1,0 +1,46 @@
+{{ $time := . }} <!-- Example: "PT1H30M" or "PT45M" -->
+
+{{ $hours := "" }}
+{{ $minutes := "" }}
+{{ $displayTime := "" }}
+
+{{/* Extract hours and minutes using regex submatches */}}
+{{ $match := findRESubmatch `PT(?:(\d+)H)?(?:(\d+)M)?` $time }}
+
+{{ if $match }}
+    {{ $hours = index (index $match 0) 1 }}
+    {{ $minutes = index (index $match 0) 2 }}
+{{ end }}
+
+{{/* Format hours string */}}
+{{ $hoursStr := "" }}
+{{ if $hours }}
+    {{ $hNum := int $hours }}
+    {{ if gt $hNum 0 }}
+        {{ $hoursStr = printf "%d Hr%s" $hNum (cond (gt $hNum 1) "s" "") }}
+    {{ end }}
+{{ end }}
+
+{{/* Format minutes string */}}
+{{ $minutesStr := "" }}
+{{ if $minutes }}
+    {{ $mNum := int $minutes }}
+    {{ if gt $mNum 0 }}
+        {{ $minutesStr = printf "%d Min%s" $mNum (cond (gt $mNum 1) "s" "") }}
+    {{ end }}
+{{ end }}
+
+{{/* Combine results */}}
+{{ if and $hoursStr $minutesStr }}
+    {{ $displayTime = printf "%s %s" $hoursStr $minutesStr }}
+{{ else if $hoursStr }}
+    {{ $displayTime = $hoursStr }}
+{{ else if $minutesStr }}
+    {{ $displayTime = $minutesStr }}
+{{ else }}
+    {{ $displayTime = "0 minutes" }}
+{{ end }}
+
+<!-- Output to Page -->
+{{ return $displayTime }}
+

--- a/layouts/partials/recipe/humanize-time.html
+++ b/layouts/partials/recipe/humanize-time.html
@@ -1,46 +1,50 @@
-{{ $time := . }} <!-- Example: "PT1H30M" or "PT45M" -->
-
+{{ $time := . }}
+{{ $days := "" }}
 {{ $hours := "" }}
 {{ $minutes := "" }}
-{{ $displayTime := "" }}
+{{ $seconds := "" }}
 
-{{/* Extract hours and minutes using regex submatches */}}
-{{ $match := findRESubmatch `PT(?:(\d+)H)?(?:(\d+)M)?` $time }}
+{{ $match := findRESubmatch `P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?` $time }}
 
 {{ if $match }}
-    {{ $hours = index (index $match 0) 1 }}
-    {{ $minutes = index (index $match 0) 2 }}
+  {{ $days = index (index $match 0) 1 }}
+  {{ $hours = index (index $match 0) 2 }}
+  {{ $minutes = index (index $match 0) 3 }}
+  {{ $seconds = index (index $match 0) 4 }}
 {{ end }}
 
-{{/* Format hours string */}}
-{{ $hoursStr := "" }}
-{{ if $hours }}
-    {{ $hNum := int $hours }}
-    {{ if gt $hNum 0 }}
-        {{ $hoursStr = printf "%d Hr%s" $hNum (cond (gt $hNum 1) "s" "") }}
-    {{ end }}
+{{ $parts := slice }}
+
+{{ with $days }}
+  {{ $d := int . }}
+  {{ if gt $d 0 }}
+    {{ $parts = $parts | append (i18n "recipeDay" (dict "Count" $d)) }}
+  {{ end }}
 {{ end }}
 
-{{/* Format minutes string */}}
-{{ $minutesStr := "" }}
-{{ if $minutes }}
-    {{ $mNum := int $minutes }}
-    {{ if gt $mNum 0 }}
-        {{ $minutesStr = printf "%d Min%s" $mNum (cond (gt $mNum 1) "s" "") }}
-    {{ end }}
+{{ with $hours }}
+  {{ $h := int . }}
+  {{ if gt $h 0 }}
+    {{ $parts = $parts | append (i18n "recipeHour" (dict "Count" $h)) }}
+  {{ end }}
 {{ end }}
 
-{{/* Combine results */}}
-{{ if and $hoursStr $minutesStr }}
-    {{ $displayTime = printf "%s %s" $hoursStr $minutesStr }}
-{{ else if $hoursStr }}
-    {{ $displayTime = $hoursStr }}
-{{ else if $minutesStr }}
-    {{ $displayTime = $minutesStr }}
+{{ with $minutes }}
+  {{ $m := int . }}
+  {{ if gt $m 0 }}
+    {{ $parts = $parts | append (i18n "recipeMinute" (dict "Count" $m)) }}
+  {{ end }}
+{{ end }}
+
+{{ with $seconds }}
+  {{ $s := int . }}
+  {{ if gt $s 0 }}
+    {{ $parts = $parts | append (i18n "recipeSecond" (dict "Count" $s)) }}
+  {{ end }}
+{{ end }}
+
+{{ if $parts }}
+  {{ return delimit $parts " " }}
 {{ else }}
-    {{ $displayTime = "0 minutes" }}
+  {{ return $time }}
 {{ end }}
-
-<!-- Output to Page -->
-{{ return $displayTime }}
-


### PR DESCRIPTION
Humanize the recipe times.

- This just provides the intial ability to show recipe times in a human readable format.

- It might be worthwhile converting hours to minutes to prevent the recipe width from growing too much.