### PR TITLE
fix: correct paths for subdirectory deployments

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -79,7 +79,7 @@
         <!-- Please don't remove this, keep my open source work credited :) -->
         <p class="credits theme-by text-muted">
           {{ i18n "poweredBy" (dict "Version" hugo.Version) | safeHTML }}
-          {{ if $.GitInfo }}&nbsp;&bull;&nbsp;[<a href="{{ .Site.Params.commit }}{{ .GitInfo.Hash }}">{{ substr .GitInfo.Hash 0 8 }}</a>]{{ end }}
+          {{ if and $.GitInfo .Site.Params.commit }}&nbsp;&bull;&nbsp;[<a href="{{ .Site.Params.commit }}{{ .GitInfo.Hash }}">{{ substr .GitInfo.Hash 0 8 }}</a>]{{ end }}
         </p>
       </div>
     </div>

--- a/layouts/partials/search-provider.html
+++ b/layouts/partials/search-provider.html
@@ -1,4 +1,4 @@
-{{- $provider := "fuse" -}}
+{{- $provider := "none" -}}
 
 {{- with site.Params.search -}}
   {{- $provider = lower (.provider | default (.providor | default "fuse")) -}}

--- a/layouts/partials/search-provider.html
+++ b/layouts/partials/search-provider.html
@@ -1,4 +1,4 @@
-{{- $provider := "none" -}}
+{{- $provider := "fuse" -}}
 
 {{- with site.Params.search -}}
   {{- $provider = lower (.provider | default (.providor | default "fuse")) -}}

--- a/layouts/partials/show-source.html
+++ b/layouts/partials/show-source.html
@@ -1,7 +1,7 @@
 {{- if and .Site.Params.sourceRepo (or .Params.showSource (and .Site.Params.showSource (ne .Params.showSource false))) }}
   {{- with .File.Path }}
     {{- $url := printf "%s%s" $.Site.Params.sourceRepo . }}
-    {{- if and $.GitInfo }}
+    {{- if $.GitInfo }}
       {{- $hash := $.GitInfo.Hash }}
       {{- $url = replaceRE `/blob/[^/]+/` (printf "/blob/%s/" $hash) $url }}
     {{- end }}

--- a/static/js/search-fuse.js
+++ b/static/js/search-fuse.js
@@ -8,7 +8,7 @@
   // --- fuse provider ---
 
   function fetchSearchIndex(url) {
-    return fetch(url || '/index.json')
+    return fetch(url)
       .then(function (response) {
         if (!response.ok) {
           throw new Error('Network response was not ok: ' + response.status + ' ' + response.statusText);


### PR DESCRIPTION
:robot: *Human guided, AI assisted PR ([using this skill](https://github.com/henryiii/skills/blob/main/branch-and-pr/SKILL.md)). AI text below.* :robot:

## Summary

Fixes path issues that break the site when deployed under a subdirectory (e.g. `halogenica.net/beautifulhugo/`):

- **`index.json` loaded from base URL**: `search-fuse.js` had a fallback `|| '/index.json'` that bypassed the `relURL`-computed path from the template, causing the search index to be fetched from the domain root instead of the subdirectory.
- **`false` in commit link URL**: When `commit = false` in config (and `enableGitInfo = true`), the footer rendered `false` + GitInfo hash as the link URL (e.g. `false87df0540...`). Now the commit link only renders when `.Site.Params.commit` is actually set to a truthy value.
- **Redundant `and` in show-source.html**: `{{ if and $.GitInfo }}` simplified to `{{ if $.GitInfo }}` (single-condition `and` is a no-op).

Assisted-by: opencode:glm-5