### PR TITLE
fix: search index URL broken on subdirectory deployments

### DIFF
--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -39,6 +39,7 @@ enableGitInfo = true
   headerImgStyle = "narrow"
   showSource = true
   sourceRepo = "https://github.com/halogenica/beautifulhugo/blob/master/exampleSite/"
+  comment = "https://github.com/halogenica/beautifulhugo/commit/"
 
   [Params.search]
     provider = "fuse"

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -38,8 +38,8 @@
   <script>
     window.searchProviderConfig = {
      provider: "{{ $searchProvider }}",
-     searchIndexURL: "{{ "/index.json" | relURL }}",
-     searchPageURL: "{{ "/search" | relLangURL }}"
+     searchIndexURL: {{ "index.json" | relURL }},
+     searchPageURL: {{ "search" | relLangURL }}
     };
     window.searchConfig = {
      resultsLabel: "{{ $search.results_label | default (i18n "searchResultsLabel" | default "Search results" ) }}",

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -156,8 +156,8 @@
 <script>
   window.searchProviderConfig = {
     provider: "{{ $searchProvider }}",
-    searchIndexURL: "{{ "/index.json" | relURL }}",
-    searchPageURL: "{{ "/search" | relLangURL }}"
+    searchIndexURL: {{ "index.json" | relURL }},
+    searchPageURL: {{ "search" | relLangURL }}
   };
   window.searchConfig = {
     noResultsText: "{{ $search.no_results_text | default (i18n "searchNoResultsText" | default "No results found for " ) }}",


### PR DESCRIPTION
:robot: *Human guided, AI assisted PR ([using this skill](https://github.com/henryiii/skills/blob/main/branch-and-pr/SKILL.md)). AI text below.* :robot:

## Summary

Fix search functionality when the site is deployed under a subpath (e.g. `https://halogenica.net/beautifulhugo/`).

## Problem

`relURL` with a leading slash (e.g. `"/index.json" | relURL`) produces a server-root-relative path like `/index.json`, which ignores the `baseURL` subpath. When deployed to a subdirectory, `fetch("/index.json")` hits the wrong URL — it should be `/beautifulhugo/index.json`.

## Changes

- **`layouts/partials/nav.html`**: Remove leading `/` from `relURL`/`relLangURL` arguments for `searchIndexURL` and `searchPageURL`
- **`layouts/_default/search.html`**: Same fix as above
- **`exampleSite/hugo.toml`**: Add `comment` config per user request

Assisted-by: OpenCode:glm-5