### PR TITLE
fix: search page asset URLs broken on subdirectory deployments

### DIFF
--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
   {{- $searchProvider := partial "search-provider.html" . -}}
   {{- $search := .Site.Params.search | default (dict) -}}
-  <link rel="stylesheet" href="{{ "/css/search.css" | relURL }}">
+  <link rel="stylesheet" href="{{ "css/search.css" | relURL }}">
   <div class="search-page-container" role="main">
     {{- if eq $searchProvider "none" }}
     <div class="container{{ if .Params.fullWidth }}-fluid{{ end }}">
@@ -54,6 +54,6 @@
      untitledText: "{{ $search.untitled_text | default (i18n "searchUntitledText" | default "Untitled" ) }}"
     };
   </script>
-  <script src="{{ "/js/search.js" | relURL }}"></script>
+  <script src="{{ "js/search.js" | relURL }}"></script>
   {{- end }}
 {{ end }}


### PR DESCRIPTION
:robot: *Human guided, AI assisted PR ([using this skill](https://github.com/henryiii/skills/blob/main/branch-and-pr/SKILL.md)). AI text below.* :robot:

## Summary

Fix the search page (`/search/`) failing to load its CSS and JS when the site is deployed under a subpath.

## Problem

Same `relURL` leading-slash issue as #740. `"/css/search.css" | relURL` and `"/js/search.js" | relURL` produce server-root paths (`/css/search.css`, `/js/search.js`) that ignore the `baseURL` subpath. Under a subdirectory deployment like `https://halogenica.net/beautifulhugo/`, these resolve to the wrong URLs.

## Changes

- **`layouts/_default/search.html`**: Remove leading `/` from `relURL` arguments for `css/search.css` and `js/search.js`, so they correctly resolve to `/beautifulhugo/css/search.css` etc.

Assisted-by: OpenCode:glm-5