### PR TITLE
fix: add search-heading to header CSS rules for centered, sized title

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -543,7 +543,8 @@ img::selection {
 
 .intro-header .page-heading,
 .intro-header .tags-heading,
-.intro-header .categories-heading {
+.intro-header .categories-heading,
+.intro-header .search-heading {
   text-align: center;
 }
 
@@ -567,7 +568,8 @@ img::selection {
 .intro-header .page-heading h1,
 .intro-header .page-heading .h1,
 .intro-header .tags-heading h1,
-.intro-header .categories-heading h1 {
+.intro-header .categories-heading h1,
+.intro-header .search-heading h1 {
   margin-top: 0;
   font-size: 50px;
 }
@@ -637,7 +639,8 @@ img::selection {
   .intro-header .page-heading h1,
   .intro-header .page-heading .h1,
   .intro-header .tags-heading h1,
-  .intro-header .categories-heading h1 {
+  .intro-header .categories-heading h1,
+  .intro-header .search-heading h1 {
     font-size: 72px;
   }
 .intro-header .post-heading h1,

--- a/static/css/print.css
+++ b/static/css/print.css
@@ -95,7 +95,8 @@
   .intro-header .page-heading h1,
   .intro-header .page-heading .h1,
   .intro-header .tags-heading h1,
-  .intro-header .categories-heading h1 {
+  .intro-header .categories-heading h1,
+  .intro-header .search-heading h1 {
     color: #000 !important;
   }
 


### PR DESCRIPTION
:robot: *Human guided, AI assisted PR ([using this skill](https://github.com/henryiii/skills/blob/main/branch-and-pr/SKILL.md)). AI text below.* :robot:

## Summary

The search page title was left-aligned and had inconsistent font sizing compared to other pages (tags, categories, regular pages). This was because the search page uses `type: search`, so the header partial generates a `search-heading` class, but the CSS only had rules for `page-heading`, `tags-heading`, and `categories-heading`.

## Changes

- Added `.intro-header .search-heading` to the `text-align: center` rule in `main.css`
- Added `.intro-header .search-heading h1` to the `font-size: 50px` rule in `main.css`
- Added `.intro-header .search-heading h1` to the responsive `font-size: 72px` rule in `main.css`
- Added `.intro-header .search-heading h1` to the print stylesheet color override in `print.css`

Assisted-by: OpenCode:glm-5