### PR TITLE
style: use dark grey for tooltip background

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1986,3 +1986,8 @@ mjx-container mjx-wrap {
   display: block !important;
   max-width: max-content;
 }
+
+/* Dark grey tooltip background instead of black */
+.tooltip {
+  --bs-tooltip-bg: #343a40;
+}


### PR DESCRIPTION
:robot: *Human guided, AI assisted PR ([using this skill](https://github.com/henryiii/skills/blob/main/branch-and-pr/SKILL.md)). AI text below.* :robot:

Override Bootstrap tooltip background color from black (#000) to dark grey (#343a40) for better visual appearance.

Assisted-by: OpenCode:Kimi-K2.6