### PR TITLE
feat(search): decode HTML entities in search results

### DIFF
--- a/static/js/search-fuse.js
+++ b/static/js/search-fuse.js
@@ -163,9 +163,7 @@
 
   function decodeHtml(text) {
     if (!text) return '';
-    var div = document.createElement('div');
-    div.innerHTML = text;
-    return div.textContent || div.innerText;
+    return new DOMParser().parseFromString(text, 'text/html').body.textContent || '';
   }
 
   function escapeHtml(text) {

--- a/static/js/search-fuse.js
+++ b/static/js/search-fuse.js
@@ -161,6 +161,13 @@
     }
   }
 
+  function decodeHtml(text) {
+    if (!text) return '';
+    var div = document.createElement('div');
+    div.innerHTML = text;
+    return div.textContent || div.innerText;
+  }
+
   function escapeHtml(text) {
     if (!text) return '';
     var div = document.createElement('div');
@@ -188,9 +195,9 @@
     hits.forEach(function (hit) {
       var title = hit.title || cfg.untitledText || 'Untitled';
       html += '<a class="navbar-search-result-item" href="' + escapeHtml(hit.url) + '">';
-      html += '<span class="navbar-search-result-title">' + escapeHtml(title) + '</span>';
+      html += '<span class="navbar-search-result-title">' + escapeHtml(decodeHtml(title)) + '</span>';
       if (hit.excerpt) {
-        html += '<span class="navbar-search-result-excerpt">' + escapeHtml(hit.excerpt) + '</span>';
+        html += '<span class="navbar-search-result-excerpt">' + escapeHtml(decodeHtml(hit.excerpt)) + '</span>';
       }
       html += '</a>';
     });


### PR DESCRIPTION
Add a `decodeHtml` helper function to ensure that HTML-encoded characters in page titles and excerpts are properly decoded before being escaped and rendered in the search results dropdown. This prevents double-encoding or raw entity display in the UI.