### PR TITLE
feat: add post thumbnails on list pages

### DIFF
--- a/exampleSite/content/page/configuration.md
+++ b/exampleSite/content/page/configuration.md
@@ -277,8 +277,9 @@ These options can be set in the front matter of any page or post:
 | `showAvatar` | bool | Show/hide navbar avatar (default: `true`) |
 | `comments` | bool | Enable comments on this page |
 | `hidden` | bool | Hide from list pages |
-| `image` | string | Post preview image (circular, shown in list pages) |
+| `image` | string | Post preview image (full-width banner on list pages; also used for SEO/social sharing) |
 | `video` | string | Post preview video (loop, autoplay, muted) |
+| `thumbnail` | string | Post thumbnail image (rounded rectangle, shown beside summary on list pages; falls back to `image`) |
 | `summary` | string | Custom summary text |
 | `description` | string | Page description for meta tags and structured data (see [SEO & i18n — Description Cascade](../seo-and-i18n/#description-cascade)) |
 | `type` | string | Content type that determines template behavior: `"page"`, `"post"`, or `"recipe"` (see [Pages & Layouts](../pages-and-layouts/)) |

--- a/exampleSite/content/page/pages-and-layouts.md
+++ b/exampleSite/content/page/pages-and-layouts.md
@@ -293,12 +293,12 @@ The page is still accessible via its direct URL and appears in navigation menus 
 
 ### Post Preview Images
 
-On list pages, posts can show a circular preview image or video:
+On list pages, posts can show a full-width preview image or video:
 
 ```yaml
 ---
 title: My Post
-image: /img/avatar-icon.png
+image: /img/my-post-image.jpg
 ---
 ```
 
@@ -310,6 +310,26 @@ title: My Post
 video: clip.mp4
 ---
 ```
+
+### Post Thumbnails
+
+Posts can display a thumbnail image beside the summary on list pages:
+
+```yaml
+---
+title: My Post
+thumbnail: /img/my-thumb.jpg
+---
+```
+
+If `thumbnail` is not set but `image` is, the `image` will be used as the thumbnail automatically. Set both to use different images for the full-width banner and the thumbnail:
+
+```yaml
+---
+title: My Post
+image: /img/my-post-image.jpg
+thumbnail: /img/my-thumb.jpg
+---
 
 ### Custom Summaries
 

--- a/exampleSite/content/post/2015-01-04-first-post.md
+++ b/exampleSite/content/post/2015-01-04-first-post.md
@@ -4,6 +4,7 @@ author: "[Michael Henderson](https://example.com)"
 date: 2015-01-05
 categories: ["personal"]
 tags: ["personal", "intro", "tutorial"]
+thumbnail: /img/hexagon-thumb.jpg
 ---
 
 This is my first post, how exciting!

--- a/exampleSite/content/post/2015-01-15-pirates.md
+++ b/exampleSite/content/post/2015-01-15-pirates.md
@@ -4,6 +4,7 @@ date: 2015-01-15
 categories: ["history"]
 tags: ["humor", "history"]
 showPostNav: false
+thumbnail: /img/sphere-thumb.jpg
 ---
 
 Piracy is typically an act of robbery or criminal violence at sea. The term can include acts committed on land, in the air, or in other major bodies of water or on a shore. It does not normally include crimes committed against persons traveling on the same vessel as the perpetrator (e.g. one passenger stealing from others on the same vessel). The term has been used throughout history to refer to raids across land borders by non-state agents.

--- a/exampleSite/content/post/2015-02-13-hamlet-monologue.md
+++ b/exampleSite/content/post/2015-02-13-hamlet-monologue.md
@@ -5,6 +5,7 @@ author: "William Shakespeare"
 date: 2015-02-13
 categories: ["literature"]
 tags: ["literature", "history"]
+thumbnail: /img/triangle-thumb.jpg
 ---
 
 To be, or not to be--that is the question:

--- a/layouts/partials/post_preview.html
+++ b/layouts/partials/post_preview.html
@@ -16,9 +16,6 @@
         {{ end }}
     </a>
 
-    <p class="post-meta">
-        {{ partial "post_meta.html" . }}
-    </p>
     {{ $thumbnail := .Params.thumbnail | default .Params.image }}
     {{ if $thumbnail }}
     <div class="post-image">
@@ -27,6 +24,9 @@
         </a>
     </div>
     {{ end }}
+    <p class="post-meta">
+        {{ partial "post_meta.html" . }}
+    </p>
     <div class="post-entry">
         {{ if or (.Truncated) (.Params.summary) (eq .Type "recipe") }}
         {{ .Summary }}

--- a/layouts/partials/post_preview.html
+++ b/layouts/partials/post_preview.html
@@ -19,6 +19,14 @@
     <p class="post-meta">
         {{ partial "post_meta.html" . }}
     </p>
+    {{ $thumbnail := .Params.thumbnail | default .Params.image }}
+    {{ if $thumbnail }}
+    <div class="post-image">
+        <a href="{{ .Permalink }}">
+            <img src="{{ $thumbnail | relURL }}" alt="{{ .Title }}" />
+        </a>
+    </div>
+    {{ end }}
     <div class="post-entry">
         {{ if or (.Truncated) (.Params.summary) (eq .Type "recipe") }}
         {{ .Summary }}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -453,13 +453,13 @@ img::selection {
 
 .post-image {
   float: right;
-  margin: 0 0 10px 15px;
+  margin: 5px 0 10px 15px;
 }
 
 .post-image img {
   border-radius: 8px;
-  height: 150px;
-  width: 150px;
+  width: 200px;
+  height: 130px;
   object-fit: cover;
 }
 
@@ -489,8 +489,8 @@ img::selection {
   }
 
   .post-image img {
-    height: 120px;
-    width: 120px;
+    height: 100px;
+    width: 150px;
   }
 }
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -453,26 +453,21 @@ img::selection {
 
 .post-image {
   float: right;
-  height: 192px;
-  width: 192px;
-  margin-top: -35px;
-  filter: grayscale(90%);
-}
-
-.post-image:hover {
-  filter: grayscale(0%);
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .post-image:hover {
-    filter: grayscale(90%);
-  }
+  margin: 0 0 10px 15px;
 }
 
 .post-image img {
-  border-radius: 100px;
-  height: 192px;
-  width: 192px;
+  border-radius: 8px;
+  height: 150px;
+  width: 150px;
+  object-fit: cover;
+}
+
+.img-title {
+  max-width: 100%;
+  height: auto;
+  border-radius: 4px;
+  margin-top: 8px;
 }
 
 .post-preview .post-read-more {
@@ -487,16 +482,15 @@ img::selection {
 }
 
 @media only screen and (max-width: 500px) {
-  .post-image, .post-image img {
-    height: 100px;
-    width: 100px;
+  .post-image {
+    float: none;
+    text-align: center;
+    margin: 10px 0;
   }
 
-  .post-image {
-    width: 100%;
-    text-align: center;
-    margin-top: 0;
-    float: left;
+  .post-image img {
+    height: 120px;
+    width: 120px;
   }
 }
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -458,8 +458,8 @@ img::selection {
 
 .post-image img {
   border-radius: 8px;
-  width: 200px;
-  height: 130px;
+  width: 150px;
+  height: 150px;
   object-fit: cover;
 }
 
@@ -489,8 +489,8 @@ img::selection {
   }
 
   .post-image img {
-    height: 100px;
-    width: 150px;
+    height: 120px;
+    width: 120px;
   }
 }
 


### PR DESCRIPTION
This doesn't look very good, I'll probably try again.

:robot: *Human guided, AI assisted PR ([using this skill](https://github.com/henryiii/skills/blob/main/branch-and-pr/SKILL.md)). AI text below.* :robot:

## Summary

Add post thumbnails on list pages, enabling a Medium-style thumbnail image beside the post summary. Closes #233.

## Changes

- **`layouts/partials/post_preview.html`** — Render a `.post-image` thumbnail div when `thumbnail` or `image` front matter is set. Falls back from `thumbnail` to `image` automatically.
- **`static/css/main.css`** — Modernize `.post-image` styles: rounded rectangle (`border-radius: 8px`), `object-fit: cover`, `float: right` on desktop, centered on mobile. Remove dead circular/grayscale CSS. Add `.img-title` styling for full-width banner images.
- **Example site** — Add `thumbnail` front matter to 3 posts so the feature is visible in the demo.
- **Docs** — Update `configuration.md` (fix `image` description, add `thumbnail` param) and `pages-and-layouts.md` (add Post Thumbnails section with examples).

## Front Matter

| Param | Type | Description |
|-------|------|-------------|
| `thumbnail` | string | Post thumbnail (rounded rectangle, beside summary on list pages; falls back to `image`) |
| `image` | string | Full-width banner image on list pages + SEO/social sharing |

If both `thumbnail` and `image` are set, `thumbnail` is used for the list-page thumbnail and `image` renders as the full-width banner.

Assisted-by: OpenCode:glm-5