### PR TITLE
fix: home and nodes incorrectly return the same canonical url

### DIFF
--- a/layouts/partials/seo/main.html
+++ b/layouts/partials/seo/main.html
@@ -1,4 +1,11 @@
 {{- partial "seo/schema" . }}
 {{- partial "opengraph.html" . }}
-<link rel="canonical" href="{{ .Permalink }}" />
 {{- partial "seo/twitter" . }}
+{{/* Handle Single Pages vs List/Homepage Pagination */}}
+{{- if .IsNode }}
+  {{/* If it's a list page (home, section, taxonomy), trigger the paginator to get the correct URL */}}
+  <link rel="canonical" href="{{ .Paginator.URL | absURL }}">
+{{- else }}
+  {{/* If it's a regular single post/page */}}
+  <link rel="canonical" href="{{ .Permalink }}">
+{{- end }}


### PR DESCRIPTION
The previous code returns the same canonical url

- http://something/post/

This canonical reference remained the same whether you were really on "/" or "/page/2" or three.

This is an issue as search engines would see "/post/" and "/post/page/2" as duplicates, impacting page ranking.

The new code resolves these issues and correctly gives each node its correct canonical URL.