### PR TITLE
chore: avoid extra files from Claude

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ Temporary Items
 .hugo_build.lock
 exampleSite/public/
 /public/
+
+# Claude requires a symlink to AGENTS.md, all other harnesses support the std
+CLAUDE.md
+.claude/


### PR DESCRIPTION
Claude Code makes extra files because it doesn't follow standards that all the other frameworks follow. :/
