### PR TITLE
fix(seo): self-canonicalize paginated pages without breaking listings

### DIFF
--- a/exampleSite/content/page/configuration.md
+++ b/exampleSite/content/page/configuration.md
@@ -256,6 +256,7 @@ See [Theming](../theming/#custom-stylesheets) for details on using these hooks f
 |-------|------|-------------|
 | `disclaimerText` | string | Disclaimer text shown in footer with a yellow-bordered box |
 | `commit` | string | Base URL for Git commit links (appended with `.GitInfo.Hash`) |
+| `disableCanonical` | bool | Suppress the `<link rel="canonical">` tag site-wide (see [SEO & i18n — Canonical URLs](../seo-and-i18n/#canonical-urls)) |
 
 Git features (`commit`) require `enableGitInfo = true` at the top level of your config (not under `[Params]`) so Hugo populates `.GitInfo`. Example:
 
@@ -288,6 +289,8 @@ These options can be set in the front matter of any page or post:
 | `share_img` | string | Social sharing image (falls back to `image` then `logo`) |
 | `ExpiryDate` | date | Adds `<meta name="robots" content="unavailable_after: ...">` |
 | `seo` | map | Per-page robot meta tag overrides (see [SEO & i18n](../seo-and-i18n/)) |
+| `canonicalURL` | string | Override the canonical link for this page (absolute or relative; see [SEO & i18n — Canonical URLs](../seo-and-i18n/#canonical-urls)) |
+| `disableCanonical` | bool | Suppress the canonical link tag for this page |
 | `ghRepo` | string | GitHub repo for buttons (`"user/repo"`) |
 | `ghBadge` | list | Which badges to show: `["star","watch","fork","follow"]` |
 | `ghCount` | bool | Show count on GitHub buttons (default: `true`) |

--- a/exampleSite/content/page/seo-and-i18n.md
+++ b/exampleSite/content/page/seo-and-i18n.md
@@ -166,8 +166,10 @@ Every page emits a `<link rel="canonical">` tag so search engines know the
 preferred URL for the content. The URL is resolved in this order:
 
 1. **Front matter `canonicalURL`** — if set, it always wins. Relative values
-   are resolved against your `baseURL`. Use this when a page intentionally
-   duplicates another and should point search engines at the original:
+   are resolved against the current language's base URL (so they stay
+   language-correct on multilingual sites); absolute URLs are emitted as-is.
+   Use this when a page intentionally duplicates another and should point
+   search engines at the original:
 
    ```yaml
    ---

--- a/exampleSite/content/page/seo-and-i18n.md
+++ b/exampleSite/content/page/seo-and-i18n.md
@@ -160,6 +160,40 @@ The page description (used in meta tags and structured data) follows this cascad
 2. `.Params.subtitle` (the subtitle)
 3. `.Summary` (auto-generated from content)
 
+## Canonical URLs
+
+Every page emits a `<link rel="canonical">` tag so search engines know the
+preferred URL for the content. The URL is resolved in this order:
+
+1. **Front matter `canonicalURL`** — if set, it always wins. Relative values
+   are resolved against your `baseURL`. Use this when a page intentionally
+   duplicates another and should point search engines at the original:
+
+   ```yaml
+   ---
+   title: Reposted Article
+   canonicalURL: https://example.com/the-original/
+   ---
+   ```
+
+2. **Paginated list pages** (home, sections, taxonomy terms) self-canonicalize.
+   Page two of a sequence points at itself (`…/page/2/`) rather than at page
+   one, which is [Google's current recommendation](https://developers.google.com/search/docs/specialty/ecommerce/pagination-and-incremental-page-loading)
+   for paginated content.
+
+3. **Everything else** uses the page's own permalink.
+
+### Disabling the tag
+
+Set `disableCanonical = true` in your site `[Params]` to drop the tag
+site-wide, or in a single page's front matter to drop it for that page only —
+for example if you provide canonical links through your own `head_custom.html`:
+
+```toml
+[Params]
+  disableCanonical = true
+```
+
 ## Multilingual Support
 
 Beautiful Hugo supports Hugo's standard multilingual configuration with per-language content directories.

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -8,7 +8,8 @@
           </div>
         {{ end }}
         <div class="posts-list">
-          {{ range where .Paginator.Pages "Params.hidden" "!=" true }}
+          {{ $pag := .Paginate (partial "func/list-pages.html" .) }}
+          {{ range $pag.Pages }}
             {{ partial "post_preview.html" .}}
           {{ end }}
         </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -9,8 +9,7 @@
         {{ end }}
 
         <div class="posts-list">
-          {{ $mainSections := default (slice "post" "posts") site.Params.mainSections }}
-          {{ $pag := .Paginate (where (where site.RegularPages "Type" "in" $mainSections) "Params.hidden" "!=" true) }}
+          {{ $pag := .Paginate (partial "func/list-pages.html" .) }}
           {{ range $pag.Pages }}
             {{ partial "post_preview" . }}
           {{ end }}

--- a/layouts/partials/func/list-pages.html
+++ b/layouts/partials/func/list-pages.html
@@ -1,0 +1,26 @@
+{{- /*
+  Returns the page collection that a list node (home, section, or taxonomy
+  term) displays and paginates.
+
+  This is the single source of truth for that collection so that the
+  canonical link built in <head> (see partials/seo/canonical.html) and the
+  listing built later in <body> paginate the *exact same* set. Hugo caches
+  one paginator per page: whichever `.Paginate`/`.Paginator` call runs first
+  wins, and a later call with a different collection is silently ignored. By
+  routing every caller through this partial, the head and body always agree.
+
+  - Home: regular pages whose type is in `mainSections`, matching the
+    historical home-page listing.
+  - Section / term: the node's own `.Pages` (Hugo's default paginator set).
+
+  In every case pages flagged `hidden` in front matter are dropped before
+  pagination, so they neither appear nor leave gaps in the page numbering.
+
+  Returns: a page collection (slice of pages).
+*/ -}}
+{{- $pages := .Pages -}}
+{{- if .IsHome -}}
+  {{- $mainSections := default (slice "post" "posts") site.Params.mainSections -}}
+  {{- $pages = where site.RegularPages "Type" "in" $mainSections -}}
+{{- end -}}
+{{- return (where $pages "Params.hidden" "!=" true) -}}

--- a/layouts/partials/seo/canonical.html
+++ b/layouts/partials/seo/canonical.html
@@ -1,0 +1,30 @@
+{{- /*
+  Emits the <link rel="canonical"> tag for the current page.
+
+  Resolution order:
+    1. A `canonicalURL` in the page front matter wins — useful when a page
+       intentionally duplicates another and should point search engines at
+       the original. Relative values are resolved against the site baseURL.
+    2. Paginated nodes (home, section, term) use the paginator URL so that
+       each page of a sequence (…/page/2/) self-canonicalizes instead of all
+       pointing at page 1, which is what Google now recommends. The collection
+       comes from `func/list-pages` so the URL built here in <head> matches
+       the listing rendered later in <body> (see that partial for why).
+    3. Everything else (single pages, the taxonomy index, etc.) uses the
+       page permalink.
+
+  Set `disableCanonical = true` in site params to drop the tag site-wide, or
+  in a page's front matter to drop it for that page only.
+*/ -}}
+{{- if not ($.Param "disableCanonical") -}}
+  {{- with .Params.canonicalURL -}}
+<link rel="canonical" href="{{ . | absURL }}" />
+  {{- else -}}
+    {{- if or .IsHome (eq .Kind "section") (eq .Kind "term") -}}
+      {{- $paginator := .Paginate (partial "func/list-pages.html" .) -}}
+<link rel="canonical" href="{{ $paginator.URL | absURL }}" />
+    {{- else -}}
+<link rel="canonical" href="{{ .Permalink }}" />
+    {{- end -}}
+  {{- end -}}
+{{- end -}}

--- a/layouts/partials/seo/canonical.html
+++ b/layouts/partials/seo/canonical.html
@@ -4,7 +4,8 @@
   Resolution order:
     1. A `canonicalURL` in the page front matter wins — useful when a page
        intentionally duplicates another and should point search engines at
-       the original. Relative values are resolved against the site baseURL.
+       the original. Relative values are resolved against the current
+       language's base URL; absolute URLs are emitted unchanged.
     2. Paginated nodes (home, section, term) use the paginator URL so that
        each page of a sequence (…/page/2/) self-canonicalizes instead of all
        pointing at page 1, which is what Google now recommends. The collection
@@ -18,11 +19,11 @@
 */ -}}
 {{- if not ($.Param "disableCanonical") -}}
   {{- with .Params.canonicalURL -}}
-<link rel="canonical" href="{{ . | absURL }}" />
+<link rel="canonical" href="{{ . | absLangURL }}" />
   {{- else -}}
     {{- if or .IsHome (eq .Kind "section") (eq .Kind "term") -}}
       {{- $paginator := .Paginate (partial "func/list-pages.html" .) -}}
-<link rel="canonical" href="{{ $paginator.URL | absURL }}" />
+<link rel="canonical" href="{{ $paginator.URL | absLangURL }}" />
     {{- else -}}
 <link rel="canonical" href="{{ .Permalink }}" />
     {{- end -}}

--- a/layouts/partials/seo/main.html
+++ b/layouts/partials/seo/main.html
@@ -1,4 +1,4 @@
 {{- partial "seo/schema" . }}
 {{- partial "opengraph.html" . }}
-<link rel="canonical" href="{{ .Permalink }}" />
+{{- partial "seo/canonical.html" . }}
 {{- partial "seo/twitter" . }}


### PR DESCRIPTION
:robot: Closes #751. Supersedes #750.

## Problem

The canonical link added in #731 uses `.Permalink`, so **every paginated page canonicalizes to page 1** (`/page/2/` → `/`, `/post/page/2/` → `/post/`). Google's current guidance is that paginated pages should **self-canonicalize**.

Switching to `.Paginator.URL` (as #750 proposes) fixes the URLs but introduces a worse, *silent* bug. The SEO partial runs in `<head>`, before the body. Calling `.Paginator` there builds the **default, unfiltered** paginator first; Hugo caches one paginator per page and then hands that cached set to the body's filtered `.Paginate`, ignoring the filter. I reproduced this: a `hidden: true` post **leaks onto the home page**. This is the "breaks my own site" behavior reported in #751.

## Fix

The key constraint: the `<head>` canonical and the `<body>` listing must paginate the **exact same** collection. So this centralizes that collection.

- **`layouts/partials/func/list-pages.html`** (new) — single source of truth for a list node's collection (home → `mainSections` regular pages; section/term → `.Pages`), with `hidden` pages filtered out *before* pagination so they neither appear nor leave gaps in page numbering.
- **`layouts/partials/seo/canonical.html`** (new) — dedicated, overridable canonical partial. Resolution order:
  1. front-matter `canonicalURL` (absolute or relative — for intentional duplicate content),
  2. paginator URL for `home`/`section`/`term` (self-canonical),
  3. permalink for everything else.

  Honors `disableCanonical` (site-wide `[Params]` or per-page front matter). The taxonomy *index* (`/tags/`) keeps using `.Permalink`, so no phantom paginated pages are generated.
- **`seo/main.html`, `index.html`, `list.html`** routed through the shared collection partial.
- Documented in `exampleSite` (`seo-and-i18n.md`, `configuration.md`).

This gives the #751 author what they asked for: a standard partial that's overridable per page and disableable via config.

## Verification (built example site, diffed against baseline)

- ✅ The 6 paginated pages now self-canonicalize (`/page/2/` → `/page/2/`, `/post/page/2/` → `/post/page/2/`, …); the other 95 canonicals are unchanged.
- ✅ **0 listing regressions** across all 40 listing pages (same pages, same order).
- ✅ A `hidden` post no longer leaks into home/section listings (the #750 bug).
- ✅ Front-matter `canonicalURL` works for both absolute and relative values.
- ✅ `disableCanonical` works site-wide and per-page.
- ✅ Clean build, no warnings or errors.

## Out of scope

The "should `/page/` even be a paginated post list" question raised in #751 is the separate concern the author flagged; this PR only fixes canonical correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)