### PR TITLE
feat: post preview thumbnails on list pages (#233)

### DIFF
--- a/exampleSite/content/page/pages-and-layouts.md
+++ b/exampleSite/content/page/pages-and-layouts.md
@@ -330,7 +330,7 @@ The page is still accessible via its direct URL and appears in navigation menus 
 
 ### Post Preview Images
 
-On list pages, posts can show a circular preview image or video:
+On list pages, posts can show a rounded thumbnail floated beside the snippet (Medium-style). It is grayscale by default and turns to full color on hover:
 
 ```yaml
 ---
@@ -339,7 +339,17 @@ image: /img/avatar-icon.png
 ---
 ```
 
-For a video preview (loop, autoplay, muted):
+Use `thumbnail` to set a dedicated list-view image. It falls back to `image` when unset, so you can crop a separate, square-friendly version just for previews while keeping `image` for sharing/SEO:
+
+```yaml
+---
+title: My Post
+thumbnail: /img/my-post-thumb.png
+image: /img/my-post.png
+---
+```
+
+For a video preview (loop, autoplay, muted) — shown only when no `thumbnail`/`image` is set:
 
 ```yaml
 ---

--- a/exampleSite/content/page/pages-and-layouts.md
+++ b/exampleSite/content/page/pages-and-layouts.md
@@ -349,6 +349,16 @@ image: /img/my-post.png
 ---
 ```
 
+Setting `thumbnail` to an empty string explicitly suppresses the preview image, even when `image` is set (useful for keeping `image` for sharing/SEO without showing a thumbnail in the list):
+
+```yaml
+---
+title: My Post
+thumbnail: ""
+image: /img/my-post.png
+---
+```
+
 For a video preview (loop, autoplay, muted) — shown only when no `thumbnail`/`image` is set:
 
 ```yaml

--- a/exampleSite/content/page/pages-and-layouts.md
+++ b/exampleSite/content/page/pages-and-layouts.md
@@ -293,7 +293,7 @@ The page is still accessible via its direct URL and appears in navigation menus 
 
 ### Post Preview Images
 
-On list pages, posts can show a circular preview image or video:
+On list pages, posts can show a rounded thumbnail floated beside the snippet (Medium-style). It is grayscale by default and turns to full color on hover:
 
 ```yaml
 ---
@@ -302,7 +302,17 @@ image: /img/avatar-icon.png
 ---
 ```
 
-For a video preview (loop, autoplay, muted):
+Use `thumbnail` to set a dedicated list-view image. It falls back to `image` when unset, so you can crop a separate, square-friendly version just for previews while keeping `image` for sharing/SEO:
+
+```yaml
+---
+title: My Post
+thumbnail: /img/my-post-thumb.png
+image: /img/my-post.png
+---
+```
+
+For a video preview (loop, autoplay, muted) — shown only when no `thumbnail`/`image` is set:
 
 ```yaml
 ---

--- a/exampleSite/content/post/2015-01-15-pirates.md
+++ b/exampleSite/content/post/2015-01-15-pirates.md
@@ -5,6 +5,7 @@ categories: ["history"]
 tags: ["humor", "history"]
 showPostNav: false
 hidePostDates: true
+image: /img/gallery/sunset.jpg
 ---
 
 Piracy is typically an act of robbery or criminal violence at sea. The term can include acts committed on land, in the air, or in other major bodies of water or on a shore. It does not normally include crimes committed against persons traveling on the same vessel as the perpetrator (e.g. one passenger stealing from others on the same vessel). The term has been used throughout history to refer to raids across land borders by non-state agents.

--- a/exampleSite/content/post/2015-01-15-pirates.md
+++ b/exampleSite/content/post/2015-01-15-pirates.md
@@ -4,6 +4,7 @@ date: 2015-01-15
 categories: ["history"]
 tags: ["humor", "history"]
 showPostNav: false
+image: /img/gallery/sunset.jpg
 ---
 
 Piracy is typically an act of robbery or criminal violence at sea. The term can include acts committed on land, in the air, or in other major bodies of water or on a shore. It does not normally include crimes committed against persons traveling on the same vessel as the perpetrator (e.g. one passenger stealing from others on the same vessel). The term has been used throughout history to refer to raids across land borders by non-state agents.

--- a/exampleSite/content/post/2015-01-19-soccer.md
+++ b/exampleSite/content/post/2015-01-19-soccer.md
@@ -4,6 +4,8 @@ subtitle: Best sport ever!
 date: 2015-01-19
 categories: ["sports"]
 tags: ["sports"]
+thumbnail: /img/gallery/mountain-thumb.jpg
+image: /img/gallery/mountain.jpg
 ---
 
 From Wikipedia:

--- a/layouts/partials/post_preview.html
+++ b/layouts/partials/post_preview.html
@@ -6,26 +6,36 @@
             {{ .Params.subtitle }}
         </h3>
         {{ end }}
-        {{ if .Params.image }}
-        <img src="{{ strings.TrimPrefix "/" .Params.image | relURL }}" alt="{{ .Title }}" class="img-title" />
-        {{ end }}
-        {{ if .Params.video }}
-        <video loop autoplay muted playsinline class="img-title">
-            <source src="{{ strings.TrimPrefix "/" .Params.video | relURL }}">
-        </video>
-        {{ end }}
     </a>
 
     <p class="post-meta">
         {{ partial "post_meta.html" . }}
     </p>
-    <div class="post-entry">
-        {{ if or (.Truncated) (.Params.summary) (eq .Type "recipe") }}
-        {{ .Summary }}
-        <a href="{{ .RelPermalink }}" class="post-read-more">[{{ i18n "readMore" }}]</a>
-        {{ else }}
-        {{ .Content }}
+    <div class="post-entry-container">
+        {{ $thumbnail := .Params.thumbnail | default .Params.image }}
+        {{ if $thumbnail }}
+        <div class="post-image">
+            <a href="{{ .RelPermalink }}">
+                <img src="{{ strings.TrimPrefix "/" $thumbnail | relURL }}" alt="{{ .Title }}" />
+            </a>
+        </div>
+        {{ else if .Params.video }}
+        <div class="post-image">
+            <a href="{{ .RelPermalink }}">
+                <video loop autoplay muted playsinline>
+                    <source src="{{ strings.TrimPrefix "/" .Params.video | relURL }}">
+                </video>
+            </a>
+        </div>
         {{ end }}
+        <div class="post-entry">
+            {{ if or (.Truncated) (.Params.summary) (eq .Type "recipe") }}
+            {{ .Summary }}
+            <a href="{{ .RelPermalink }}" class="post-read-more">[{{ i18n "readMore" }}]</a>
+            {{ else }}
+            {{ .Content }}
+            {{ end }}
+        </div>
     </div>
 
     {{ if or .Params.categories .Params.tags }}

--- a/layouts/partials/post_preview.html
+++ b/layouts/partials/post_preview.html
@@ -12,14 +12,15 @@
         {{ partial "post_meta.html" . }}
     </p>
     <div class="post-entry-container">
-        {{ $thumbnail := cond (isset .Params "thumbnail") .Params.thumbnail .Params.image }}
+        {{ $hasThumbnail := isset .Params "thumbnail" }}
+        {{ $thumbnail := cond $hasThumbnail .Params.thumbnail .Params.image }}
         {{ if $thumbnail }}
         <div class="post-image">
             <a href="{{ .RelPermalink }}">
                 <img src="{{ strings.TrimPrefix "/" $thumbnail | relURL }}" alt="{{ .Title }}" />
             </a>
         </div>
-        {{ else if .Params.video }}
+        {{ else if and (not $hasThumbnail) .Params.video }}
         <div class="post-image">
             <a href="{{ .RelPermalink }}">
                 <video loop autoplay muted playsinline>

--- a/layouts/partials/post_preview.html
+++ b/layouts/partials/post_preview.html
@@ -12,7 +12,7 @@
         {{ partial "post_meta.html" . }}
     </p>
     <div class="post-entry-container">
-        {{ $thumbnail := .Params.thumbnail | default .Params.image }}
+        {{ $thumbnail := cond (isset .Params "thumbnail") .Params.thumbnail .Params.image }}
         {{ if $thumbnail }}
         <div class="post-image">
             <a href="{{ .RelPermalink }}">

--- a/layouts/partials/post_preview.html
+++ b/layouts/partials/post_preview.html
@@ -6,26 +6,36 @@
             {{ .Params.subtitle }}
         </h3>
         {{ end }}
-        {{ if .Params.image }}
-        <img src="{{ .Params.image | relURL }}" alt="{{ .Title }}" class="img-title" />
-        {{ end }}
-        {{ if .Params.video }}
-        <video loop autoplay muted playsinline class="img-title">
-            <source src="{{ .Params.video | relURL }}">
-        </video>
-        {{ end }}
     </a>
 
     <p class="post-meta">
         {{ partial "post_meta.html" . }}
     </p>
-    <div class="post-entry">
-        {{ if or (.Truncated) (.Params.summary) (eq .Type "recipe") }}
-        {{ .Summary }}
-        <a href="{{ .Permalink }}" class="post-read-more">[{{ i18n "readMore" }}]</a>
-        {{ else }}
-        {{ .Content }}
+    <div class="post-entry-container">
+        {{ $thumbnail := .Params.thumbnail | default .Params.image }}
+        {{ if $thumbnail }}
+        <div class="post-image">
+            <a href="{{ .Permalink }}">
+                <img src="{{ $thumbnail | relURL }}" alt="{{ .Title }}" />
+            </a>
+        </div>
+        {{ else if .Params.video }}
+        <div class="post-image">
+            <a href="{{ .Permalink }}">
+                <video loop autoplay muted playsinline>
+                    <source src="{{ .Params.video | relURL }}">
+                </video>
+            </a>
+        </div>
         {{ end }}
+        <div class="post-entry">
+            {{ if or (.Truncated) (.Params.summary) (eq .Type "recipe") }}
+            {{ .Summary }}
+            <a href="{{ .Permalink }}" class="post-read-more">[{{ i18n "readMore" }}]</a>
+            {{ else }}
+            {{ .Content }}
+            {{ end }}
+        </div>
     </div>
 
     {{ if or .Params.categories .Params.tags }}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -455,7 +455,7 @@ img::selection {
   float: right;
   height: 192px;
   width: 192px;
-  margin-top: -35px;
+  margin-left: 20px;
   filter: grayscale(90%);
 }
 
@@ -469,10 +469,12 @@ img::selection {
   }
 }
 
-.post-image img {
-  border-radius: 100px;
+.post-image img,
+.post-image video {
+  border-radius: 8px;
   height: 192px;
   width: 192px;
+  object-fit: cover;
 }
 
 .post-preview .post-read-more {
@@ -487,7 +489,7 @@ img::selection {
 }
 
 @media only screen and (max-width: 500px) {
-  .post-image, .post-image img {
+  .post-image, .post-image img, .post-image video {
     height: 100px;
     width: 100px;
   }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -497,7 +497,7 @@ img::selection {
   .post-image {
     width: 100%;
     text-align: center;
-    margin-top: 0;
+    margin-left: 0;
     float: left;
   }
 }


### PR DESCRIPTION
Close #748, my first attempt, too.

:robot: _AI text below_ :robot:

## What

Adds Medium-style preview thumbnails beside the post snippet on list pages, close #233.

| Before | After |
| --- | --- |
| `Params.image` rendered full-width and **unstyled** (the `img-title` class has no CSS) | Image renders as a rounded thumbnail floated beside the entry, grayscale → color on hover |

## Why this was mostly a rewiring

The theme already shipped complete, working `.post-image` / `.post-entry-container` CSS for a floated thumbnail, but it had been **orphaned** since 2019 (commit `daa0bcb`), when `post_preview.html` switched to rendering `Params.image` as a full-width `img-title` element that no stylesheet ever targeted. This PR reconnects the template to those styles and modernizes them.

## Changes

- **`layouts/partials/post_preview.html`** — Restructured into `.post-entry-container` + `.post-image` + `.post-entry`. New `thumbnail` front-matter key, falling back to `image` when unset, so authors can crop a dedicated list-view image while keeping `image` for sharing/SEO. Video previews show only when no thumbnail/image is set.
- **`static/css/main.css`** — Rounded corners (`8px`) instead of a space-wasting circle; `object-fit: cover` for clean cropping; `video` now gets the same treatment; removed the stale `margin-top: -35px` that overlapped the (now longer) post-meta line, replaced with `margin-left: 20px`.
- **`exampleSite/content/page/pages-and-layouts.md`** — Documents the `thumbnail`/`image` behavior and hover/grayscale styling.
- **Example posts** — pirates (uses `image`, demonstrates fallback) and soccer (uses dedicated `thumbnail` + `image`) showcase the feature.

## Reviewer notes

- Default behavior of `Params.image` on list pages changes from full-width to side thumbnail. Single post pages are unaffected (they never used `image`).
- Verified `hugo --minify -s exampleSite` builds cleanly across the example site, and checked the rendered layout on desktop (floated right) and mobile (centered above text).

Assisted-by: ClaudeCode:claude-opus-4.8