### PR TITLE
ci: update Hugo CI matrix upper bound to 0.163.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        hugo: [0.146.2, 0.155.2, 0.161.1]
+        hugo: [0.146.2, 0.155.2, 0.163.0]
     steps:
       - name: Install Hugo CLI
         run: >

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ hugo serve -s exampleSite --disableFastRender
 ## Hugo Version
 
 - **Minimum Hugo version**: `0.146.2` (enforced at runtime in `layouts/_default/baseof.html`).
-- **CI matrix** tests against `0.146.2`, `0.147.2`, and `0.155.2`.
+- **CI matrix** tests against `0.146.2`, `0.155.2`, and `0.163.0`.
 - The deploy workflow pins `0.146.2`.
 - CI uses the **extended** Hugo binary.
 


### PR DESCRIPTION
:robot: *Human guided, AI assisted PR ([using this skill](https://github.com/henryiii/skills/blob/main/branch-and-pr/SKILL.md)). AI text below.* :robot:

Update the CI test matrix to replace 0.161.1 with 0.163.0 as the latest Hugo release. Also fix AGENTS.md docs to reflect the current matrix: 0.146.2, 0.155.2, 0.163.0.

Assisted-by: OpenCode:glm-5