### PR TITLE
fix: accept abbreviated month layouts in dateformat validation

### DIFF
--- a/layouts/partials/page_meta.html
+++ b/layouts/partials/page_meta.html
@@ -5,7 +5,7 @@
     {{ if and .Site.Params.dateformat (not (strings.HasPrefix $format ":")) }}
       {{- $nowFmt := now.Format $format -}}
       {{- $yearOK := or (not (findRE `2006` $format)) (findRE (now.Format "2006") $nowFmt) -}}
-      {{- $monthOK := or (findRE (now.Format "01") $nowFmt) (findRE (now.Format "January") $nowFmt) -}}
+      {{- $monthOK := or (findRE (now.Format "01") $nowFmt) (findRE (now.Format "Jan") $nowFmt) (findRE (now.Format "January") $nowFmt) -}}
       {{- $dayOK := or (findRE (now.Format "02") $nowFmt) (findRE (now.Format "2") $nowFmt) -}}
       {{ if or (not $yearOK) (not $monthOK) (not $dayOK) }}
         {{ errorf "beautifulhugo: Params.dateformat %q is not a valid Go time layout. Go uses the reference time Mon Jan 2 15:04:05 MST 2006 — use e.g. \"2006-01-02\" instead of \"2023-10-15\", or use a Hugo locale token like \":date_long\". See https://go.dev/src/time/format.go" .Site.Params.dateformat }}

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -9,7 +9,7 @@
   {{ if and .Site.Params.dateformat (not (strings.HasPrefix $format ":")) }}
     {{- $nowFmt := now.Format $format -}}
     {{- $yearOK := or (not (findRE `2006` $format)) (findRE (now.Format "2006") $nowFmt) -}}
-    {{- $monthOK := or (findRE (now.Format "01") $nowFmt) (findRE (now.Format "January") $nowFmt) -}}
+    {{- $monthOK := or (findRE (now.Format "01") $nowFmt) (findRE (now.Format "Jan") $nowFmt) (findRE (now.Format "January") $nowFmt) -}}
     {{- $dayOK := or (findRE (now.Format "02") $nowFmt) (findRE (now.Format "2") $nowFmt) -}}
     {{ if or (not $yearOK) (not $monthOK) (not $dayOK) }}
       {{ errorf "beautifulhugo: Params.dateformat %q is not a valid Go time layout. Go uses the reference time Mon Jan 2 15:04:05 MST 2006 — use e.g. \"2006-01-02\" instead of \"2023-10-15\", or use a Hugo locale token like \":date_long\". See https://go.dev/src/time/format.go" .Site.Params.dateformat }}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

The `dateformat` validator in `layouts/partials/post_meta.html` and `layouts/partials/page_meta.html` only accepted the numeric (`01`) and full (`January`) month forms. This meant that valid Go layouts using the abbreviated month token (`Jan`) — most notably `"Jan 2, 2006"`, the canonical Go reference time format — failed the build with a misleading "is not a valid Go time layout" error.

- Added `(findRE (now.Format "Jan") $nowFmt)` to the `$monthOK` check in both `post_meta.html` and `page_meta.html`.
- The fix is minimal (one line change per file) and preserves the existing style and structure.

## Verification

- `dateFormat = "Jan 2, 2006"` — builds cleanly (previously errored)
- `dateFormat = "2 Jan 2006"` — builds cleanly (previously errored)
- `dateFormat = "2023-10-15"` — still produces `ERROR … is not a valid Go time layout` (validator correctly rejects real mistakes)
- Unmodified `exampleSite/hugo.toml` (`dateFormat = ":date_long"`) — clean build with `hugo --minify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #759.
