### PR TITLE
fix: stop hidden pages leaking into section and term listings

### DIFF
--- a/layouts/partials/seo/schema.html
+++ b/layouts/partials/seo/schema.html
@@ -14,14 +14,8 @@
 {{- if .IsNode -}}
   {{- $pagesToPaginate := slice -}}
 
-  {{/* 1. Direct the data source based on what kind of page we are on */}}
-  {{- if eq .Kind "home" -}}
-    {{/* Homepage: grab articles from your main configured sections */}}
-    {{- $pagesToPaginate = partial "func/list-pages" . -}}
-  {{- else -}}
-    {{/* Section, Taxonomy, or Term: dynamically inherit THIS specific page's list context */}}
-    {{- $pagesToPaginate = .Pages -}}
-  {{- end -}}
+  {{/* 1. Get the filtered page collection (hidden pages excluded) for this node */}}
+  {{- $pagesToPaginate = partial "func/list-pages" . -}}
 
   {{/* 2. Pass that collection directly to the standard Hugo paginator */}}
   {{- $paginator = .Paginate $pagesToPaginate -}}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Bug

Pages with `hidden: true` in front matter were leaking into section and taxonomy term listing pages, both in the visible HTML and in the JSON-LD structured data.

## Root Cause

`layouts/partials/seo/schema.html` builds the paginator in `<head>` (before body templates execute). Hugo enforces a strict one-paginator-per-page rule: whichever `.Paginate` call runs first wins, and subsequent calls with a different collection are silently ignored.

For `.Kind "home"` the schema partial correctly used `partial "func/list-pages" .`, which filters out `hidden: true` pages. But for every other node kind (sections, taxonomy terms) it fell through to the unfiltered `.Pages`:

```go
{{- if eq .Kind "home" -}}
  {{- $pagesToPaginate = partial "func/list-pages" . -}}
{{- else -}}
  {{/* Section, Taxonomy, or Term */}}
  {{- $pagesToPaginate = .Pages -}}   ← unfiltered!
{{- end -}}
```

Because `schema.html` runs first, the unfiltered paginator won the race. The filtered `.Paginate` call in `layouts/_default/list.html` was then silently ignored, so hidden posts appeared in section/term listings and their JSON-LD.

## Fix

Route all node kinds through `partial "func/list-pages" .`. That partial already handles both home and non-home nodes — returning `.Pages` filtered by `hidden != true` for section/term pages, and the `mainSections` filtered list for home. The home/else branching collapses to a single unconditional call:

```go
{{/* 1. Get the filtered page collection (hidden pages excluded) for this node */}}
{{- $pagesToPaginate = partial "func/list-pages" . -}}
```

## Verification

1. Created `exampleSite/content/post/zz-hidden-test.md` with `hidden: true` and title `ZZHIDDENTEST`.
2. Built with `hugo -s exampleSite`.
3. `grep ZZHIDDENTEST /tmp/bh-verify-.../post/index.html` → no output (post does not appear in section listing or its JSON-LD).
4. `grep Pirates /tmp/bh-verify-.../index.html` → found (normal posts still list correctly on home page).
5. Removed the test post; `git status` shows only `layouts/partials/seo/schema.html` modified.
6. Final clean build `hugo --minify -s exampleSite` succeeded with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #759.
