### PR TITLE
fix: close delayDisqus document-ready handler (JS syntax error)

### DIFF
--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -100,9 +100,10 @@ $(function(){
       (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(disqus);
     })();
       
-    $(this).hide(); 
+    $(this).hide();
     });
-      
+  });
+
 </script>
 <script id="dsq-count-scr" src="//{{ .Site.Config.Services.Disqus.Shortname }}.disqus.com/count.js" async></script>
 {{ end }}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Bug

In `layouts/partials/scripts.html`, the inline script that powers the delayed Disqus comment loader opens a jQuery document-ready wrapper — `$(function(){` — but never closes it before `</script>`. The only `});` present closes the inner `$('#show-comments').on('click', function(){...})` handler; the outer wrapper is left open.

This is a JavaScript syntax error. `node --check` on the extracted script reports `SyntaxError: Unexpected end of input`. As a result, the entire script block fails to parse, the click handler never registers, and the "Show comments" button does nothing when `delayDisqus` is enabled with a Disqus shortname.

## Fix

Add the missing `});` to properly close the `$(function(){` document-ready wrapper before `</script>`.

The diff is a single logical change: one line added (`  });`) and one trailing-whitespace cleanup on the preceding line. No refactoring or reformatting.

## Verification

- `node --check` on the extracted JS (with a dummy shortname substituted) now passes.
- `hugo --minify -s exampleSite` builds cleanly with no errors (tested against Hugo 0.163.0 extended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #759.
