### PR TITLE
fix: fetch the language-specific search index

### DIFF
--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -38,7 +38,7 @@
   <script>
     window.searchProviderConfig = {
      provider: "{{ $searchProvider }}",
-     searchIndexURL: {{ "index.json" | relURL }},
+     searchIndexURL: {{ "index.json" | relLangURL }},
      searchPageURL: {{ "search" | relLangURL }}
     };
     window.searchConfig = {

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -156,7 +156,7 @@
 <script>
   window.searchProviderConfig = {
     provider: "{{ $searchProvider }}",
-    searchIndexURL: {{ "index.json" | relURL }},
+    searchIndexURL: {{ "index.json" | relLangURL }},
     searchPageURL: {{ "search" | relLangURL }}
   };
   window.searchConfig = {


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

- The fuse search configuration used `relURL` for `searchIndexURL`, which always resolves to the default-language `/index.json`.
- Multilingual Hugo sites emit one search index per language (e.g. `/fr/index.json`), so non-default languages were silently searching the wrong index.
- Changed `relURL` to `relLangURL` in both `layouts/partials/nav.html` and `layouts/_default/search.html`, matching the already-correct `searchPageURL` which uses `relLangURL`.

## Verification

**Single-language (unchanged output):** Built the example site and confirmed `searchIndexURL` still renders as `/index.json` — no regression for single-language sites.

**Multilingual (corrected output):** Added a minimal `[languages.en]` / `[languages.fr]` stanza to the example config and rebuilt. Before the fix, the French home page would have emitted `searchIndexURL:"/index.json"`. After the fix it correctly emits `searchIndexURL:"/fr/index.json"`, and Hugo does emit `/fr/index.json` as expected.

## Test plan

- [ ] Build the example site with `hugo --minify -s exampleSite` and confirm no build errors.
- [ ] For a multilingual site, verify that each language's pages reference the correct per-language `index.json` (e.g. `/fr/index.json` for French).
- [ ] Confirm single-language sites are unaffected (output remains `/index.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #759.
