### PR TITLE
docs: remove stale params from the example site config

### DIFF
--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -39,7 +39,6 @@ enableGitInfo = true
   headerImgStyle = "narrow"
   showSource = true
   sourceRepo = "https://github.com/halogenica/beautifulhugo/blob/master/exampleSite/"
-  comment = "https://github.com/halogenica/beautifulhugo/commit/"
 
   [Params.search]
     provider = "fuse"
@@ -55,11 +54,7 @@ enableGitInfo = true
   src = "/img/hexagon.jpg"
   desc = "Hexagon"
 
-#[Params.AISearchSummary.Googlebot]
-#summaryLimit = 150
-#[Params.AISearchSummary.robots]
-#summaryLimit = 300
-
+# For AI search summary limits, see [Params.seo] in the SEO & i18n docs.
 
 [Params.author]
   name = "Some Person"


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

- Removed `Params.comment` which was a typo'd leftover of `Params.commit` (disabled two lines above it); `git grep` confirms nothing in the theme reads `Params.comment`
- Replaced the stale commented-out `[Params.AISearchSummary.*]` block (which referenced a config scheme never implemented) with a single pointer comment directing users to the actual `[Params.seo]` feature documented in the SEO & i18n page

## Test plan

- [x] `hugo --minify -s exampleSite` builds cleanly (103 pages, no errors)
- [x] Only `exampleSite/hugo.toml` is modified
- [x] `git grep -n "Params.comment"` returns no hits in template code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #759.
