### PR TITLE
fix: remove StumbleUpon, fix email share icon, omit empty via param

### DIFF
--- a/layouts/partials/share-links.html
+++ b/layouts/partials/share-links.html
@@ -4,7 +4,7 @@
     <ul class="share" aria-label="Social sharing" role="list">
       <!-- Twitter -->
       <li role="listitem">
-        <a href="//twitter.com/share?url={{ .Permalink }}&amp;text={{ .Title }}&amp;via={{ .Site.Params.author.twitter }}" target="_blank" rel="noopener noreferrer" title="Share on Twitter">
+        <a href="//twitter.com/share?url={{ .Permalink }}&amp;text={{ .Title }}{{ with .Site.Params.author.twitter }}&amp;via={{ . }}{{ end }}" target="_blank" rel="noopener noreferrer" title="Share on Twitter">
           <i class="fab fa-twitter" aria-hidden="true"></i>
           <span class="visually-hidden">Share on Twitter</span>
         </a>
@@ -34,14 +34,6 @@
         </a>
       </li>
 
-      <!-- StumbleUpon -->
-      <li role="listitem">
-        <a href="//www.stumbleupon.com/submit?url={{ .Permalink }}&amp;title={{ .Title }}" target="_blank" rel="noopener noreferrer" title="Share on StumbleUpon">
-          <i class="fab fa-stumbleupon" aria-hidden="true"></i>
-          <span class="visually-hidden">Share on StumbleUpon</span>
-        </a>
-      </li>
-
       <!-- Pinterest -->
       <li role="listitem">
         <a href="//www.pinterest.com/pin/create/button/?url={{ .Permalink }}&amp;description={{ .Title }}" target="_blank" rel="noopener noreferrer" title="Share on Pinterest">
@@ -53,7 +45,7 @@
       <!-- Email -->
       <li role="listitem">
         <a href="mailto:?body={{ .Permalink }}&amp;subject={{ .Title }}" title="Share via email">
-          <i class="fab fa-at" aria-hidden="true"></i>
+          <i class="fas fa-at" aria-hidden="true"></i>
           <span class="visually-hidden">Share via email</span>
         </a>
       </li>


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Three bug fixes to `layouts/partials/share-links.html`:

- **Remove StumbleUpon**: StumbleUpon shut down in 2018; the share link has been dead for years. Removed the entire `<li>` block.
- **Fix email share icon**: The email entry used `fab fa-at`, but `fa-at` is a solid (not brand) icon — Font Awesome renders nothing with the wrong prefix. Changed to `fas fa-at`.
- **Omit empty `via=` param on Twitter share**: The Twitter share URL always appended `&via={{ .Site.Params.author.twitter }}` even when `author.twitter` was unset, producing a dangling `&via=` query parameter. Wrapped it in `{{ with .Site.Params.author.twitter }}&amp;via={{ . }}{{ end }}` so the param is only included when the value is set.

## Test plan

- [x] `hugo --minify -s exampleSite` builds clean (no errors or warnings)
- [x] A built post page contains no "stumbleupon" text
- [x] The email icon class is `fas fa-at` in the built output
- [x] The Twitter share URL includes `&via=username` when `author.twitter = "username"` is set
- [x] The Twitter share URL has NO `via=` param when `author.twitter` is absent from config
- [x] `git status` shows only `layouts/partials/share-links.html` changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #759.
