### PR TITLE
fix: handle quoted values for ai-summary-limit

### DIFF
--- a/layouts/partials/seo/meta/get-ai-summary-limit.html
+++ b/layouts/partials/seo/meta/get-ai-summary-limit.html
@@ -6,7 +6,7 @@
 {{- else if eq $value "none" -}}
   {{/* None means no limit so return an empty string value. */}}
 {{- else if findRE `^\d+$` $value -}}
-  {{- $tag = printf "max-snippet:%d" $value -}}
+  {{- $tag = printf "max-snippet:%d" (int $value) -}}
 {{- else -}}
   {{- errorf "ai-summary-limit has an invalid value." -}}
 {{- end -}}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

- `printf "%d"` in `layouts/partials/seo/meta/get-ai-summary-limit.html` emits `max-snippet:%!d(string=50)` when the front matter value is a quoted number (e.g. `ai-summary-limit: "50"`)
- The `findRE` guard passes for both int and string representations since Hugo casts to string for regex, but `printf "%d"` only accepts an actual integer
- Fix: cast `$value` to `int` before formatting — `printf "max-snippet:%d" (int $value)`

## Test plan

- [ ] Build `hugo --minify -s exampleSite` succeeds cleanly with no errors
- [ ] Confirm pages with integer `ai-summary-limit` still render `max-snippet:50` correctly
- [ ] Manually verified: adding `ai-summary-limit: "50"` (quoted) to a page's front matter renders `<meta name="googlebot" content="max-snippet:50">` (before this fix it rendered `max-snippet:%!d(string=50)`)
- [ ] Revert test content change before committing — only `layouts/partials/seo/meta/get-ai-summary-limit.html` is modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #759.
