### PR TITLE
refactor: extract duplicated logic into shared partials

### DIFF
--- a/layouts/partials/func/date-format.html
+++ b/layouts/partials/func/date-format.html
@@ -1,0 +1,28 @@
+{{- /*
+  Resolves the date format string used to render page/post dates and
+  validates a user-supplied `Params.dateformat` against Go's reference
+  time layout.
+
+  Go's `time` package formats dates against the reference time
+  Mon Jan 2 15:04:05 MST 2006, so a string like "2023-10-15" silently
+  produces garbage. This partial heuristically checks that the resolved
+  format round-trips year/month/day and emits an `errorf` if it does not,
+  so misconfiguration fails the build instead of shipping wrong dates.
+
+  Locale tokens (formats beginning with ":", e.g. ":date_long") are
+  passed through untouched.
+
+  Takes: the page context (.).
+  Returns: the resolved format string.
+*/ -}}
+{{- $format := default (i18n "dateFormat") .Site.Params.dateformat -}}
+{{- if and .Site.Params.dateformat (not (strings.HasPrefix $format ":")) -}}
+  {{- $nowFmt := now.Format $format -}}
+  {{- $yearOK := or (not (findRE `2006` $format)) (findRE (now.Format "2006") $nowFmt) -}}
+  {{- $monthOK := or (findRE (now.Format "01") $nowFmt) (findRE (now.Format "Jan") $nowFmt) (findRE (now.Format "January") $nowFmt) -}}
+  {{- $dayOK := or (findRE (now.Format "02") $nowFmt) (findRE (now.Format "2") $nowFmt) -}}
+  {{- if or (not $yearOK) (not $monthOK) (not $dayOK) -}}
+    {{- errorf "beautifulhugo: Params.dateformat %q is not a valid Go time layout. Go uses the reference time Mon Jan 2 15:04:05 MST 2006 — use e.g. \"2006-01-02\" instead of \"2023-10-15\", or use a Hugo locale token like \":date_long\". See https://go.dev/src/time/format.go" .Site.Params.dateformat -}}
+  {{- end -}}
+{{- end -}}
+{{- return $format -}}

--- a/layouts/partials/func/menu-name.html
+++ b/layouts/partials/func/menu-name.html
@@ -1,0 +1,20 @@
+{{- /*
+  Resolves the display name for a navbar menu entry.
+
+  Defaults to the entry's `.Name`. If the entry declares an
+  `.Identifier`, it looks up an i18n string keyed `menu_<identifier>`
+  and uses the translation when one exists (i.e. differs from the key),
+  allowing menu labels to be localized without renaming the menu entry.
+
+  Takes: a menu entry.
+  Returns: the display name string.
+*/ -}}
+{{- $name := .Name -}}
+{{- with .Identifier -}}
+  {{- $key := printf "menu_%s" . -}}
+  {{- $translated := i18n $key -}}
+  {{- if and $translated (ne $translated $key) -}}
+    {{- $name = $translated -}}
+  {{- end -}}
+{{- end -}}
+{{- return $name -}}

--- a/layouts/partials/func/toc-state.html
+++ b/layouts/partials/func/toc-state.html
@@ -1,0 +1,31 @@
+{{- /*
+  Computes the availability state for the TOC / posts side panel, shared
+  by the navbar toggle button (nav.html) and the panel itself (toc.html).
+
+  - `isListPage`: the node is a section or the home page, so the panel
+    shows a posts list rather than a table of contents.
+  - `hasToc`: the rendered TableOfContents contains at least one item.
+  - `listPages`: on the home page, the mainSections-filtered non-hidden
+    regular pages; on a section, the paginator's pages. Empty otherwise.
+  - `hasListPages`: whether `listPages` is non-empty.
+
+  Note: this touches `.Paginator`, but only relocates logic the callers
+  already ran, so the cached paginator selection is unchanged.
+
+  Takes: the page context (.).
+  Returns: dict with "isListPage", "hasToc", "hasListPages", "listPages".
+*/ -}}
+{{- $isListPage := or .IsSection .IsHome -}}
+{{- $hasToc := and .TableOfContents (findRE `<li>` .TableOfContents) -}}
+{{- $hasListPages := false -}}
+{{- $listPages := slice -}}
+{{- if $isListPage -}}
+  {{- if .IsHome -}}
+    {{- $mainSections := default (slice "post" "posts") site.Params.mainSections -}}
+    {{- $listPages = where (where site.RegularPages "Type" "in" $mainSections) "Params.hidden" "!=" true -}}
+  {{- else -}}
+    {{- $listPages = .Paginator.Pages -}}
+  {{- end -}}
+  {{- $hasListPages = gt (len $listPages) 0 -}}
+{{- end -}}
+{{- return (dict "isListPage" $isListPage "hasToc" $hasToc "hasListPages" $hasListPages "listPages" $listPages) -}}

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -5,19 +5,8 @@
     <a class="navbar-brand" href="{{ "" | absLangURL }}">{{ .Site.Params.homeTitle | default .Site.Title }}</a>
     <div class="d-flex align-items-center">
       {{ if ne ($.Param "toc") false }}
-      {{ $hasToc := and .TableOfContents (findRE `<li>` .TableOfContents) }}
-      {{ $isListPage := or .IsSection .IsHome }}
-      {{ $hasListPages := false }}
-      {{ if $isListPage }}
-        {{ if .IsHome }}
-          {{ $mainSections := default (slice "post" "posts") site.Params.mainSections }}
-          {{ $filtered := where (where site.RegularPages "Type" "in" $mainSections) "Params.hidden" "!=" true }}
-          {{ $hasListPages = gt (len $filtered) 0 }}
-        {{ else }}
-          {{ $hasListPages = gt (len .Paginator.Pages) 0 }}
-        {{ end }}
-      {{ end }}
-      {{ if or $hasToc $hasListPages }}
+      {{ $tocState := partial "func/toc-state.html" . }}
+      {{ if or $tocState.hasToc $tocState.hasListPages }}
       <button class="theme-toggle" id="toc-toggle" aria-label="Table of contents" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Table of contents">
         <span class="fas fa-list"></span>
       </button>
@@ -43,14 +32,7 @@
     <div class="collapse navbar-collapse" id="main-navbar">
       <ul class="navbar-nav ms-auto">
         {{ range .Site.Menus.main.ByWeight }}
-          {{ $name := .Name }}
-          {{ with .Identifier }}
-            {{ $key := printf "menu_%s" . }}
-            {{ $translated := i18n $key }}
-            {{ if and $translated (ne $translated $key) }}
-              {{ $name = $translated }}
-            {{ end }}
-          {{ end }}
+          {{ $name := partial "func/menu-name.html" . }}
           {{ if .HasChildren }}
             <li class="nav-item dropdown" >
               <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
@@ -58,14 +40,7 @@
               </a>
               <ul class="dropdown-menu dropdown-menu-end">
                 {{ range .Children }}
-                  {{ $childName := .Name }}
-                  {{ with .Identifier }}
-                    {{ $key := printf "menu_%s" . }}
-                    {{ $translated := i18n $key }}
-                    {{ if and $translated (ne $translated $key) }}
-                      {{ $childName = $translated }}
-                    {{ end }}
-                  {{ end }}
+                  {{ $childName := partial "func/menu-name.html" . }}
                   <li><a class="dropdown-item" href="{{ .URL | relLangURL }}">{{ $childName }}</a></li>
                 {{ end }}
               </ul>

--- a/layouts/partials/page_meta.html
+++ b/layouts/partials/page_meta.html
@@ -1,16 +1,7 @@
 <div class="page-meta">
   {{ $show := default .Site.Params.showPageDates .Params.showPageDates }}
   {{ if $show }}
-    {{ $format := default (i18n "dateFormat") .Site.Params.dateformat }}
-    {{ if and .Site.Params.dateformat (not (strings.HasPrefix $format ":")) }}
-      {{- $nowFmt := now.Format $format -}}
-      {{- $yearOK := or (not (findRE `2006` $format)) (findRE (now.Format "2006") $nowFmt) -}}
-      {{- $monthOK := or (findRE (now.Format "01") $nowFmt) (findRE (now.Format "Jan") $nowFmt) (findRE (now.Format "January") $nowFmt) -}}
-      {{- $dayOK := or (findRE (now.Format "02") $nowFmt) (findRE (now.Format "2") $nowFmt) -}}
-      {{ if or (not $yearOK) (not $monthOK) (not $dayOK) }}
-        {{ errorf "beautifulhugo: Params.dateformat %q is not a valid Go time layout. Go uses the reference time Mon Jan 2 15:04:05 MST 2006 — use e.g. \"2006-01-02\" instead of \"2023-10-15\", or use a Hugo locale token like \":date_long\". See https://go.dev/src/time/format.go" .Site.Params.dateformat }}
-      {{ end }}
-    {{ end }}
+    {{ $format := partial "func/date-format.html" . }}
     {{ $datestr := time.Format $format .Date }}
     {{ $lastmodstr := time.Format $format .Lastmod }}
     {{ if ne $datestr $lastmodstr }}

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -5,16 +5,7 @@
   {{- else -}}
     {{- $data = .Site.Data -}}
   {{- end -}}
-  {{ $format := default (i18n "dateFormat") .Site.Params.dateformat }}
-  {{ if and .Site.Params.dateformat (not (strings.HasPrefix $format ":")) }}
-    {{- $nowFmt := now.Format $format -}}
-    {{- $yearOK := or (not (findRE `2006` $format)) (findRE (now.Format "2006") $nowFmt) -}}
-    {{- $monthOK := or (findRE (now.Format "01") $nowFmt) (findRE (now.Format "Jan") $nowFmt) (findRE (now.Format "January") $nowFmt) -}}
-    {{- $dayOK := or (findRE (now.Format "02") $nowFmt) (findRE (now.Format "2") $nowFmt) -}}
-    {{ if or (not $yearOK) (not $monthOK) (not $dayOK) }}
-      {{ errorf "beautifulhugo: Params.dateformat %q is not a valid Go time layout. Go uses the reference time Mon Jan 2 15:04:05 MST 2006 — use e.g. \"2006-01-02\" instead of \"2023-10-15\", or use a Hugo locale token like \":date_long\". See https://go.dev/src/time/format.go" .Site.Params.dateformat }}
-    {{ end }}
-  {{ end }}
+  {{ $format := partial "func/date-format.html" . }}
   {{ $datestr := time.Format $format .Date }}
   {{ $lastmodstr := time.Format $format .Lastmod }}
   {{ $show := not ( .Site.Params.hidePostDates ) }}

--- a/layouts/partials/seo/structured/article.html
+++ b/layouts/partials/seo/structured/article.html
@@ -10,20 +10,9 @@
   {{- $keywords = $keywords | append . -}}
 {{- end -}}
 
-{{- $authors := partial "author_list.html" . -}}
-{{- $authorSchema := slice -}}
-{{- $authorIds := slice -}}
-{{- range $authors -}}
-  {{- $authorId := (print $.Site.BaseURL (print "#author-" (urlize .name))) }}
-  {{- $authorIds = $authorIds | append (dict "@id" $authorId) }}
-  {{- $a := dict
-    "@type" "Person"
-    "name" .name
-    "url" (or .url $.Site.BaseURL)
-    "@id" $authorId
-  -}}
-  {{- $authorSchema = $authorSchema | append $a -}}
-{{- end -}}
+{{- $authorData := partial "seo/structured/author-schema.html" . -}}
+{{- $authorSchema := $authorData.schema -}}
+{{- $authorIds := $authorData.ids -}}
 
 {{- $schema := dict
   "@type" "Article"

--- a/layouts/partials/seo/structured/author-schema.html
+++ b/layouts/partials/seo/structured/author-schema.html
@@ -1,0 +1,28 @@
+{{- /*
+  Builds the author JSON-LD fragments shared by the Article and Recipe
+  structured-data schemas.
+
+  For each author returned by `author_list.html` it produces a full
+  schema.org Person dict (with a stable `@id`) plus a lightweight
+  `{ "@id": ... }` reference used in the parent schema's `author` field.
+
+  Takes: the page context (.).
+  Returns: dict with
+    - "schema": slice of Person dicts.
+    - "ids": slice of @id reference dicts.
+*/ -}}
+{{- $authors := partial "author_list.html" . -}}
+{{- $authorSchema := slice -}}
+{{- $authorIds := slice -}}
+{{- range $authors -}}
+  {{- $authorId := (print $.Site.BaseURL (print "#author-" (urlize .name))) -}}
+  {{- $authorIds = $authorIds | append (dict "@id" $authorId) -}}
+  {{- $a := dict
+    "@type" "Person"
+    "name" .name
+    "url" (or .url $.Site.BaseURL)
+    "@id" $authorId
+  -}}
+  {{- $authorSchema = $authorSchema | append $a -}}
+{{- end -}}
+{{- return (dict "schema" $authorSchema "ids" $authorIds) -}}

--- a/layouts/partials/seo/structured/recipe.html
+++ b/layouts/partials/seo/structured/recipe.html
@@ -32,20 +32,9 @@
   {{- $instructions = $instructions | append $s -}}
 {{- end -}}
 
-{{- $authors := partial "author_list.html" . -}}
-{{- $authorSchema := slice -}}
-{{- $authorIds := slice -}}
-{{- range $authors -}}
-  {{- $authorId := (print $.Site.BaseURL (print "#author-" (urlize .name))) }}
-  {{- $authorIds = $authorIds | append (dict "@id" $authorId) }}
-  {{- $a := dict
-    "@type" "Person"
-    "name" .name
-    "url" (or .url $.Site.BaseURL)
-    "@id" $authorId
-  -}}
-  {{- $authorSchema = $authorSchema | append $a -}}
-{{- end -}}
+{{- $authorData := partial "seo/structured/author-schema.html" . -}}
+{{- $authorSchema := $authorData.schema -}}
+{{- $authorIds := $authorData.ids -}}
 
 {{- $schema := dict
   "@type" (slice "Article" "Recipe")

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -1,17 +1,9 @@
 {{- if ne ($.Param "toc") false -}}
-{{- $isListPage := or .IsSection .IsHome -}}
-{{- $hasToc := and .TableOfContents (findRE `<li>` .TableOfContents) -}}
-{{- $hasListPages := false -}}
-{{- $listPages := slice -}}
-{{- if $isListPage -}}
-  {{- if .IsHome -}}
-    {{- $mainSections := default (slice "post" "posts") site.Params.mainSections -}}
-    {{- $listPages = where (where site.RegularPages "Type" "in" $mainSections) "Params.hidden" "!=" true -}}
-  {{- else -}}
-    {{- $listPages = .Paginator.Pages -}}
-  {{- end -}}
-  {{- $hasListPages = gt (len $listPages) 0 -}}
-{{- end -}}
+{{- $tocState := partial "func/toc-state.html" . -}}
+{{- $isListPage := $tocState.isListPage -}}
+{{- $hasToc := $tocState.hasToc -}}
+{{- $hasListPages := $tocState.hasListPages -}}
+{{- $listPages := $tocState.listPages -}}
 {{- if or $hasToc $hasListPages -}}
 <div class="toc-wrapper" id="toc-wrapper" data-toc-mode="{{ if $isListPage }}posts{{ else }}headings{{ end }}">
   <div class="toc-panel" id="toc-panel" role="dialog" aria-label="Table of contents">


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Pure refactor that pulls four blocks of duplicated template logic into shared returning partials. No behavior change.

## Extractions

1. **`func/date-format.html`** — dateformat resolution + Go-layout validation (the `errorf` on misconfigured `Params.dateformat`), previously duplicated in `post_meta.html` and `page_meta.html`.
2. **`seo/structured/author-schema.html`** — author Person dicts and `@id` reference slices for JSON-LD, previously duplicated in the Article and Recipe structured-data schemas. Returns `(dict \"schema\" ... \"ids\" ...)`.
3. **`func/menu-name.html`** — the `menu_<identifier>` i18n lookup, previously duplicated for top-level entries and dropdown children in `nav.html`.
4. **`func/toc-state.html`** — TOC / posts-panel availability (`isListPage`, `hasToc`, `hasListPages`, `listPages`), previously duplicated between the navbar toggle (`nav.html`) and the panel (`toc.html`). The `toc` guards stay at the call sites.

## Verification

- Built the example site before and after the refactor. The **minified production output is byte-identical**, and the non-minified output differs only in insignificant blank lines from partial trim markers (every HTML file matches once blank lines are ignored; same file set).
- Confirmed the dateformat validation still fires: `dateformat = \"2023-10-15\"` emits the unchanged `not a valid Go time layout` error, while `dateformat = \"Jan 2, 2006\"` builds clean.
- `hugo --minify -s exampleSite` builds clean.

Part of #759.

🤖 Generated with [Claude Code](https://claude.com/claude-code)