### PR TITLE
refactor: simplify redundant template logic

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -27,11 +27,8 @@
 		{{- if and (eq $social.id "linkedin") (not (findRE "/" $authorValue)) -}}
 		  {{- $authorValue = printf "in/%s" $authorValue -}}
 		{{- end -}}
-		{{ if or ( hasPrefix $authorValue "http://" ) ( hasPrefix $authorValue "https://" ) }}
-		  <a {{ if $social.rel }}rel="{{ $social.rel }} noopener noreferrer" {{ else }}rel="noopener noreferrer" {{ end }}href="{{ printf "%s" $authorValue }}" title="{{ $social.title }}" aria-label="{{ $social.title }}">
-		{{ else }}
-		  <a {{ if $social.rel }}rel="{{ $social.rel }} noopener noreferrer" {{ else }}rel="noopener noreferrer" {{ end }}href="{{ printf $social.url $authorValue }}" title="{{ $social.title }}" aria-label="{{ $social.title }}">
-		{{ end }}
+		{{- $href := or (and (or (hasPrefix $authorValue "http://") (hasPrefix $authorValue "https://")) $authorValue) (printf $social.url $authorValue) -}}
+		  <a rel="{{ with $social.rel }}{{ . }} {{ end }}noopener noreferrer" href="{{ $href }}" title="{{ $social.title }}" aria-label="{{ $social.title }}">
                   <span class="fa-stack fa-lg">
                     <i class="fas fa-circle fa-stack-2x"></i>
                     <i class="{{ $social.icon }} fa-stack-1x fa-inverse" aria-hidden="true"></i>

--- a/layouts/partials/github-buttons.html
+++ b/layouts/partials/github-buttons.html
@@ -9,13 +9,12 @@
   Only the specified badges will be rendered.
 */ -}}
 
-{{ if and .Params.ghRepo (or .Params.ghBadge (and .Site.Params.ghBadge)) }}
+{{ $badges := .Params.ghBadge | default .Site.Params.ghBadge }}
+{{ if and .Params.ghRepo $badges }}
   {{ $repo := .Params.ghRepo }}
-  {{ $badges := .Params.ghBadge | default .Site.Params.ghBadge }}
   {{ $count := .Params.ghCount | default .Site.Params.ghCount | default true }}
   {{ $user := index (split $repo "/") 0 }}
   {{ $repoName := index (split $repo "/") 1 }}
-  {{ if $badges }}
     <div class="gh-buttons" style="margin-bottom: 20px;">
       {{ range $badges }}
         {{ $type := . }}
@@ -36,5 +35,4 @@
         <iframe src="{{ $iframeSrc }}" frameborder="0" scrolling="0" width="{{ $width }}" height="{{ $height }}" title="GitHub"></iframe>
       {{ end }}
     </div>
-  {{ end }}
 {{ end }}

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -21,35 +21,40 @@
   {{ if not (isset .Params "hidePostDates") }}
      {{ $show = not .Params.hidePostDates }}
   {{ end }}
+  {{ $sep := false }}
   {{ if $show }}
     <i class="fas fa-calendar"></i>&nbsp;{{ $datestr | i18n "postedOnDate"}}
     {{ if ne $datestr $lastmodstr }}
       &nbsp;({{ $lastmodstr | i18n "lastModified"  }})
     {{ end }}
+    {{ $sep = true }}
   {{ end }}
   {{ if $.Param "readingTime" }}
-    {{ if $show }}
+    {{ if $sep }}
       &nbsp;|&nbsp;
     {{ end }}
     <i class="fas fa-clock"></i>&nbsp;{{ i18n "readingTime"}}{{ .ReadingTime }}&nbsp;{{ i18n "readTime" }}
+    {{ $sep = true }}
   {{ end }}
   {{ if $.Param "wordCount" }}
-    {{ if $.Param "readingTime" }}
+    {{ if $sep }}
       &nbsp;|&nbsp;
     {{ end }}
     <i class="fas fa-book"></i>&nbsp;{{ .WordCount }}&nbsp;{{ i18n "words" }}
+    {{ $sep = true }}
   {{ end }}
   {{ if not ($.Param "hideAuthor") }}
-    {{ if $.Param "wordCount" }}
+    {{ if $sep }}
       &nbsp;|&nbsp;
     {{ end }}
     {{- $authors := partial "author_list.html" . -}}
     {{- range $authors -}}
       <i class="fas fa-user"></i>&nbsp;{{ if .url }}<a href="{{ .url }}" class="text-reset">{{ .name }}</a>{{ else }}{{ .name }}{{ end }}
     {{- end -}}
+    {{ $sep = true }}
   {{ end }}
   {{- if .Site.Params.staticman -}}
-    {{ if not ($.Param "hideAuthor") }}
+    {{ if $sep }}
       &nbsp;|&nbsp;
     {{ end }}
     <i class="fas fa-comment"></i>&nbsp;
@@ -66,6 +71,7 @@
         0 {{ i18n "oneComment" }}
       {{ end }}
     {{ end }}
+    {{ $sep = true }}
   {{ end }}
   {{ if .IsTranslated -}}
     {{- $sortedTranslations := sort .Translations "Site.Language.Weight" -}}

--- a/layouts/partials/search_index.json.html
+++ b/layouts/partials/search_index.json.html
@@ -1,7 +1,7 @@
 {{- $index := slice -}}
 {{- range site.RegularPages -}}
     {{- if and (not .Params.searchHidden) (ne .Layout `archives`) (ne .Layout `search`) -}}
-        {{- $index = $index | append (dict "title" .Title "content" (.Plain | plainify) "url" .Permalink "excerpt" (.Summary | plainify)) -}}
+        {{- $index = $index | append (dict "title" .Title "content" .Plain "url" .Permalink "excerpt" (.Summary | plainify)) -}}
     {{- end -}}
 {{- end -}}
 {{- $index | jsonify -}}

--- a/layouts/partials/seo/meta/meta-robots.html
+++ b/layouts/partials/seo/meta/meta-robots.html
@@ -1,13 +1,13 @@
 {{/* 
       List of standard meta tags related to robots 
       This list only contains tags which are either true or false
-      For tags which take values, a seperate partial will need to be created
+      For tags which take values, a separate partial will need to be created
 */}}
 {{- $robots_boolean_tags := slice "noindex" "nofollow" "none" "nosnippet" "notranslate" -}}
 {{- $robots_boolean_tags = $robots_boolean_tags | append "noimageindex" "noarchive" "nocache" "noai" "noimageai" -}}
 
 {{- $site_seo := dict -}}
-{{/* Only get this value is the pae is part of a mainSection */}}
+{{/* Only get this value if the page is part of a mainSection */}}
 {{- $mainSections := default (slice "post" "posts") site.Params.mainSections -}}
 {{- if in $mainSections .Section -}}
   {{- $site_seo = site.Params.seo -}}
@@ -30,20 +30,18 @@
   {{- range $name, $content := . -}}
   {{- $tags := slice -}}
     {{- if reflect.IsMap $content -}}
-      {{- $meta_tags := slice -}}
       {{- range $key, $value := $content -}}
         {{- if eq $key "ai-summary-limit" -}}
           {{- $ai_summary_value := partial "seo/meta/get-ai-summary-limit.html" $value -}}
           {{/* ai_summary_value may be an empty string if $value was set to "none" */}}
           {{- with $ai_summary_value -}}
-            {{- $meta_tags = $meta_tags | append $ai_summary_value -}}
+            {{- $tags = $tags | append $ai_summary_value -}}
           {{- end -}}
         {{- else if in $robots_boolean_tags $key -}}
           {{- if $value -}}
-            {{- $meta_tags = $meta_tags | append $key -}}
+            {{- $tags = $tags | append $key -}}
           {{- end -}}
         {{- end -}}
-        {{- $tags = $tags | append $meta_tags -}}
       {{- end -}}
     {{- end -}}
     {{- if $tags }}

--- a/layouts/partials/seo/structured/article.html
+++ b/layouts/partials/seo/structured/article.html
@@ -46,4 +46,4 @@
 {{- if .Site.Params.logo -}}
   {{- $schema = merge $schema (dict "image" (strings.TrimPrefix "/" .Site.Params.logo | absURL)) -}}
 {{- end -}}
-{{- return ($authorSchema = $authorSchema | append (slice $schema)) }}
+{{- return ($authorSchema | append $schema) }}

--- a/layouts/partials/seo/structured/recipe.html
+++ b/layouts/partials/seo/structured/recipe.html
@@ -82,4 +82,4 @@
 {{- with .Params.share_img }}{{ $image = . }}{{ else with .Params.image }}{{ $image = . }}{{ else with .Site.Params.logo }}{{ $image = . }}{{ end -}}
 {{- with $image }}{{ $schema = merge $schema (dict "image" (absURL (strings.TrimPrefix "/" .))) }}{{ end -}}
 
-{{- return ($authorSchema = $authorSchema | append (slice $schema)) }}
+{{- return ($authorSchema | append $schema) }}

--- a/layouts/partials/share-links.html
+++ b/layouts/partials/share-links.html
@@ -1,4 +1,3 @@
-{{ if or .Params.socialShare (and .Site.Params.socialShare (ne .Params.socialShare false)) }}
 <!-- Social Share Button HTML -->
 <div class="share-box" role="region">
     <ul class="share" aria-label="Social sharing" role="list">
@@ -51,4 +50,3 @@
       </li>
     </ul>
   </div>
-  {{ end }}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

A set of small, in-place simplifications of redundant template logic. All output was verified against a clean build of the example site (see below).

## Changes

- **footer.html** — The social-icon loop had two near-identical `<a>` opening tags differing only in the `href`. Compute `$href` once (and drop the pointless `printf "%s"`), emit a single `<a>`, and collapse the duplicated `rel` logic into `rel="{{ with $social.rel }}{{ . }} {{ end }}noopener noreferrer"`.
- **github-buttons.html** — `(and .Site.Params.ghBadge)` is the identity, and the inner `{{ if $badges }}` made the outer `or` redundant. Compute `$badges` first and gate once on `.Params.ghRepo` and `$badges`. Same configs render buttons.
- **share-links.html** — The partial re-implemented page/site `socialShare` gating, but its only caller (`single.html`) already gates with `{{ if and (ne .Type "page") ($.Param "socialShare") }}`. `$.Param` already implements page-over-site precedence with identical observable behavior for every combination, so the partial-internal `if` wrapper was removed (markup unchanged).
- **search_index.json.html** — `.Plain` is already the plain-text rendering of the page; piping it through `plainify` re-parsed it as HTML (a wasted full parse per page) and could strip HTML-like tokens from the index. Changed `(.Plain | plainify)` to `.Plain`. `(.Summary | plainify)` is left alone — `.Summary` genuinely contains HTML.
- **seo/meta/meta-robots.html** — Inside the key loop, the code appended to an accumulating `$meta_tags` and then appended that whole slice to `$tags` on every iteration, producing duplicates that the trailing `uniq` papered over. Now each key appends once directly to `$tags`. Also fixed two comment typos ("seperate" → "separate", "Only get this value is the pae is part of" → "Only get this value if the page is part of").
- **seo/structured/article.html** and **seo/structured/recipe.html** — `{{- return ($authorSchema = $authorSchema | append (slice $schema)) }}` used a needless assignment-inside-return, and `append (slice $schema)` is just `append $schema`. Both now use `{{- return ($authorSchema | append $schema) }}`.
- **post_meta.html** — Each `&nbsp;|&nbsp;` separator previously keyed off whether the *immediately preceding* feature was enabled (wordCount's separator checked readingTime, the author's checked wordCount, etc.), so e.g. `wordCount = true` with `readingTime = false` jammed the word count against the date with no separator. Now a `$sep` scratch flag tracks whether any meta item has rendered so far, and each later block emits its separator iff something came before it. Which items render and their order are unchanged.

## Intentional output changes

These two changes alter output by design; everything else is byte- or whitespace-identical (verified by normalizing inter-tag whitespace across every generated HTML page — all semantically equal, including meta-robots output).

1. **Search index fidelity.** `index.json` differs: dropping the redundant `plainify` preserves more of the original page text (e.g. line breaks become `\n` instead of being collapsed, and HTML-like code tokens are no longer re-parsed away). Spot-check: the math-and-diagrams entry now preserves a `\n` where `plainify` had collapsed it to a space; per-page content length is always equal-or-greater, never smaller, so no content is lost.
2. **Separator fix for partial configs.** With the example config (`readingTime = true`, `wordCount = true`) the post_meta output is unchanged. Verified the fix with two temporary config overrides:
   - `readingTime = false`, `wordCount = true` → `<date> &nbsp;|&nbsp; <N> words &nbsp;|&nbsp; <author>` (exactly one separator before the word count; previously there was none).
   - `readingTime = true`, `wordCount = false` → `<date> &nbsp;|&nbsp; <N> min &nbsp;|&nbsp; <author>` (author still separated correctly).

## Verification

- `hugo -s exampleSite` before/after: all generated HTML semantically identical (inter-tag whitespace only); `index.json` differs as described above.
- `hugo --minify -s exampleSite` builds clean.

Part of #759.

🤖 Generated with [Claude Code](https://claude.com/claude-code)