### PR TITLE
chore: modernize head and microdata markup

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,7 +6,7 @@
 {{- $themeAttr := "" -}}
 {{- if eq $themeMode "dark" -}}{{ $themeAttr = ` data-theme="dark"` }}{{ else if eq $themeMode "light" -}}{{ $themeAttr = ` data-theme="light"` }}{{ end -}}
 <!DOCTYPE html>
-<html lang="{{ .Lang }}" itemscope itemtype="http://schema.org/WebPage"{{ $themeAttr | safeHTMLAttr }}>
+<html lang="{{ .Lang }}" itemscope itemtype="https://schema.org/WebPage"{{ $themeAttr | safeHTMLAttr }}>
   <head>
     {{- if eq $themeMode "auto" -}}
     <script>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -20,15 +20,15 @@
 {{- end }}
 
   <meta charset="utf-8" />
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 
  <!-- Site Title, Description, Author, and Favicon -->
 
 {{ if .IsHome }}
   <title>{{ .Site.Params.homeTitle | default .Site.Title }}</title>
 {{ else }}
-  <title>{{ $title }}{{ with .Site.Params.homeTitle }} - {{ . }}{{ end }}</title>
+  {{ $suffix := .Site.Params.homeTitle | default .Site.Title }}
+  <title>{{ $title }}{{ if and $suffix (ne $title $suffix) }} - {{ $suffix }}{{ end }}</title>
 {{ end }}
 
 {{- with $description }}
@@ -44,7 +44,7 @@
 <!-- Hugo Version number -->
 {{ hugo.Generator -}}
 <!-- Links and stylesheets -->
-<link rel="alternate" href="{{ "index.xml" | absLangURL }}" type="application/rss+xml" title="{{ .Site.Title }}">
+{{ with .Site.Home.OutputFormats.Get "RSS" }}<link rel="alternate" href="{{ .RelPermalink }}" type="application/rss+xml" title="{{ $.Site.Title }}">{{ end }}
 
 {{ $mathEngine := $.Param "mathEngine" | default "katex" }}
 {{- if .Site.Params.selfHosted -}}

--- a/layouts/partials/shortcodes/beautifulfigure.html
+++ b/layouts/partials/shortcodes/beautifulfigure.html
@@ -21,7 +21,7 @@ Based on hugo-easy-gallery by Li-Wen Yip: https://github.com/liwenyip/hugo-easy-
   {{- $src = print $pageRel $src }}
 {{- end }}
 <div class="box fancy-figure caption-position-{{ .Get "caption-position" | default "bottom" }}{{ with .Get "caption-effect" }} caption-effect-{{.}}{{end}}{{ with .Get "class" }} {{ . }}{{ end }}" {{ with .Get "width" }}style="max-width:{{.}}"{{end}}>
-  <figure {{- with .Get "class" }} class="{{.}}"{{ end }} itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject">
+  <figure {{- with .Get "class" }} class="{{.}}"{{ end }} itemprop="associatedMedia" itemscope itemtype="https://schema.org/ImageObject">
     <div class="img"{{ if .Parent }} style="background-image: url('{{ $thumb }}');"{{ end }}{{ with $size }} data-size="{{.}}"{{ end }}>
       <img itemprop="thumbnail" src="{{ $thumb }}" {{ with .Get "alt" | default (.Get "caption") | default $thumb }}alt="{{.}}"{{ end }}/><!-- <img> hidden if in .gallery -->
     </div>

--- a/layouts/shortcodes/gallery.html
+++ b/layouts/shortcodes/gallery.html
@@ -5,7 +5,7 @@ Documentation and licence at https://github.com/liwenyip/hugo-easy-gallery/
 <!-- count how many times we've called this shortcode; load the css if it's the first time -->
 {{- if not ($.Page.Store.Get "figurecount") }}<link rel="stylesheet" href="{{ "css/hugo-easy-gallery.css" | relURL }}" />{{ end }}
 {{- $.Page.Store.Set "figurecount" (add ($.Page.Store.Get "figurecount" | default 0) 1) }}
-<div class="gallery caption-position-{{ with .Get "caption-position" | default "bottom" }}{{.}}{{end}} caption-effect-{{ with .Get "caption-effect" | default "slide" }}{{.}}{{end}} hover-effect-{{ with .Get "hover-effect" | default "zoom" }}{{.}}{{end}} {{ if ne (.Get "hover-transition") "none" }}hover-transition{{end}}" itemscope itemtype="http://schema.org/ImageGallery">
+<div class="gallery caption-position-{{ with .Get "caption-position" | default "bottom" }}{{.}}{{end}} caption-effect-{{ with .Get "caption-effect" | default "slide" }}{{.}}{{end}} hover-effect-{{ with .Get "hover-effect" | default "zoom" }}{{.}}{{end}} {{ if ne (.Get "hover-transition") "none" }}hover-transition{{end}}" itemscope itemtype="https://schema.org/ImageGallery">
 	{{- with (.Get "dir") -}}
 		{{- $files := readDir (print "/static/" .) }}
 		{{- range $files -}}
@@ -19,7 +19,7 @@ Documentation and licence at https://github.com/liwenyip/hugo-easy-gallery/
 				{{- $thumbexists := where $files "Name" $thumb }}
 				{{- $thumbURL := relURL (strings.TrimPrefix "/" (print ($.Get "dir") "/" $thumb)) }}
 				<div class="box">
-				  <figure itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject">
+				  <figure itemprop="associatedMedia" itemscope itemtype="https://schema.org/ImageObject">
 				    <div class="img" style="background-image: url('{{ if $thumbexists }}{{ $thumbURL }}{{ else }}{{ $linkURL }}{{ end }}');" >
 				      <img itemprop="thumbnail" src="{{ if $thumbexists }}{{ $thumbURL }}{{ else }}{{ $linkURL }}{{ end }}" alt="{{ $caption }}" /><!-- <img> hidden if in .gallery -->
 				    </div>


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

- **Drop `X-UA-Compatible` meta**: The `<meta http-equiv="X-UA-Compatible" content="IE=edge">` tag is ignored by every current browser; removing it declutters the `<head>`.
- **Fix viewport to allow pinch-zoom**: Removed `maximum-scale=1.0` from the viewport meta. Blocking pinch-zoom fails Lighthouse accessibility audits and WCAG 1.4.4. New value: `width=device-width, initial-scale=1`.
- **Upgrade schema.org itemtypes to HTTPS**: Changed `http://schema.org/` → `https://schema.org/` in `layouts/_default/baseof.html` (WebPage), `layouts/partials/shortcodes/beautifulfigure.html` (ImageObject), and `layouts/shortcodes/gallery.html` (ImageGallery, ImageObject). The JSON-LD partials were already correct.
- **Output-format-aware RSS alternate link**: Replaced the hardcoded `index.xml` link with the pattern already used in `footer.html` — `{{ with .Site.Home.OutputFormats.Get "RSS" }}`. The link now correctly disappears when RSS output is disabled or renamed, and produces a root-relative URL rather than an absolute one.
- **⚠️ Behavior change — page title suffix**: Non-home page titles previously only appended a site-name suffix when `Params.homeTitle` was explicitly set. Most sites set only the standard `title`, so page titles like `My Post` never included the site name. The new logic falls back to `.Site.Title` when `homeTitle` is absent, producing `My Post - Beautiful Hugo`. Duplication is guarded: if the page title already equals the suffix, no ` - suffix` is appended. Sites that relied on bare page titles (no suffix) will see a visual change in browser tabs and search-engine snippets.

## Test plan

- [x] `hugo --minify -s exampleSite` builds cleanly with no warnings
- [x] Before/after diff shows only the five expected change categories (no surprises)
- [x] Home page `<title>` is unchanged (`Beautiful Hugo`)
- [x] No doubled `X - X` titles anywhere in the build
- [x] 404 page builds fine with new title `404 Page not found - Beautiful Hugo`
- [x] Build with `home = ["HTML", "JSON"]` (RSS disabled): alternate link absent, no build errors

Part of #759.

🤖 Generated with [Claude Code](https://claude.com/claude-code)