### PR TITLE
feat: use Hugo's related-content engine for related posts

### DIFF
--- a/exampleSite/content/page/configuration.md
+++ b/exampleSite/content/page/configuration.md
@@ -117,7 +117,7 @@ When `selfHosted = true`, the following assets are served from `static/` instead
 | `wordCount` | bool | `false` | Show word count in post meta |
 | `hideAuthor` | bool | `false` | Hide author from post meta |
 | `socialShare` | bool | `false` | Enable social sharing buttons on posts |
-| `showRelatedPosts` | bool | `false` | Show related posts (by tag intersection) |
+| `showRelatedPosts` | bool | `false` | Show related posts, ranked by relevance via Hugo's [related-content engine](#related-posts) |
 | `related_content_limit` | int | `5` | Max number of related posts to display |
 | `rss` | bool | `false` | Show RSS icon in footer |
 | `disableFigureOverride` | bool | `false` | When `true`, use Hugo's native `<figure>` shortcode; `beautifulfigure` remains available |
@@ -140,6 +140,35 @@ When `selfHosted = true`, the following assets are served from `static/` instead
   showPostNav = true
   sourceRepo = "https://github.com/user/repo/blob/main/"
 ```
+
+### Related Posts
+
+When `showRelatedPosts = true`, each post displays a "See also" list of related content. This uses Hugo's built-in [related-content engine](https://gohugo.io/content-management/related/) (`.Site.RegularPages.Related`), which is index-backed and ranks suggestions by **relevance** rather than site order. The number of items shown is capped by `related_content_limit` (default `5`).
+
+> **Heads up:** Without a `[related]` configuration block, Hugo's defaults rank by the front-matter `keywords` and `date` indices — **not** by `tags`. If your posts rely on `tags` (as the theme historically did), add the `[related]` block below so tag overlap drives the ranking.
+
+The recommended setup preserves and improves on the old tag-based behavior by indexing `tags` (highest weight), then `keywords`, then `date`:
+
+```toml
+# Ranking configuration for showRelatedPosts (Hugo's related-content engine)
+[related]
+  includeNewer = true
+  threshold = 80
+  toLower = false
+  [[related.indices]]
+    name = "tags"
+    weight = 100
+  [[related.indices]]
+    name = "keywords"
+    weight = 80
+  [[related.indices]]
+    name = "date"
+    weight = 10
+```
+
+- `threshold` (0–100) controls how strong a match must be before a post is suggested; posts with no qualifying matches show no "See also" section.
+- `includeNewer = true` allows newer posts to be suggested (Hugo excludes them by default).
+- Each `[[related.indices]]` `weight` controls how much that field contributes to the relevance score.
 
 ### Table of Contents Panel
 

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -20,6 +20,21 @@ enableGitInfo = true
   category = "categories"
   tag = "tags"
 
+# Ranking configuration for showRelatedPosts (Hugo's related-content engine)
+[related]
+  includeNewer = true
+  threshold = 80
+  toLower = false
+  [[related.indices]]
+    name = "tags"
+    weight = 100
+  [[related.indices]]
+    name = "keywords"
+    weight = 80
+  [[related.indices]]
+    name = "date"
+    weight = 10
+
 [Params]
   subtitle = "Build a beautiful and simple website in minutes"
   mainSections = ["post", "recipe"]

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -44,7 +44,7 @@
         {{ end }}
 
         {{ if $.Param "showRelatedPosts" }}
-          {{- $related := where (where .Site.RegularPages ".Params.tags" "intersect" .Params.tags) "Permalink" "!=" .Permalink }}
+          {{- $related := .Site.RegularPages.Related . }}
           {{- $num_to_show := $.Param "related_content_limit" | default 5 }}
           {{- with first $num_to_show $related }}
             <h4 class="see-also">{{ i18n "seeAlso" }}</h4>


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## What & why

The `showRelatedPosts` feature previously built its "See also" list with a hand-rolled query in `layouts/_default/single.html`:

```go-html-template
{{- $related := where (where .Site.RegularPages ".Params.tags" "intersect" .Params.tags) "Permalink" "!=" .Permalink }}
```

That approach is O(pages) per page, unranked (it returns matches in *site order*, not by relevance), and only ever considers `tags`. This PR swaps it for Hugo's built-in [related-content engine](https://gohugo.io/content-management/related/):

```go-html-template
{{- $related := .Site.RegularPages.Related . }}
```

`.Related` is index-backed, excludes the current page automatically, and ranks results by **relevance**. The `related_content_limit` / `first` cap and the rendering markup are unchanged.

A `[related]` block is added to the example `hugo.toml` (next to `[taxonomies]`) and documented in `configuration.md`. It indexes `tags` (weight 100), then `keywords` (80), then `date` (10), so tag-driven suggestions are preserved and improved.

## ⚠️ Migration note

This is an **intentional behavior change**. Hugo's *default* related config ranks by the front-matter `keywords` and `date` indices and does **not** consider `tags`. Existing sites that use `showRelatedPosts` and rely on tag overlap **must add a `[related]` block** with a `tags` index to keep tag-based suggestions:

```toml
# Ranking configuration for showRelatedPosts (Hugo's related-content engine)
[related]
  includeNewer = true
  threshold = 80
  toLower = false
  [[related.indices]]
    name = "tags"
    weight = 100
  [[related.indices]]
    name = "keywords"
    weight = 80
  [[related.indices]]
    name = "date"
    weight = 10
```

Sites without any `[related]` block still build fine — they just fall back to Hugo's default keywords+date ranking.

## Verification / evidence

Built the example site (which sets `showRelatedPosts = true`) before and after the change.

- **Coverage unchanged:** 9 posts have a "See also" section both before and after — posts that share tags still get suggestions.
- **Ranking improved (reordering):** e.g. post **"Test markdown"** (tags: `example, markdown, tutorial`):
  - **Before** (site order): `Manage robot meta tags…`, `First post!`
  - **After** (relevance): `First post!`, `Manage robot meta tags…` — "First post!" shares the `tutorial` tag and is now ranked first.
- **Graceful empty state:** post **"Soccer"** (only tag `sports`, shared by nothing else) shows **no** "See also" section, before and after — the `threshold` correctly suppresses it.
- **No-config fallback:** building a copy of the config with the `[related]` block **removed** still succeeds (no error); results then rank by Hugo's default keywords+date indices (yielding a different, tag-agnostic set), confirming the migration note.
- `hugo --minify -s exampleSite` builds cleanly; the diff touches only `single.html`, `exampleSite/hugo.toml`, and `configuration.md`.

Part of #759.

🤖 Generated with [Claude Code](https://claude.com/claude-code)