### PR TITLE
feat: internationalize remaining hardcoded UI strings

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -122,9 +122,35 @@
 - id: archiveYearFilter
   translation: "Filter by year"
 
-# Categories
+# Categories / Tags
 - id: categoriesLabel
   translation: "Categories: "
+- id: tagsLabel
+  translation: "Tags: "
+
+# Table of Contents
+- id: tocLabel
+  translation: "Table of Contents"
+- id: tocPostsLabel
+  translation: "Posts"
+- id: tocCloseLabel
+  translation: "Close table of contents"
+
+# Breadcrumb / Pagination
+- id: breadcrumbHomeLabel
+  translation: "Home"
+- id: paginationPageLabel
+  translation: "Page {{ . }}"
+
+# CollectionPage schema
+- id: termPagesTitle
+  translation: "Articles tagged with '{{ . }}'"
+- id: termPagesDescription
+  translation: "Explore all posts and thoughts related to {{ . }}"
+- id: taxonomyPagesTitle
+  translation: "Browse Content by {{ . }}"
+- id: taxonomyPagesDescription
+  translation: "A complete index of {{ . }} used to organize topics."
 
 # View source
 - id: viewSource

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -24,7 +24,7 @@
         {{ end }}
         {{ if .Params.tags }}
           <div class="blog-tags">
-            <span>Tags: </span>
+            <span>{{ i18n "tagsLabel" | default "Tags: " }}</span>
             {{ range .Params.tags }}
               {{- $tagName := . -}}
               {{- with $.Site.GetPage (printf "/%s/%s" "tags" ($tagName | urlize)) -}}

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -7,7 +7,7 @@
       {{ if ne ($.Param "toc") false }}
       {{ $tocState := partial "func/toc-state.html" . }}
       {{ if or $tocState.hasToc $tocState.hasListPages }}
-      <button class="theme-toggle" id="toc-toggle" aria-label="Table of contents" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Table of contents">
+      <button class="theme-toggle" id="toc-toggle" aria-label="{{ i18n "tocLabel" | default "Table of Contents" }}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ i18n "tocLabel" | default "Table of Contents" }}">
         <span class="fas fa-list"></span>
       </button>
       {{ end }}

--- a/layouts/partials/post_preview.html
+++ b/layouts/partials/post_preview.html
@@ -40,7 +40,7 @@
         {{ end }}
         {{ end }}
         {{ if .Params.tags }}
-        <span class="blog-tags-label">Tags: </span>
+        <span class="blog-tags-label">{{ i18n "tagsLabel" | default "Tags: " }}</span>
         {{ range .Params.tags }}
         {{- $tagName := . -}}
         {{- with $.Site.GetPage (printf "/%s/%s" "tags" ($tagName | urlize)) -}}

--- a/layouts/partials/seo/structured/breadcrumb.html
+++ b/layouts/partials/seo/structured/breadcrumb.html
@@ -13,7 +13,7 @@
 {{- $items = $items | append (dict
   "@type" "ListItem"
   "position" $position
-  "name" "Home"
+  "name" (i18n "breadcrumbHomeLabel" | default "Home")
   "item" .Site.BaseURL
 ) -}}
 
@@ -56,7 +56,7 @@
   {{- $items = $items | append (dict
     "@type" "ListItem"
     "position" $position
-    "name" (print "Page " $paginator.PageNumber)
+    "name" (i18n "paginationPageLabel" $paginator.PageNumber | default (print "Page " $paginator.PageNumber))
     "item" $currentPageUrl
   ) -}}
 {{- end -}}

--- a/layouts/partials/seo/structured/collection-page.html
+++ b/layouts/partials/seo/structured/collection-page.html
@@ -24,16 +24,16 @@
   {{- $schemaDescription = $schemaDescription | plainify | htmlUnescape | replaceRE "\n+" " " | chomp }}
   {{- if or (eq .Kind "taxonomy") (eq .Kind "term") }}
     {{- if eq .Kind "term" }}
-      {{- $schemaTitle = printf "Articles tagged with '%s'" .Title }}
-      {{- $schemaDescription = printf "Explore all posts and thoughts related to %s" .Title }}
+      {{- $schemaTitle = i18n "termPagesTitle" .Title | default (printf "Articles tagged with '%s'" .Title) }}
+      {{- $schemaDescription = i18n "termPagesDescription" .Title | default (printf "Explore all posts and thoughts related to %s" .Title) }}
     {{- else if eq .Kind "taxonomy" }}
-      {{- $schemaTitle = printf "Browse Content by %s" .Title }}
-      {{- $schemaDescription = printf "A complete index of %s used to organize topics." (lower .Title) }}
+      {{- $schemaTitle = i18n "taxonomyPagesTitle" .Title | default (printf "Browse Content by %s" .Title) }}
+      {{- $schemaDescription = i18n "taxonomyPagesDescription" (lower .Title) | default (printf "A complete index of %s used to organize topics." (lower .Title)) }}
     {{- end }}
   {{- end }}
 
   {{- if gt $paginator.PageNumber 1 }}
-    {{- $schemaTitle = printf "%s (Page %d)" $schemaTitle $paginator.PageNumber }}
+    {{- $schemaTitle = printf "%s (%s)" $schemaTitle (i18n "paginationPageLabel" $paginator.PageNumber | default (print "Page " $paginator.PageNumber)) }}
   {{- end }}
 
   {{/* Assemble the entire Schema Object */}}

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -6,10 +6,10 @@
 {{- $listPages := $tocState.listPages -}}
 {{- if or $hasToc $hasListPages -}}
 <div class="toc-wrapper" id="toc-wrapper" data-toc-mode="{{ if $isListPage }}posts{{ else }}headings{{ end }}">
-  <div class="toc-panel" id="toc-panel" role="dialog" aria-label="Table of contents">
+  <div class="toc-panel" id="toc-panel" role="dialog" aria-label="{{ i18n "tocLabel" | default "Table of Contents" }}">
     <div class="toc-header">
-      <span class="toc-title">{{ if $isListPage }}Posts{{ else }}Table of Contents{{ end }}</span>
-      <button class="toc-close" id="toc-close" aria-label="Close table of contents">&times;</button>
+      <span class="toc-title">{{ if $isListPage }}{{ i18n "tocPostsLabel" | default "Posts" }}{{ else }}{{ i18n "tocLabel" | default "Table of Contents" }}{{ end }}</span>
+      <button class="toc-close" id="toc-close" aria-label="{{ i18n "tocCloseLabel" | default "Close table of contents" }}">&times;</button>
     </div>
     <nav class="toc-body">
       {{- if $isListPage -}}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

This PR internationalizes hardcoded English UI strings that were flagged in a code review, following the `{{ i18n "key" | default "English fallback" }}` pattern already used for search strings. Only `i18n/en.yaml` is populated; sites using other languages fall back gracefully to the English text via the `| default` clause.

### New i18n keys added to `i18n/en.yaml`

| Key | English value | Used in |
|-----|--------------|---------|
| `tagsLabel` | `"Tags: "` | `layouts/_default/single.html`, `layouts/partials/post_preview.html` |
| `tocLabel` | `"Table of Contents"` | `layouts/partials/toc.html` (panel title, dialog aria-label), `layouts/partials/nav.html` (toggle button aria-label + title) |
| `tocPostsLabel` | `"Posts"` | `layouts/partials/toc.html` (list-page panel title) |
| `tocCloseLabel` | `"Close table of contents"` | `layouts/partials/toc.html` (close button aria-label) |
| `breadcrumbHomeLabel` | `"Home"` | `layouts/partials/seo/structured/breadcrumb.html` |
| `paginationPageLabel` | `"Page {{ . }}"` | `layouts/partials/seo/structured/breadcrumb.html`, `layouts/partials/seo/structured/collection-page.html` |
| `termPagesTitle` | `"Articles tagged with '{{ . }}'"` | `layouts/partials/seo/structured/collection-page.html` |
| `termPagesDescription` | `"Explore all posts and thoughts related to {{ . }}"` | `layouts/partials/seo/structured/collection-page.html` |
| `taxonomyPagesTitle` | `"Browse Content by {{ . }}"` | `layouts/partials/seo/structured/collection-page.html` |
| `taxonomyPagesDescription` | `"A complete index of {{ . }} used to organize topics."` | `layouts/partials/seo/structured/collection-page.html` |

### Verification

A before/after build of the example site was compared with `diff -r`. The only textual difference is that the TOC toggle button and panel dialog `aria-label` changed from `"Table of contents"` (lowercase c, hardcoded) to `"Table of Contents"` (title case, from the i18n key) — a minor improvement in consistency. All other English-language output is byte-identical between the before and after builds.

- JSON-LD breadcrumb `"name": "Home"` and `"name": "Page 2"` — confirmed identical
- JSON-LD CollectionPage term/taxonomy titles and descriptions — confirmed identical
- Tags label in post body and preview — confirmed identical
- TOC panel title "Table of Contents" / "Posts" — confirmed identical
- `hugo --minify -s exampleSite` exits cleanly with no errors or warnings

Part of #759.

🤖 Generated with [Claude Code](https://claude.com/claude-code)