### PR TITLE
fix: canonical paginator URLs and relative in-site links

### DIFF
--- a/layouts/_default/archive.html
+++ b/layouts/_default/archive.html
@@ -9,7 +9,7 @@
         {{ end }}
 
 {{ $mainSections := default (slice "post" "posts") site.Params.mainSections }}
-{{ $pages := where (where site.RegularPages.ByDate.Reverse "Section" "in" $mainSections) "Params.hidden" "!=" true }}
+{{ $pages := where (where site.RegularPages.ByDate.Reverse "Type" "in" $mainSections) "Params.hidden" "!=" true }}
 {{ $groups := $pages.GroupByDate "2006" }}
         {{ $years := slice }}
         {{ range $groups }}
@@ -28,7 +28,7 @@
             <h2 class="archive-year-heading">{{ .Key }}</h2>
             <div class="archive-list">
               {{ range .Pages }}
-                <a href="{{ .Permalink }}" class="archive-item">
+                <a href="{{ .RelPermalink }}" class="archive-item">
                   <span class="archive-item-title">{{ .Title }}</span>
                   {{ if .Params.subtitle }}
                     <span class="archive-item-subtitle">{{ .Params.subtitle }}</span>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -17,7 +17,7 @@
             {{ range .Params.categories }}
               {{- $catName := . -}}
               {{- with $.Site.GetPage (printf "/%s/%s" "categories" ($catName | urlize)) -}}
-              <a href="{{ .Permalink }}">{{ $catName }}</a>&nbsp;
+              <a href="{{ .RelPermalink }}">{{ $catName }}</a>&nbsp;
               {{- end -}}
             {{ end }}
           </div>
@@ -28,7 +28,7 @@
             {{ range .Params.tags }}
               {{- $tagName := . -}}
               {{- with $.Site.GetPage (printf "/%s/%s" "tags" ($tagName | urlize)) -}}
-              <a href="{{ .Permalink }}">{{ $tagName }}</a>&nbsp;
+              <a href="{{ .RelPermalink }}">{{ $tagName }}</a>&nbsp;
               {{- end -}}
             {{ end }}
           </div>
@@ -62,19 +62,19 @@
 
       {{ if and (ne .Type "page") (default true ($.Param "showPostNav")) }}
         {{ if .PrevInSection }}
-          <a href="{{ .PrevInSection.Permalink }}" class="nav-side-arrow nav-side-prev" title="{{ .PrevInSection.Title }}" aria-label="{{ i18n "previousPost" }}: {{ .PrevInSection.Title }}">
+          <a href="{{ .PrevInSection.RelPermalink }}" class="nav-side-arrow nav-side-prev" title="{{ .PrevInSection.Title }}" aria-label="{{ i18n "previousPost" }}: {{ .PrevInSection.Title }}">
             <i class="fas fa-chevron-left"></i>
           </a>
         {{ end }}
         {{ if .NextInSection }}
-          <a href="{{ .NextInSection.Permalink }}" class="nav-side-arrow nav-side-next" title="{{ .NextInSection.Title }}" aria-label="{{ i18n "nextPost" }}: {{ .NextInSection.Title }}">
+          <a href="{{ .NextInSection.RelPermalink }}" class="nav-side-arrow nav-side-next" title="{{ .NextInSection.Title }}" aria-label="{{ i18n "nextPost" }}: {{ .NextInSection.Title }}">
             <i class="fas fa-chevron-right"></i>
           </a>
         {{ end }}
         <ul class="post-pager blog-post-pager">
           {{ if .PrevInSection }}
             <li class="pager-prev">
-              <a href="{{ .PrevInSection.Permalink }}" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ .PrevInSection.Title }}"><i class="fas fa-chevron-left"></i> {{ i18n "previousPost" }}</a>
+              <a href="{{ .PrevInSection.RelPermalink }}" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ .PrevInSection.Title }}"><i class="fas fa-chevron-left"></i> {{ i18n "previousPost" }}</a>
             </li>
           {{ else }}
             <li class="pager-prev"></li>
@@ -84,7 +84,7 @@
           </li>
           {{ if .NextInSection }}
             <li class="pager-next">
-              <a href="{{ .NextInSection.Permalink }}" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ .NextInSection.Title }}">{{ i18n "nextPost" }} <i class="fas fa-chevron-right"></i></a>
+              <a href="{{ .NextInSection.RelPermalink }}" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ .NextInSection.Title }}">{{ i18n "nextPost" }} <i class="fas fa-chevron-right"></i></a>
             </li>
           {{ else }}
             <li class="pager-next"></li>

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -15,14 +15,14 @@
         {{ range $key, $value := $terms.Alphabetical }}
           <div class="terms-item">
             <div class="terms-item-header">
-              <a href="{{ with $.Site.GetPage (printf "/%s/%s" $data.Plural ($value.Name | urlize)) }}{{ .Permalink }}{{ end }}">
+              <a href="{{ with $.Site.GetPage (printf "/%s/%s" $data.Plural ($value.Name | urlize)) }}{{ .RelPermalink }}{{ end }}">
                 {{ $value.Name }}
               </a>
               <span class="terms-item-count">{{ $value.Count }}</span>
             </div>
             <div class="terms-item-pages">
               {{ range $item := $value.Pages }}
-                <a href="{{ $item.Permalink }}" class="terms-item-page">{{ $item.Title }}</a>
+                <a href="{{ $item.RelPermalink }}" class="terms-item-page">{{ $item.Title }}</a>
               {{ end }}
             </div>
           </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -70,7 +70,7 @@
             &nbsp;&bull;&nbsp;
           {{ end }}
           {{ if or .Site.Params.homeTitle .Site.Title }}
-            <a href="{{ "" | absLangURL }}">{{ .Site.Params.homeTitle | default .Site.Title }}</a>
+            <a href="{{ "" | relLangURL }}">{{ .Site.Params.homeTitle | default .Site.Title }}</a>
           {{ end }}
         </p>
         <!-- Please don't remove this, keep my open source work credited :) -->

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -2,7 +2,7 @@
 {{- $search := site.Params.search | default (dict) -}}
 <nav class="navbar navbar-expand-md navbar-light navbar-custom fixed-top">
   <div class="container-fluid">
-    <a class="navbar-brand" href="{{ "" | absLangURL }}">{{ .Site.Params.homeTitle | default .Site.Title }}</a>
+    <a class="navbar-brand" href="{{ "" | relLangURL }}">{{ .Site.Params.homeTitle | default .Site.Title }}</a>
     <div class="d-flex align-items-center">
       {{ if ne ($.Param "toc") false }}
       {{ $tocState := partial "func/toc-state.html" . }}
@@ -97,10 +97,10 @@
       {{ with .Site.Params.logo }}
         <div class="avatar-container">
           <div class="avatar-img-border">
-            <a title="{{ $page.Site.Title }}" href="{{ "" | absLangURL }}">
+            <a title="{{ $page.Site.Title }}" href="{{ "" | relLangURL }}">
             {{- $image := resources.Get . -}}
             {{ if $image }}
-              <img class="avatar-img" src="{{ ($image.Fit "300x300 webp q100").Permalink }}" alt="{{ $page.Site.Title }}" />
+              <img class="avatar-img" src="{{ ($image.Fit "300x300 webp q100").RelPermalink }}" alt="{{ $page.Site.Title }}" />
             {{else}}
               <img class="avatar-img" src="{{ strings.TrimPrefix "/" . | relURL }}" alt="{{ $page.Site.Title }}" />
              {{end}}

--- a/layouts/partials/paginator.html
+++ b/layouts/partials/paginator.html
@@ -2,12 +2,12 @@
   <ul class="post-pager">
     {{ if .Paginator.HasPrev }}
       <li class="pager-prev">
-        <a href="{{ path.Join .RelPermalink "page" .Paginator.Prev.PageNumber }}">&larr; {{ i18n "newerPosts" }}</a>
+        <a href="{{ .Paginator.Prev.URL }}">&larr; {{ i18n "newerPosts" }}</a>
       </li>
     {{ end }}
     {{ if .Paginator.HasNext }}
       <li class="pager-next">
-        <a href="{{ path.Join .RelPermalink "page" .Paginator.Next.PageNumber }}">{{ i18n "olderPosts" }} &rarr;</a>
+        <a href="{{ .Paginator.Next.URL }}">{{ i18n "olderPosts" }} &rarr;</a>
       </li>
     {{ end }}
   </ul>

--- a/layouts/partials/post_preview.html
+++ b/layouts/partials/post_preview.html
@@ -1,5 +1,5 @@
 <article class="post-preview">
-    <a href="{{ .Permalink }}">
+    <a href="{{ .RelPermalink }}">
         <h2 class="post-title">{{ .Title }}</h2>
         {{ if .Params.subtitle }}
         <h3 class="post-subtitle">
@@ -22,7 +22,7 @@
     <div class="post-entry">
         {{ if or (.Truncated) (.Params.summary) (eq .Type "recipe") }}
         {{ .Summary }}
-        <a href="{{ .Permalink }}" class="post-read-more">[{{ i18n "readMore" }}]</a>
+        <a href="{{ .RelPermalink }}" class="post-read-more">[{{ i18n "readMore" }}]</a>
         {{ else }}
         {{ .Content }}
         {{ end }}
@@ -35,7 +35,7 @@
         {{ range .Params.categories }}
         {{- $catName := . -}}
         {{- with $.Site.GetPage (printf "/%s/%s" "categories" ($catName | urlize)) -}}
-        <a href="{{ .Permalink }}" class="blog-tags-category">{{ $catName }}</a>&nbsp;
+        <a href="{{ .RelPermalink }}" class="blog-tags-category">{{ $catName }}</a>&nbsp;
         {{- end -}}
         {{ end }}
         {{ end }}
@@ -44,7 +44,7 @@
         {{ range .Params.tags }}
         {{- $tagName := . -}}
         {{- with $.Site.GetPage (printf "/%s/%s" "tags" ($tagName | urlize)) -}}
-        <a href="{{ .Permalink }}">{{ $tagName }}</a>&nbsp;
+        <a href="{{ .RelPermalink }}">{{ $tagName }}</a>&nbsp;
         {{- end -}}
         {{ end }}
         {{ end }}

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -16,7 +16,7 @@
       <ul class="toc-post-list">
         {{- range $listPages -}}
         {{- if ne .Params.hidden true -}}
-        <li><a href="{{ .Permalink }}">{{ .Title }}</a></li>
+        <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
         {{- end -}}
         {{- end -}}
       </ul>


### PR DESCRIPTION
:robot: _AI text below_ :robot:

This is a behavior-sensitive sweep aligning URL generation with the theme's relative-URL convention, in three groups:

**1. Canonical paginator URLs** (`layouts/partials/paginator.html`)
The prev/next links were hand-built with `path.Join .RelPermalink "page" .Paginator.Prev.PageNumber`. This (a) ignored a customized `[pagination] path` config and (b) linked page 2's "newer" target to `/section/page/1/`, which is an alias redirect rather than the canonical section URL. Replaced with Hugo's canonical `{{ .Paginator.Prev.URL }}` / `{{ .Paginator.Next.URL }}`.

**2. Archive selection by Type** (`layouts/_default/archive.html`)
mainSections pages were selected with `"Section" "in" $mainSections`, while every other listing in the theme matches `"Type" "in"`. A page can override `type` in front matter, which made archives inconsistent with listings. Changed `"Section"` to `"Type"`.

**3. Relative in-site page links** (`.Permalink` -> `.RelPermalink`, `absLangURL` -> `relLangURL`)
Per the theme's convention that in-site asset and page links use relative URLs so sites work under subpath deployments. Touched: post-preview title/read-more/category/tag links, single.html category/tag and all four prev/next-in-section links, the toc posts panel, archive items, terms header and per-term links, the processed avatar image, and the navbar brand / avatar wrapper / footer site-title home links.

**Keep-list (absolute URLs intentional, untouched):** everything under `seo/` (JSON-LD / OpenGraph / Twitter), the share-links share targets, the disqus/cusdis/staticman/utterances/giscus comment partials, `translation_link.html` and the multilingual language-switcher links in `nav.html`, the already-relative RSS link in `footer.html`, and `head.html` (owned by another in-flight PR).

**Verification:**
- Root build (`baseURL` at `/`): changed hrefs lose the `http://localhost:1313` host prefix and become root-relative; page 2's paginator "newer" link becomes the section root `/post/` instead of the `/post/page/1` alias; archive page selection is identical (same 12 items). SEO/share/translation URLs unchanged.
- Subpath build (`-b http://localhost/blog/`): post-preview titles, prev/next post links, toc panel links, archive items, terms links, navbar brand, footer home link, and paginator prev/next all start with `/blog/`; page 2's "newer" link is exactly `/blog/post/`.
- Custom pagination path (`[pagination] path = "p"`): build succeeds and paginator links use `/post/p/3/` style with the page-2 "newer" link at the canonical `/post/` (before the fix they would have stayed `/page/2`).
- `hugo --minify -s exampleSite` builds clean; only the eight intended template files changed.

Part of #759.

🤖 Generated with [Claude Code](https://claude.com/claude-code)