### PR TITLE
feat: custom background colors for images

### DIFF
--- a/exampleSite/content/page/figures-and-galleries.md
+++ b/exampleSite/content/page/figures-and-galleries.md
@@ -75,6 +75,16 @@ Add `class="white"` to give the figure a white background, which helps images wi
 {{</* beautifulfigure src="/img/global-ike.png" caption="White background for dark mode" class="white center" width="25%" */>}}
 ```
 
+### With arbitrary background color (for dark mode and images with transparent backgrounds)
+
+Add `background-color` to give the figure a custom background color:
+
+{{< beautifulfigure src="/img/global-ike.png" caption="White background for dark mode" background-color="#ffffff5b" width="25%" >}}
+
+```markdown
+{{</* beautifulfigure src="/img/global-ike.png" caption="White background for dark mode" background-color="#ffffff5b" width="25%" */>}}
+```
+
 ### All parameters
 
 | Parameter | Type | Default | Description |

--- a/layouts/partials/shortcodes/beautifulfigure.html
+++ b/layouts/partials/shortcodes/beautifulfigure.html
@@ -20,9 +20,12 @@ Based on hugo-easy-gallery by Li-Wen Yip: https://github.com/liwenyip/hugo-easy-
 {{- else if not (strings.HasPrefix $src "http") }}
   {{- $src = print $pageRel $src }}
 {{- end }}
+{{- $background := .Get "background-color" }}
+
+
 <div class="box fancy-figure caption-position-{{ .Get "caption-position" | default "bottom" }}{{ with .Get "caption-effect" }} caption-effect-{{.}}{{end}}{{ with .Get "class" }} {{ . }}{{ end }}" {{ with .Get "width" }}style="max-width:{{.}}"{{end}}>
   <figure {{- with .Get "class" }} class="{{.}}"{{ end }} itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject">
-    <div class="img"{{ if .Parent }} style="background-image: url('{{ $thumb }}');"{{ end }}{{ with $size }} data-size="{{.}}"{{ end }}>
+    <div class="img"{{ if and .Parent $background }} style="background-color: {{ $background | default "#FFFFFF" }};"{{ else if .Parent}} style="background-image: url('{{ $thumb }}');"{{end }}{{ with $size }} data-size="{{.}}"{{ end }}>
       <img itemprop="thumbnail" src="{{ $thumb }}" {{ with .Get "alt" | default (.Get "caption") | default $thumb }}alt="{{.}}"{{ end }}/><!-- <img> hidden if in .gallery -->
     </div>
     {{- with $src }}


### PR DESCRIPTION
`class="white"` is a nice feature, but it is too bright. This allows you to specify whatever color your want. 

```
{{< figure src="/deep_sky/icarus/demo_3_style_transfer_clouds.png" background-color="#ffffff5b" title="Transferring cloud formations" caption="The gloom of dark clouds (middle row) can be alleviated (top and bottom rows) by transferring styles from preferable source images. " >}}
```
<img width="482" height="249" alt="image" src="https://github.com/user-attachments/assets/e0c866d2-28de-418e-a91a-754185624c8a" />
