### PR TITLE
fix: reset auto-group so multiple tabs blocks render per page

### DIFF
--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -7,6 +7,8 @@
 {{- if not $groupId -}}
   {{- $groupId = .Page.Store.Get "tabs-last-auto-group" -}}
   {{- .Page.Store.Delete "tabs-last-auto-group" -}}
+  {{/* Reset the auto-group so the next tabs block starts a fresh group. */}}
+  {{- .Page.Store.Delete "tabs-auto-group" -}}
 {{- end -}}
 {{- if not $groupId -}}
   {{- $groupId = $instanceId -}}

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -7,7 +7,6 @@
 {{- if not $groupId -}}
   {{- $groupId = .Page.Store.Get "tabs-last-auto-group" -}}
   {{- .Page.Store.Delete "tabs-last-auto-group" -}}
-  {{/* Reset the auto-group so the next tabs block starts a fresh group. */}}
   {{- .Page.Store.Delete "tabs-auto-group" -}}
 {{- end -}}
 {{- if not $groupId -}}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes #781.

`tabs.html` consumed the auto-group but only cleared `tabs-last-auto-group`, leaving `tabs-auto-group` set. Subsequent `{{</* tabs */>}}` blocks on the same page then filed their tab entries under the first block's already-consumed data key, so they rendered with no buttons (showing only the first pane). This deletes `tabs-auto-group` when the group is consumed so each block starts fresh.