### PR TITLE
fix: honor per-page pagerSize despite head paginating first

### DIFF
--- a/exampleSite/content/page/configuration.md
+++ b/exampleSite/content/page/configuration.md
@@ -127,6 +127,7 @@ When `selfHosted = true`, the following assets are served from `static/` instead
 | `toc` | bool | `true` | Show a floating table-of-contents button on pages with headings |
 | `showSource` | bool | `false` | Show a "View source" button linking to the page's source file in the repository |
 | `showPostNav` | bool | `true` | Show previous/next post navigation (side arrows on wide screens, bottom pager on narrow screens) |
+| `pagerSize` | int | — | Posts per page on a list page. Set it in the front matter of the home page, a section, or a term to override the global `pagination.pagerSize` for that node |
 | `sourceRepo` | string | — | Base URL for the repository source browser (e.g. `https://github.com/user/repo/blob/main/`). The page's `.File.Path` is appended automatically. When `enableGitInfo = true` is set, the branch in the URL is replaced with the current commit hash, so the link always points to the exact version of the file |
 
 ```toml

--- a/exampleSite/content/page/pages-and-layouts.md
+++ b/exampleSite/content/page/pages-and-layouts.md
@@ -113,6 +113,15 @@ title: "Blog"
 Welcome to the blog. Below are all posts in chronological order.
 ```
 
+The number of posts per page defaults to the global `pagination.pagerSize` site setting. To override it for one list page (the home page, a section, or a taxonomy term), set `pagerSize` in that page's front matter:
+
+```yaml
+---
+title: "Blog"
+pagerSize: 10
+---
+```
+
 ## Taxonomy Pages
 
 Taxonomies group content by terms. Beautiful Hugo includes two by default:

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -8,7 +8,7 @@
           </div>
         {{ end }}
         <div class="posts-list">
-          {{ $pag := .Paginate (partial "func/list-pages.html" .) }}
+          {{ $pag := partial "func/paginate.html" . }}
           {{ range $pag.Pages }}
             {{ partial "post_preview.html" .}}
           {{ end }}

--- a/layouts/partials/func/list-pages.html
+++ b/layouts/partials/func/list-pages.html
@@ -2,12 +2,9 @@
   Returns the page collection that a list node (home, section, or taxonomy
   term) displays and paginates.
 
-  This is the single source of truth for that collection so that the
-  canonical link built in <head> (see partials/seo/canonical.html) and the
-  listing built later in <body> paginate the *exact same* set. Hugo caches
-  one paginator per page: whichever `.Paginate`/`.Paginator` call runs first
-  wins, and a later call with a different collection is silently ignored. By
-  routing every caller through this partial, the head and body always agree.
+  This is the single source of truth for that collection. All `.Paginate`
+  calls go through `func/paginate.html`, which pairs this collection with a
+  consistent page size — see that partial for why head and body must agree.
 
   - Home: regular pages whose type is in `mainSections`, matching the
     historical home-page listing.

--- a/layouts/partials/func/paginate.html
+++ b/layouts/partials/func/paginate.html
@@ -1,0 +1,24 @@
+{{- /*
+  Creates (or retrieves) the paginator for a list node.
+
+  Hugo caches one paginator per page: whichever `.Paginate` call runs first
+  wins, and later calls silently return the same paginator. Because the SEO
+  partials in <head> paginate before the body templates do, every call site
+  must agree on both the collection and the page size. The collection comes
+  from `func/list-pages`; the size is resolved here:
+
+  - `pagerSize` in the page front matter (or site params) overrides the
+    global `pagination.pagerSize` for that node.
+  - Otherwise Hugo's configured default applies.
+
+  Takes: the page context (.).
+  Returns: the paginator.
+*/ -}}
+{{- $pages := partial "func/list-pages.html" . -}}
+{{- $paginator := "" -}}
+{{- with .Param "pagerSize" -}}
+  {{- $paginator = $.Paginate $pages (int .) -}}
+{{- else -}}
+  {{- $paginator = .Paginate $pages -}}
+{{- end -}}
+{{- return $paginator -}}

--- a/layouts/partials/seo/canonical.html
+++ b/layouts/partials/seo/canonical.html
@@ -22,7 +22,7 @@
 <link rel="canonical" href="{{ . | absLangURL }}" />
   {{- else -}}
     {{- if or .IsHome (eq .Kind "section") (eq .Kind "term") -}}
-      {{- $paginator := .Paginate (partial "func/list-pages.html" .) -}}
+      {{- $paginator := partial "func/paginate.html" . -}}
 <link rel="canonical" href="{{ $paginator.URL | absLangURL }}" />
     {{- else -}}
 <link rel="canonical" href="{{ .Permalink }}" />

--- a/layouts/partials/seo/schema.html
+++ b/layouts/partials/seo/schema.html
@@ -12,13 +12,8 @@
 {{- $collectionOfPosts := dict }}
 
 {{- if .IsNode -}}
-  {{- $pagesToPaginate := slice -}}
-
-  {{/* 1. Get the filtered page collection (hidden pages excluded) for this node */}}
-  {{- $pagesToPaginate = partial "func/list-pages" . -}}
-
-  {{/* 2. Pass that collection directly to the standard Hugo paginator */}}
-  {{- $paginator = .Paginate $pagesToPaginate -}}
+  {{/* Shared partial so head and body paginate the same collection and size */}}
+  {{- $paginator = partial "func/paginate.html" . -}}
   {{- $isAbsoluteHome := and .IsHome (or (not $paginator) (eq $paginator.PageNumber 1)) -}}
   {{- /* Safely commit to this specific page instance's memory bank */ -}}
   {{- .Store.Set "isAbsoluteHome" $isAbsoluteHome -}}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Hugo honors only the first `.Paginate` call on a page, and the SEO partials in `<head>` (`seo/canonical.html`, `seo/schema.html`) paginate before the body renders. A site override of `list.html`/`index.html` that passed an explicit size to `.Paginate` was silently ignored — only the global `pagination.pagerSize` had an effect.

This adds a shared `func/paginate.html` partial that pairs the `func/list-pages` collection with a size resolved from the new `pagerSize` param (page front matter, then site params, then Hugo's global default), and routes all three `.Paginate` call sites through it. The head and body now always paginate the identical collection and size, and sites get a supported knob: set `pagerSize` in the front matter of the home page, a section, or a term.

Verified with the example site: `pagerSize: 2` on the home page renders 2 previews per page with correct self-canonicalizing `/page/N/` links; without it the global size applies as before. Documented in `configuration.md` and `pages-and-layouts.md`.