### PR TITLE
fix: do not double the language prefix for pageRef menu entries

### DIFF
--- a/layouts/partials/func/menu-url.html
+++ b/layouts/partials/func/menu-url.html
@@ -1,0 +1,2 @@
+{{- /* Menu entries with a resolved page already carry the full relative URL; only bare `url` entries need the language prefix. */ -}}
+{{- if .Page }}{{ .URL }}{{ else }}{{ .URL | relLangURL }}{{ end -}}

--- a/layouts/partials/func/menu-url.html
+++ b/layouts/partials/func/menu-url.html
@@ -1,2 +1,14 @@
-{{- /* Menu entries with a resolved page already carry the full relative URL; only bare `url` entries need the language prefix. */ -}}
-{{- if .Page }}{{ .URL }}{{ else }}{{ .URL | relLangURL }}{{ end -}}
+{{- /*
+  Resolves the href for a navbar menu entry.
+
+  Entries resolved to a page (`pageRef`) already carry the full relative
+  URL, including the language prefix and any baseURL subpath. Applying
+  `relLangURL` again would double the prefix (e.g. `/en/foo/en/about/`),
+  so only bare `url` entries get it.
+
+  Takes: a menu entry.
+  Returns: the relative URL string.
+*/ -}}
+{{- $url := .URL -}}
+{{- if not .Page -}}{{- $url = relLangURL $url -}}{{- end -}}
+{{- return $url -}}

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -41,13 +41,13 @@
               <ul class="dropdown-menu dropdown-menu-end">
                 {{ range .Children }}
                   {{ $childName := partial "func/menu-name.html" . }}
-                  <li><a class="dropdown-item" href="{{ .URL | relLangURL }}">{{ $childName }}</a></li>
+                  <li><a class="dropdown-item" href="{{ partial "func/menu-url.html" . }}">{{ $childName }}</a></li>
                 {{ end }}
               </ul>
             </li>
           {{ else }}
             <li class="nav-item" >
-              <a class="nav-link" title="{{ $name }}" href="{{ .URL  | relLangURL }}">{{ $name }}</a>
+              <a class="nav-link" title="{{ $name }}" href="{{ partial "func/menu-url.html" . }}">{{ $name }}</a>
             </li>
           {{ end }}
         {{ end }}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Menu entries that resolve to a page (`pageRef`, or a matching page) already carry the full relative URL, including the language prefix and any baseURL subpath. The nav applied `relLangURL` on top, which produced links like `/en/foo/en/about/` on multilingual sites with a non-root baseURL. Only bare `url` entries get `relLangURL` now.

Fixes #784