### PR TITLE
fix: add /v5 major version suffix to module path

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,30 @@ Install Hugo and create a new site. See [the Hugo documentation](https://gohugo.
 git submodule add https://github.com/halogenica/beautifulhugo.git themes/beautifulhugo
 ```
 
+A submodule points to a commit, not to a tag. To use a release, check out the
+tag in the submodule and commit the result:
+
+```sh
+git -C themes/beautifulhugo checkout v5.0.0
+git add themes/beautifulhugo
+```
+
 ### Hugo Module
 
 ```sh
 hugo mod init github.com/USERNAME/SITENAME
-hugo mod get github.com/halogenica/beautifulhugo
+hugo mod get github.com/halogenica/beautifulhugo/v5
 ```
 
-Stay up to date with `hugo mod get`.
+The `/v5` suffix is the major version of the theme. Pin an exact release with
+`hugo mod get github.com/halogenica/beautifulhugo/v5@v5.0.0`, or stay up to date
+with `hugo mod get -u`.
 
 If using Hugo modules, add this to your `hugo.toml`:
 
 ```toml
 [[module.imports]]
-  path = "github.com/halogenica/beautifulhugo"
+  path = "github.com/halogenica/beautifulhugo/v5"
 ```
 
 ### Preview

--- a/exampleSite/content/post/2026-05-11-theme-features.md
+++ b/exampleSite/content/post/2026-05-11-theme-features.md
@@ -34,7 +34,7 @@ Use the **Features** dropdown in the navigation bar to browse detailed documenta
 
 ```toml
 [[module.imports]]
-  path = "github.com/halogenica/beautifulhugo"
+  path = "github.com/halogenica/beautifulhugo/v5"
 
 [Params]
   subtitle = "Build a beautiful and simple website in minutes"

--- a/exampleSite/go.mod
+++ b/exampleSite/go.mod
@@ -1,7 +1,7 @@
-module github.com/halogenica/beautifulhugo/exampleSite
+module github.com/halogenica/beautifulhugo/v5/exampleSite
 
-replace github.com/halogenica/beautifulhugo => ..
+replace github.com/halogenica/beautifulhugo/v5 => ..
 
 go 1.20
 
-require github.com/halogenica/beautifulhugo v0.0.0-20260508145227-83f5d8f50cdc // indirect
+require github.com/halogenica/beautifulhugo/v5 v5.0.0 // indirect

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -5,7 +5,7 @@ title = "Beautiful Hugo"
 enableGitInfo = true
 
 [[module.imports]]
-   path = "github.com/halogenica/beautifulhugo"
+   path = "github.com/halogenica/beautifulhugo/v5"
 
 [pagination]
   pagerSize = 5

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/halogenica/beautifulhugo
+module github.com/halogenica/beautifulhugo/v5
 
 go 1.20


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Hugo Modules could not use any tagged release. The module path had no major version suffix, so Go rejected every `v2+` tag:

```
$ go list -m github.com/halogenica/beautifulhugo@v5.0.0
invalid version: module contains a go.mod file, so module path must match major version ("github.com/halogenica/beautifulhugo/v5")
$ go list -m -versions github.com/halogenica/beautifulhugo
github.com/halogenica/beautifulhugo      # no versions
```

Users could only get a pseudo-version of the default branch.

This adds the `/v5` suffix to `go.mod`, to the example site module files and config, and to the documented import path. The repository layout does not change; only the import path does. The suffix must be bumped at each future major release.

The README also gets a short note on how to pin a release with a git submodule, because a submodule points to a commit and not to a tag.

Note: a fresh tag has to be pushed after this merges, because `v5.0.0` predates the suffix.