### PR TITLE
refactor: share mainSections lookup across templates

### DIFF
--- a/layouts/_default/archive.html
+++ b/layouts/_default/archive.html
@@ -8,8 +8,7 @@
           </div>
         {{ end }}
 
-{{ $mainSections := default (slice "post" "posts") site.Params.mainSections }}
-{{ $pages := where (where site.RegularPages.ByDate.Reverse "Type" "in" $mainSections) "Params.hidden" "!=" true }}
+{{ $pages := (partial "func/list-pages.html" site.Home).ByDate.Reverse }}
 {{ $groups := $pages.GroupByDate "2006" }}
         {{ $years := slice }}
         {{ range $groups }}

--- a/layouts/partials/func/list-pages.html
+++ b/layouts/partials/func/list-pages.html
@@ -17,7 +17,6 @@
 */ -}}
 {{- $pages := .Pages -}}
 {{- if .IsHome -}}
-  {{- $mainSections := default (slice "post" "posts") site.Params.mainSections -}}
-  {{- $pages = where site.RegularPages "Type" "in" $mainSections -}}
+  {{- $pages = where site.RegularPages "Type" "in" (partial "func/main-sections.html" .) -}}
 {{- end -}}
 {{- return (where $pages "Params.hidden" "!=" true) -}}

--- a/layouts/partials/func/main-sections.html
+++ b/layouts/partials/func/main-sections.html
@@ -1,0 +1,9 @@
+{{- /*
+  Returns the list of content types treated as "posts": `Params.mainSections`
+  from the site config, or `["post", "posts"]` when unset. Callers compare
+  it against `.Type` so a front-matter `type` override is honored.
+
+  Takes: any context (unused).
+  Returns: a slice of strings.
+*/ -}}
+{{- return (default (slice "post" "posts") site.Params.mainSections) -}}

--- a/layouts/partials/func/toc-state.html
+++ b/layouts/partials/func/toc-state.html
@@ -21,8 +21,7 @@
 {{- $listPages := slice -}}
 {{- if $isListPage -}}
   {{- if .IsHome -}}
-    {{- $mainSections := default (slice "post" "posts") site.Params.mainSections -}}
-    {{- $listPages = where (where site.RegularPages "Type" "in" $mainSections) "Params.hidden" "!=" true -}}
+    {{- $listPages = partial "func/list-pages.html" . -}}
   {{- else -}}
     {{- $listPages = .Paginator.Pages -}}
   {{- end -}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -3,8 +3,7 @@
 {{- $bigimg := slice }}
 {{- $headerImgStyle := "big" }}
 {{- $contentColClass := cond .Params.fullWidth "col-12" "col-md-10 offset-md-1" }}
-{{- $mainSections := default (slice "post" "posts") site.Params.mainSections }}
-{{- $isMainContent := in $mainSections .Type }}
+{{- $isMainContent := in (partial "func/main-sections.html" .) .Type }}
 {{ if .IsHome }}
   {{- $title = .Site.Params.homeTitle | default .Site.Title }}
   {{- $subtitle = .Site.Params.subtitle }}

--- a/layouts/partials/seo/meta/meta-robots.html
+++ b/layouts/partials/seo/meta/meta-robots.html
@@ -8,8 +8,7 @@
 
 {{- $site_seo := dict -}}
 {{/* Only get this value if the page is part of a mainSection */}}
-{{- $mainSections := default (slice "post" "posts") site.Params.mainSections -}}
-{{- if in $mainSections .Section -}}
+{{- if in (partial "func/main-sections.html" .) .Type -}}
   {{- $site_seo = site.Params.seo -}}
 {{- end -}}
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Final follow-up for #759. Adds `func/main-sections.html` and removes the five copies of the `mainSections` default expression. The archive page and the TOC panel now reuse `func/list-pages.html`.

`meta-robots.html` matched on `.Section` while every other caller uses `.Type`. It now uses `.Type`, so a front-matter `type` override selects the site-wide SEO defaults consistently.

The built example site is byte-identical except one blank line in the archive page.

Closes #759. The remaining Hugo Pipes item from that review is tracked in a separate issue.