### PR TITLE
feat: bundle theme CSS/JS and skip minify in development

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ hugo serve -s exampleSite --disableFastRender
 ## Architecture
 
 - `layouts/` — Go HTML templates, partials, shortcodes, and default page layouts.
-- `assets/` — Theme-owned CSS and JS (`main.css`, `dark.css`, `main.js`, and similar). Loaded through the `css.html` and `js.html` partials, which run Hugo Pipes (`minify | fingerprint`) and emit SRI `integrity` attributes. Do not hand-minify these files.
+- `assets/` — Theme-owned CSS and JS (`main.css`, `dark.css`, `main.js`, and similar). Loaded through the `css.html` and `js.html` partials (backed by `asset.html`), which concatenate into one CSS and one JS bundle, minify in production only (`hugo.IsProduction`), fingerprint, and emit SRI `integrity` attributes. Do not hand-minify these files. Theme JS runs after all vendored libraries, so it must not be needed by inline scripts earlier in the page.
 - `static/` — Vendored third-party assets (Bootstrap 5.3.5, Font Awesome, KaTeX, PhotoSwipe, Highlight.js, Mermaid) plus self-hosted fonts.
 - `exampleSite/` — Demo content (`content/`, `hugo.toml`, and custom `layouts/partials/head_custom.html` / `footer_custom.html`).
 - `i18n/` — Translation strings in YAML.

--- a/exampleSite/content/page/theming.md
+++ b/exampleSite/content/page/theming.md
@@ -98,17 +98,21 @@ For more extensive customization, you can override any of the theme's stylesheet
 1. Bootstrap CSS
 2. Font Awesome CSS
 3. KaTeX CSS
-4. `main.css` — core layout and typography
-5. `dark.css` — dark mode overrides (only loaded when `colorScheme` is not `"light"`)
-6. Syntax highlighting CSS
-7. `codeblock.css` — code block styling
-8. `toc.css` — table of contents panel
-9. PhotoSwipe CSS
-10. `head_custom.html` — your customizations
+4. The theme bundle, one fingerprinted file that concatenates in order:
+   - `main.css` — core layout and typography
+   - `dark.css` — dark mode overrides (only when `colorScheme` is not `"light"`)
+   - `staticman.css` — only when Staticman is enabled
+   - `syntax.css` — Chroma syntax highlighting (only when `useHLJS` is off)
+   - `codeblock.css` — code block styling
+   - `toc.css` — table of contents panel (only when `toc` is not `false`)
+5. `print.css` — print stylesheet, `media="print"`
+6. Highlight.js CSS, or `syntax-dark.css` for Chroma dark mode (kept separate so JS can toggle it)
+7. PhotoSwipe CSS
+8. `head_custom.html` — your customizations
 
 Because your custom partial loads last, its rules win on equal specificity. For higher-specificity theme rules, increase your selector specificity or use `!important`.
 
-The theme's own stylesheets and scripts live in `assets/` and are processed with Hugo Pipes: each file is minified, fingerprinted for cache busting, and linked with a Subresource Integrity `integrity` attribute. To replace one, put a file with the same path in your site's `assets/` directory (for example `assets/css/main.css`). Hugo uses your copy instead of the theme's and the pipeline applies unchanged.
+The theme's own stylesheets and scripts live in `assets/` and are processed with Hugo Pipes: the files are concatenated into one CSS bundle and one JS bundle, minified in production builds (not under `hugo serve`, so the served files stay readable), fingerprinted for cache busting, and linked with a Subresource Integrity `integrity` attribute. To replace one, put a file with the same path in your site's `assets/` directory (for example `assets/css/main.css`). Hugo uses your copy instead of the theme's and the pipeline applies unchanged.
 
 ### Overriding dark.css entirely
 

--- a/layouts/partials/asset.html
+++ b/layouts/partials/asset.html
@@ -1,0 +1,17 @@
+{{- /* Return a processed resource for one or more theme assets.
+       Takes a dict with "paths" (slice of asset paths) and "ext" ("css" or "js").
+       Several paths are concatenated into one bundle. The bundle name carries a
+       hash of the member list, so pages that need different members (for example
+       a page-level toc setting) do not collide. */ -}}
+{{- $resources := slice }}
+{{- range .paths }}
+  {{- with resources.Get . }}{{ $resources = $resources | append . }}
+  {{- else }}{{ errorf "asset partial: %q not found in assets/" . }}{{ end }}
+{{- end }}
+{{- $r := index $resources 0 }}
+{{- if gt (len $resources) 1 }}
+  {{- $name := printf "%s/beautifulhugo-%s.%s" .ext (delimit .paths "," | md5 | first 8) .ext }}
+  {{- $r = $resources | resources.Concat $name }}
+{{- end }}
+{{- if hugo.IsProduction }}{{ $r = $r | minify }}{{ end }}
+{{- return ($r | fingerprint) -}}

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -1,11 +1,14 @@
-{{- /* Emit a <link> for a theme stylesheet in assets/css, minified and fingerprinted.
-       Pass a string path, or a dict with "path" and optional "id" / "media". */ -}}
-{{- $path := . }}{{ $attrs := "" }}
+{{- /* Emit a <link> for theme CSS from assets/. Pass a path string, or a dict:
+       "path"  - one asset path, or
+       "paths" - a slice of asset paths to concatenate into one bundle,
+       "id" / "media" - optional attributes.
+       Minified in production builds, always fingerprinted. */ -}}
+{{- $paths := slice }}{{ $attrs := "" }}
 {{- if reflect.IsMap . }}
-  {{- $path = .path }}
+  {{- $paths = .paths | default (slice .path) }}
   {{- with .id }}{{ $attrs = printf `%s id="%s"` $attrs . }}{{ end }}
   {{- with .media }}{{ $attrs = printf `%s media="%s"` $attrs . }}{{ end }}
-{{- end }}
-{{- with resources.Get $path | minify | fingerprint }}
+{{- else }}{{ $paths = slice . }}{{ end }}
+{{- with partial "asset.html" (dict "paths" $paths "ext" "css") }}
 <link rel="stylesheet"{{ $attrs | safeHTMLAttr }} href="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}" crossorigin="anonymous" />
-{{- else }}{{ errorf "css partial: asset %q not found" $path }}{{ end -}}
+{{- end -}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -76,15 +76,16 @@
   </script>
 {{- end }}
 
-  {{ partial "css.html" "css/main.css" }}
+  {{- /* Theme CSS is concatenated into one bundle; syntax-dark and print stay
+         separate because JS toggles the first and the second is media=print. */ -}}
+  {{- $css := slice "css/main.css" }}
+  {{- if ne ($.Param "colorScheme" | default "auto") "light" }}{{ $css = $css | append "css/dark.css" }}{{ end }}
+  {{- if .Site.Params.staticman }}{{ $css = $css | append "css/staticman.css" }}{{ end }}
+  {{- if not ($.Param "useHLJS") }}{{ $css = $css | append "css/syntax.css" }}{{ end }}
+  {{- $css = $css | append "css/codeblock.css" }}
+  {{- if ne ($.Param "toc") false }}{{ $css = $css | append "css/toc.css" }}{{ end }}
+  {{ partial "css.html" (dict "paths" $css) }}
   {{ partial "css.html" (dict "path" "css/print.css" "media" "print") }}
-  {{- if ne ($.Param "colorScheme" | default "auto") "light" -}}
-  {{ partial "css.html" "css/dark.css" }}
-  {{- end -}}
-
-  {{- if .Site.Params.staticman -}}
-  {{ partial "css.html" "css/staticman.css" }}
-  {{- end -}}
 
   {{- if .Site.Params.selfHosted -}}
   <link rel="stylesheet" href="{{ "css/fonts.css" | relURL }}" />
@@ -107,12 +108,9 @@
   <link id="hljs-dark" rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/styles/github-dark.min.css" integrity="sha384-wH75j6z1lH97ZOpMOInqhgKzFkAInZPPSPlZpYKYTOqsaizPvhQZmAtLcPKXpLyH" crossorigin="anonymous" media="{{ $darkMedia }}">
   {{- end -}}
   {{- end -}}
-  {{- else -}}
-  {{ partial "css.html" (dict "path" "css/syntax.css") }}
-  {{- if ne $colorScheme "light" -}}
+  {{- else if ne $colorScheme "light" -}}
   {{ partial "css.html" (dict "path" "css/syntax-dark.css" "id" "hljs-dark" "media" $darkMedia) }}
-  {{- end -}}
-  {{- end -}}
+  {{- end }}
   {{- if eq $colorScheme "auto" }}
   <script>
     // The link exists only from here on, so a saved theme must override the media query now.
@@ -124,13 +122,8 @@
       }
     })();
   </script>
-  {{- end -}}
-  {{ partial "css.html" "css/codeblock.css" }}
+  {{- end }}
 
-  {{- if ne ($.Param "toc") false -}}
-  {{ partial "css.html" "css/toc.css" }}
-  {{- end -}}
-  
   {{- if .Site.Params.staticman.recaptcha -}}
   <script src='https://www.google.com/recaptcha/api.js'></script>
   {{- end -}}

--- a/layouts/partials/js.html
+++ b/layouts/partials/js.html
@@ -1,7 +1,10 @@
-{{- /* Emit a <script> for a theme script in assets/js, minified and fingerprinted.
-       Pass a string path, or a dict with "path" and optional "defer" (bool). */ -}}
-{{- $path := . }}{{ $defer := false }}
-{{- if reflect.IsMap . }}{{ $path = .path }}{{ $defer = .defer }}{{ end }}
-{{- with resources.Get $path | minify | fingerprint }}
+{{- /* Emit a <script> for theme JS from assets/. Pass a path string, or a dict:
+       "path"  - one asset path, or
+       "paths" - a slice of asset paths to concatenate into one bundle,
+       "defer" - optional bool.
+       Minified in production builds, always fingerprinted. */ -}}
+{{- $paths := slice }}{{ $defer := false }}
+{{- if reflect.IsMap . }}{{ $paths = .paths | default (slice .path) }}{{ $defer = .defer }}{{ else }}{{ $paths = slice . }}{{ end }}
+{{- with partial "asset.html" (dict "paths" $paths "ext" "js") }}
 <script{{ if $defer }} defer{{ end }} src="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}" crossorigin="anonymous"></script>
-{{- else }}{{ errorf "js partial: asset %q not found" $path }}{{ end -}}
+{{- end -}}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -17,13 +17,6 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js" integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
 {{- end }}
 
-{{ partial "js.html" "js/main.js" }}
-{{- if ne ($.Param "toc") false -}}
-{{ partial "js.html" "js/toc.js" }}
-{{- end -}}
-{{- if .Site.Params.staticman }}
-{{ partial "js.html" "js/staticman.js" }}
-{{- end }}
 {{- if $.Param "useHLJS" }}
 {{- if .Site.Params.selfHosted -}}
 <script src="{{ "js/highlight.min.js" | relURL }}"></script>
@@ -41,7 +34,6 @@
 <script src="https://cdn.jsdelivr.net/npm/photoswipe@5.4.4/dist/umd/photoswipe.umd.min.js" integrity="sha384-k8EKyYcONphQ7zH4cQ0888JapXwrLTXQl/Ue1/jYgjVYahln1NWpnt2S4IC56LNh" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/photoswipe@5.4.4/dist/umd/photoswipe-lightbox.umd.min.js" integrity="sha384-IiBVbUz6+U+Tbm/ijO2P0XRwcVzNfrMzloNLkrqHkbi6w5H0v6ie4fI9BIO4SwdK" crossorigin="anonymous"></script>
 {{- end -}}
-{{ partial "js.html" "js/load-photoswipe.js" }}
 
 {{ if eq (partial "search-provider.html" .) "fuse" }}
 {{- if .Site.Params.selfHosted }}
@@ -49,8 +41,15 @@
 {{- else }}
 <script src="https://cdn.jsdelivr.net/npm/fuse.js@7.0.0/dist/fuse.min.js" integrity="sha384-PCSoOZTpbkikBEtd/+uV3WNdc676i9KUf01KOA8CnJotvlx8rRrETbDuwdjqTYvt" crossorigin="anonymous"></script>
 {{- end }}
-{{ partial "js.html" "js/search-fuse.js" }}
 {{ end }}
+
+{{- /* Theme JS is one bundle, loaded after every library it uses. */ -}}
+{{- $js := slice "js/main.js" }}
+{{- if ne ($.Param "toc") false }}{{ $js = $js | append "js/toc.js" }}{{ end }}
+{{- if .Site.Params.staticman }}{{ $js = $js | append "js/staticman.js" }}{{ end }}
+{{- $js = $js | append "js/load-photoswipe.js" }}
+{{- if eq (partial "search-provider.html" .) "fuse" }}{{ $js = $js | append "js/search-fuse.js" }}{{ end }}
+{{ partial "js.html" (dict "paths" $js) }}
 
 {{ if .Site.Params.gcse }}
 <script>


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Stacked on #792. Retarget to `master` after that merges.

- `css.html` and `js.html` now accept a `paths` slice and concatenate the members with `resources.Concat` through a new `asset.html` partial. The head builds one CSS bundle and `scripts.html` builds one JS bundle, so a typical page goes from about eight theme requests to two.
- The bundle file name includes a short hash of the member list, so pages with different page-level settings (for example `toc = false`) get their own bundle instead of colliding.
- `minify` runs only when `hugo.IsProduction` is true. `hugo serve` keeps the source readable. Fingerprinting still runs in both modes.
- The theme JS bundle now loads after every vendored library. All theme scripts already wait for `DOMContentLoaded` or are called lazily, so the order change has no behavioral effect.
- `print.css` and `syntax-dark.css` stay separate: one is `media="print"`, the other is toggled by JS through its `id`.

Verified builds in production and development environments, with `selfHosted` and `useHLJS` on, and confirmed the JS bundle parses with `node --check`.
