### PR TITLE
fix: read data-pswp-width/height in load-photoswipe.js

### DIFF
--- a/static/js/load-photoswipe.js
+++ b/static/js/load-photoswipe.js
@@ -18,8 +18,8 @@ $(document).ready(function () {
 
         var src = $a.attr('href');
         var sizeAttr = $a.data('size');
-        var width = sizeAttr ? parseInt(sizeAttr.split('x')[0], 10) : 0;
-        var height = sizeAttr ? parseInt(sizeAttr.split('x')[1], 10) : 0;
+        var width = parseInt($a.data('pswp-width'), 10) || (sizeAttr ? parseInt(sizeAttr.split('x')[0], 10) : 0);
+        var height = parseInt($a.data('pswp-height'), 10) || (sizeAttr ? parseInt(sizeAttr.split('x')[1], 10) : 0);
 
         var $figcaption = $figure.find('figcaption');
         var captionHtml = '';


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The `beautifulfigure` shortcode emits `data-pswp-width` and `data-pswp-height` when `size` is given, but `load-photoswipe.js` only read `data-size`, so the values were ignored and PhotoSwipe always loaded the image to detect its dimensions. The loader now reads the `pswp` attributes first and falls back to `data-size`.

Split out of #794.
