### PR TITLE
Fix table formatting in "Big Image Header" section

### DIFF
--- a/exampleSite/content/page/configuration.md
+++ b/exampleSite/content/page/configuration.md
@@ -203,7 +203,6 @@ Add one or more full-width header images to the home page. Multiple images cycle
 | `src` | string | — | Image path (absolute or relative) |
 | `desc` | string | — | Image description (supports Markdown links) |
 | `position` | string | — | CSS `background-position` value (e.g. `"center top"`) |
-
 | `headerImgStyle` | string | `"big"` | Header image height: `"big"` (default, 100–150px padding) or `"narrow"` (25px padding, crops image top and bottom) |
 
 ```toml


### PR DESCRIPTION
As per title - the table didn't render (see [here](https://halogenica.net/beautifulhugo/page/configuration/#:~:text=%7C%20headerImgStyle%20%7C%20string%20%7C%20%22big%22%20%7C%20Header%20image%20height%3A%20%22big%22%20(default%2C%20100%E2%80%93150px%20padding)%20or%20%22narrow%22%20(25px%20padding%2C%20crops%20image%20top%20and%20bottom)%20%7C))