### PR TITLE
feat(i18n): add missing keys to all remaining languages

### DIFF
--- a/i18n/dk.yaml
+++ b/i18n/dk.yaml
@@ -205,3 +205,23 @@
   translation:
     one: "{{ .Count }} sek."
     other: "{{ .Count }} sek."
+- id: breadcrumbHomeLabel
+  translation: "Hjem"
+- id: paginationPageLabel
+  translation: "Side {{ . }}"
+- id: tagsLabel
+  translation: "Tags: "
+- id: taxonomyPagesDescription
+  translation: "Et komplet indeks over {{ . }} brugt til at organisere emner."
+- id: taxonomyPagesTitle
+  translation: "Gennemse indhold efter {{ . }}"
+- id: termPagesDescription
+  translation: "Udforsk alle indlæg og tanker relateret til {{ . }}"
+- id: termPagesTitle
+  translation: "Artikler tagget med '{{ . }}'"
+- id: tocCloseLabel
+  translation: "Luk indholdsfortegnelse"
+- id: tocLabel
+  translation: "Indholdsfortegnelse"
+- id: tocPostsLabel
+  translation: "Indlæg"

--- a/i18n/eo.yaml
+++ b/i18n/eo.yaml
@@ -204,3 +204,23 @@
   translation:
     one: "{{ .Count }} sekundo"
     other: "{{ .Count }} sekundoj"
+- id: breadcrumbHomeLabel
+  translation: "Hejmo"
+- id: paginationPageLabel
+  translation: "Paĝo {{ . }}"
+- id: tagsLabel
+  translation: "Etikedoj: "
+- id: taxonomyPagesDescription
+  translation: "Kompleta indekso de {{ . }} uzata por organizi temojn."
+- id: taxonomyPagesTitle
+  translation: "Foliumi enhavon laŭ {{ . }}"
+- id: termPagesDescription
+  translation: "Esploru ĉiujn afiŝojn kaj pensojn rilatajn al {{ . }}"
+- id: termPagesTitle
+  translation: "Artikoloj etikeditaj per '{{ . }}'"
+- id: tocCloseLabel
+  translation: "Fermi enhavtabelon"
+- id: tocLabel
+  translation: "Enhavtabelo"
+- id: tocPostsLabel
+  translation: "Afiŝoj"

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -205,3 +205,23 @@
   translation:
     one: "{{ .Count }} segundo"
     other: "{{ .Count }} segundos"
+- id: breadcrumbHomeLabel
+  translation: "Inicio"
+- id: paginationPageLabel
+  translation: "Página {{ . }}"
+- id: tagsLabel
+  translation: "Etiquetas: "
+- id: taxonomyPagesDescription
+  translation: "Un índice completo de {{ . }} usado para organizar los temas."
+- id: taxonomyPagesTitle
+  translation: "Explorar contenido por {{ . }}"
+- id: termPagesDescription
+  translation: "Explora todas las publicaciones e ideas relacionadas con {{ . }}"
+- id: termPagesTitle
+  translation: "Artículos etiquetados con '{{ . }}'"
+- id: tocCloseLabel
+  translation: "Cerrar tabla de contenidos"
+- id: tocLabel
+  translation: "Tabla de contenidos"
+- id: tocPostsLabel
+  translation: "Publicaciones"

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -204,3 +204,23 @@
   translation:
     one: "{{ .Count }} s"
     other: "{{ .Count }} s"
+- id: breadcrumbHomeLabel
+  translation: "Accueil"
+- id: paginationPageLabel
+  translation: "Page {{ . }}"
+- id: tagsLabel
+  translation: "Étiquettes : "
+- id: taxonomyPagesDescription
+  translation: "Un index complet des {{ . }} utilisés pour organiser les sujets."
+- id: taxonomyPagesTitle
+  translation: "Parcourir le contenu par {{ . }}"
+- id: termPagesDescription
+  translation: "Explorez tous les articles et réflexions liés à {{ . }}"
+- id: termPagesTitle
+  translation: "Articles étiquetés '{{ . }}'"
+- id: tocCloseLabel
+  translation: "Fermer la table des matières"
+- id: tocLabel
+  translation: "Table des matières"
+- id: tocPostsLabel
+  translation: "Articles"

--- a/i18n/hr.yaml
+++ b/i18n/hr.yaml
@@ -204,3 +204,23 @@
   translation:
     one: "{{ .Count }} sek"
     other: "{{ .Count }} sek"
+- id: breadcrumbHomeLabel
+  translation: "Početna"
+- id: paginationPageLabel
+  translation: "Stranica {{ . }}"
+- id: tagsLabel
+  translation: "Oznake: "
+- id: taxonomyPagesDescription
+  translation: "Potpuni indeks {{ . }} za organizaciju tema."
+- id: taxonomyPagesTitle
+  translation: "Pregledaj sadržaj po {{ . }}"
+- id: termPagesDescription
+  translation: "Istražite sve objave i razmišljanja vezane uz {{ . }}"
+- id: termPagesTitle
+  translation: "Članci označeni s '{{ . }}'"
+- id: tocCloseLabel
+  translation: "Zatvori sadržaj"
+- id: tocLabel
+  translation: "Sadržaj"
+- id: tocPostsLabel
+  translation: "Objave"

--- a/i18n/it.yaml
+++ b/i18n/it.yaml
@@ -204,3 +204,23 @@
   translation:
     one: "{{ .Count }} secondo"
     other: "{{ .Count }} secondi"
+- id: breadcrumbHomeLabel
+  translation: "Home"
+- id: paginationPageLabel
+  translation: "Pagina {{ . }}"
+- id: tagsLabel
+  translation: "Tag: "
+- id: taxonomyPagesDescription
+  translation: "Un indice completo di {{ . }} usati per organizzare gli argomenti."
+- id: taxonomyPagesTitle
+  translation: "Sfoglia i contenuti per {{ . }}"
+- id: termPagesDescription
+  translation: "Esplora tutti gli articoli e i pensieri relativi a {{ . }}"
+- id: termPagesTitle
+  translation: "Articoli con tag '{{ . }}'"
+- id: tocCloseLabel
+  translation: "Chiudi l'indice"
+- id: tocLabel
+  translation: "Indice"
+- id: tocPostsLabel
+  translation: "Articoli"

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -200,3 +200,23 @@
 - id: recipeSecond
   translation:
     other: "{{ .Count }}秒"
+- id: breadcrumbHomeLabel
+  translation: "ホーム"
+- id: paginationPageLabel
+  translation: "{{ . }} ページ"
+- id: tagsLabel
+  translation: "タグ: "
+- id: taxonomyPagesDescription
+  translation: "トピックを整理するための{{ . }}の完全な索引。"
+- id: taxonomyPagesTitle
+  translation: "{{ . }}でコンテンツを探す"
+- id: termPagesDescription
+  translation: "{{ . }}に関連するすべての投稿と考えを探す"
+- id: termPagesTitle
+  translation: "'{{ . }}'のタグが付いた記事"
+- id: tocCloseLabel
+  translation: "目次を閉じる"
+- id: tocLabel
+  translation: "目次"
+- id: tocPostsLabel
+  translation: "投稿"

--- a/i18n/ko.yaml
+++ b/i18n/ko.yaml
@@ -201,3 +201,23 @@
 - id: recipeSecond
   translation:
     other: "{{ .Count }}초"
+- id: breadcrumbHomeLabel
+  translation: "홈"
+- id: paginationPageLabel
+  translation: "{{ . }} 페이지"
+- id: tagsLabel
+  translation: "태그: "
+- id: taxonomyPagesDescription
+  translation: "주제를 정리하기 위한 {{ . }}의 전체 색인입니다."
+- id: taxonomyPagesTitle
+  translation: "{{ . }}별 콘텐츠 둘러보기"
+- id: termPagesDescription
+  translation: "{{ . }}과(와) 관련된 모든 글과 생각을 살펴보세요"
+- id: termPagesTitle
+  translation: "'{{ . }}' 태그가 붙은 글"
+- id: tocCloseLabel
+  translation: "목차 닫기"
+- id: tocLabel
+  translation: "목차"
+- id: tocPostsLabel
+  translation: "글"

--- a/i18n/lmo.yaml
+++ b/i18n/lmo.yaml
@@ -339,3 +339,23 @@
   translation:
     one: "{{ .Count }} segond"
     other: "{{ .Count }} segond"
+- id: breadcrumbHomeLabel
+  translation: "Pagina principala"
+- id: paginationPageLabel
+  translation: "Pagina {{ . }}"
+- id: tagsLabel
+  translation: "Tag: "
+- id: taxonomyPagesDescription
+  translation: "On indes complet di {{ . }} doperaa per organizà i argoment."
+- id: taxonomyPagesTitle
+  translation: "Sfoja i contegnuu per {{ . }}"
+- id: termPagesDescription
+  translation: "Scoeuvr tucc i articol e i penser ligaa a {{ . }}"
+- id: termPagesTitle
+  translation: "Articol cont el tag '{{ . }}'"
+- id: tocCloseLabel
+  translation: "Sara l'indes"
+- id: tocLabel
+  translation: "Indes"
+- id: tocPostsLabel
+  translation: "Articol"

--- a/i18n/nb.yaml
+++ b/i18n/nb.yaml
@@ -204,3 +204,23 @@
   translation:
     one: "{{ .Count }} sekund"
     other: "{{ .Count }} sekunder"
+- id: breadcrumbHomeLabel
+  translation: "Hjem"
+- id: paginationPageLabel
+  translation: "Side {{ . }}"
+- id: tagsLabel
+  translation: "Emneknagger: "
+- id: taxonomyPagesDescription
+  translation: "En komplett oversikt over {{ . }} brukt til å organisere emner."
+- id: taxonomyPagesTitle
+  translation: "Bla gjennom innhold etter {{ . }}"
+- id: termPagesDescription
+  translation: "Utforsk alle innlegg og tanker knyttet til {{ . }}"
+- id: termPagesTitle
+  translation: "Artikler merket med '{{ . }}'"
+- id: tocCloseLabel
+  translation: "Lukk innholdsfortegnelse"
+- id: tocLabel
+  translation: "Innholdsfortegnelse"
+- id: tocPostsLabel
+  translation: "Innlegg"

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -205,3 +205,23 @@
   translation:
     one: "{{ .Count }} seconde"
     other: "{{ .Count }} seconden"
+- id: breadcrumbHomeLabel
+  translation: "Home"
+- id: paginationPageLabel
+  translation: "Pagina {{ . }}"
+- id: tagsLabel
+  translation: "Tags: "
+- id: taxonomyPagesDescription
+  translation: "Een volledige index van {{ . }} om onderwerpen te ordenen."
+- id: taxonomyPagesTitle
+  translation: "Blader door inhoud op {{ . }}"
+- id: termPagesDescription
+  translation: "Verken alle berichten en gedachten over {{ . }}"
+- id: termPagesTitle
+  translation: "Artikelen met tag '{{ . }}'"
+- id: tocCloseLabel
+  translation: "Inhoudsopgave sluiten"
+- id: tocLabel
+  translation: "Inhoudsopgave"
+- id: tocPostsLabel
+  translation: "Berichten"

--- a/i18n/pl.yaml
+++ b/i18n/pl.yaml
@@ -213,3 +213,23 @@
     few: "{{ .Count }} sekundy"
     many: "{{ .Count }} sekund"
     other: "{{ .Count }} sekundy"
+- id: breadcrumbHomeLabel
+  translation: "Strona główna"
+- id: paginationPageLabel
+  translation: "Strona {{ . }}"
+- id: tagsLabel
+  translation: "Tagi: "
+- id: taxonomyPagesDescription
+  translation: "Pełny indeks {{ . }} służący do porządkowania tematów."
+- id: taxonomyPagesTitle
+  translation: "Przeglądaj treści według {{ . }}"
+- id: termPagesDescription
+  translation: "Poznaj wszystkie wpisy i przemyślenia związane z {{ . }}"
+- id: termPagesTitle
+  translation: "Artykuły oznaczone tagiem '{{ . }}'"
+- id: tocCloseLabel
+  translation: "Zamknij spis treści"
+- id: tocLabel
+  translation: "Spis treści"
+- id: tocPostsLabel
+  translation: "Wpisy"

--- a/i18n/pt-br.yaml
+++ b/i18n/pt-br.yaml
@@ -204,3 +204,23 @@
   translation:
     one: "{{ .Count }} segundo"
     other: "{{ .Count }} segundos"
+- id: breadcrumbHomeLabel
+  translation: "Início"
+- id: paginationPageLabel
+  translation: "Página {{ . }}"
+- id: tagsLabel
+  translation: "Tags: "
+- id: taxonomyPagesDescription
+  translation: "Um índice completo de {{ . }} usado para organizar os tópicos."
+- id: taxonomyPagesTitle
+  translation: "Navegar pelo conteúdo por {{ . }}"
+- id: termPagesDescription
+  translation: "Explore todas as postagens e ideias relacionadas a {{ . }}"
+- id: termPagesTitle
+  translation: "Artigos marcados com '{{ . }}'"
+- id: tocCloseLabel
+  translation: "Fechar índice"
+- id: tocLabel
+  translation: "Índice"
+- id: tocPostsLabel
+  translation: "Postagens"

--- a/i18n/pt.yaml
+++ b/i18n/pt.yaml
@@ -204,3 +204,23 @@
   translation:
     one: "{{ .Count }} segundo"
     other: "{{ .Count }} segundos"
+- id: breadcrumbHomeLabel
+  translation: "Início"
+- id: paginationPageLabel
+  translation: "Página {{ . }}"
+- id: tagsLabel
+  translation: "Etiquetas: "
+- id: taxonomyPagesDescription
+  translation: "Um índice completo de {{ . }} usado para organizar os tópicos."
+- id: taxonomyPagesTitle
+  translation: "Navegar pelo conteúdo por {{ . }}"
+- id: termPagesDescription
+  translation: "Explore todas as publicações e ideias relacionadas com {{ . }}"
+- id: termPagesTitle
+  translation: "Artigos etiquetados com '{{ . }}'"
+- id: tocCloseLabel
+  translation: "Fechar índice"
+- id: tocLabel
+  translation: "Índice"
+- id: tocPostsLabel
+  translation: "Publicações"

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -212,3 +212,23 @@
     few: "{{ .Count }} секунды"
     many: "{{ .Count }} секунд"
     other: "{{ .Count }} секунды"
+- id: breadcrumbHomeLabel
+  translation: "Главная"
+- id: paginationPageLabel
+  translation: "Страница {{ . }}"
+- id: tagsLabel
+  translation: "Теги: "
+- id: taxonomyPagesDescription
+  translation: "Полный указатель {{ . }} для организации тем."
+- id: taxonomyPagesTitle
+  translation: "Просмотр содержимого по {{ . }}"
+- id: termPagesDescription
+  translation: "Все записи и мысли, связанные с {{ . }}"
+- id: termPagesTitle
+  translation: "Статьи с тегом '{{ . }}'"
+- id: tocCloseLabel
+  translation: "Закрыть оглавление"
+- id: tocLabel
+  translation: "Оглавление"
+- id: tocPostsLabel
+  translation: "Записи"

--- a/i18n/tr.yaml
+++ b/i18n/tr.yaml
@@ -204,3 +204,23 @@
   translation:
     one: "{{ .Count }} saniye"
     other: "{{ .Count }} saniye"
+- id: breadcrumbHomeLabel
+  translation: "Ana Sayfa"
+- id: paginationPageLabel
+  translation: "Sayfa {{ . }}"
+- id: tagsLabel
+  translation: "Etiketler: "
+- id: taxonomyPagesDescription
+  translation: "Konuları düzenlemek için kullanılan {{ . }} dizininin tamamı."
+- id: taxonomyPagesTitle
+  translation: "İçeriğe {{ . }} ile göz atın"
+- id: termPagesDescription
+  translation: "{{ . }} ile ilgili tüm yazıları ve düşünceleri keşfedin"
+- id: termPagesTitle
+  translation: "'{{ . }}' etiketli yazılar"
+- id: tocCloseLabel
+  translation: "İçindekiler tablosunu kapat"
+- id: tocLabel
+  translation: "İçindekiler"
+- id: tocPostsLabel
+  translation: "Yazılar"

--- a/i18n/zh-CN.yaml
+++ b/i18n/zh-CN.yaml
@@ -200,3 +200,23 @@
 - id: recipeSecond
   translation:
     other: "{{ .Count }}秒"
+- id: breadcrumbHomeLabel
+  translation: "首页"
+- id: paginationPageLabel
+  translation: "第 {{ . }} 页"
+- id: tagsLabel
+  translation: "标签："
+- id: taxonomyPagesDescription
+  translation: "用于组织主题的{{ . }}完整索引。"
+- id: taxonomyPagesTitle
+  translation: "按{{ . }}浏览内容"
+- id: termPagesDescription
+  translation: "浏览与{{ . }}相关的所有文章和想法"
+- id: termPagesTitle
+  translation: "标记为“{{ . }}”的文章"
+- id: tocCloseLabel
+  translation: "关闭目录"
+- id: tocLabel
+  translation: "目录"
+- id: tocPostsLabel
+  translation: "文章"

--- a/i18n/zh-TW.yaml
+++ b/i18n/zh-TW.yaml
@@ -201,3 +201,23 @@
 - id: recipeSecond
   translation:
     other: "{{ .Count }}秒"
+- id: breadcrumbHomeLabel
+  translation: "首頁"
+- id: paginationPageLabel
+  translation: "第 {{ . }} 頁"
+- id: tagsLabel
+  translation: "標籤："
+- id: taxonomyPagesDescription
+  translation: "用於整理主題的{{ . }}完整索引。"
+- id: taxonomyPagesTitle
+  translation: "依{{ . }}瀏覽內容"
+- id: termPagesDescription
+  translation: "瀏覽與{{ . }}相關的所有文章和想法"
+- id: termPagesTitle
+  translation: "標記為「{{ . }}」的文章"
+- id: tocCloseLabel
+  translation: "關閉目錄"
+- id: tocLabel
+  translation: "目錄"
+- id: tocPostsLabel
+  translation: "文章"


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Follow-up to #800. That PR added the ten newer i18n keys (`breadcrumbHomeLabel`, `paginationPageLabel`, `tagsLabel`, `taxonomyPagesTitle`/`Description`, `termPagesTitle`/`Description`, `tocLabel`, `tocCloseLabel`, `tocPostsLabel`) to German only. This adds them to the other 18 language files, so every file now has the same set of ids as `en.yaml`.

Hugo falls back to English for missing ids, so this only changes what non-English sites display for these labels. Native speakers are welcome to correct wording.
