### PR TITLE
fix(templates): honor false for ghCount/showPageDates, key schema cache by language

### DIFF
--- a/layouts/partials/github-buttons.html
+++ b/layouts/partials/github-buttons.html
@@ -12,7 +12,12 @@
 {{ $badges := .Params.ghBadge | default .Site.Params.ghBadge }}
 {{ if and .Params.ghRepo $badges }}
   {{ $repo := .Params.ghRepo }}
-  {{ $count := .Params.ghCount | default .Site.Params.ghCount | default true }}
+  {{ $count := true }}
+  {{ if isset .Params "ghCount" }}
+    {{ $count = .Params.ghCount }}
+  {{ else if isset .Site.Params "ghCount" }}
+    {{ $count = .Site.Params.ghCount }}
+  {{ end }}
   {{ $user := index (split $repo "/") 0 }}
   {{ $repoName := index (split $repo "/") 1 }}
     <div class="gh-buttons" style="margin-bottom: 20px;">

--- a/layouts/partials/page_meta.html
+++ b/layouts/partials/page_meta.html
@@ -1,5 +1,8 @@
 <div class="page-meta">
-  {{ $show := default .Site.Params.showPageDates .Params.showPageDates }}
+  {{ $show := .Site.Params.showPageDates }}
+  {{ if isset .Params "showPageDates" }}
+    {{ $show = .Params.showPageDates }}
+  {{ end }}
   {{ if $show }}
     {{ $format := partial "func/date-format.html" . }}
     {{ $datestr := time.Format $format .Date }}

--- a/layouts/partials/seo/schema.html
+++ b/layouts/partials/seo/schema.html
@@ -1,8 +1,8 @@
 {{- $paginator := "" -}}
 
 {{/* WebSite and Organization are always present and never change */}}
-{{- $website := partialCached "seo/structured/website" . -}}
-{{- $organization := partialCached "seo/structured/organization" . }}
+{{- $website := partialCached "seo/structured/website" . site.Language.Lang -}}
+{{- $organization := partialCached "seo/structured/organization" . site.Language.Lang }}
 
 {{/* Setup dictionaries for inclusing in @graph */}}
 {{- $webpage := dict }}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

This PR fixes two boolean-parameter bugs and one caching bug. Hugo's `default` function treats `false` as unset, so `ghCount: false` and `showPageDates: false` could never disable those features at the page or site level. Both partials now check `isset` first, so an explicit `false` is honored. The schema partial also keys its cached `website` and `organization` structured-data partials by `site.Language.Lang`, so multilingual sites no longer share the first language's title and base URL across all languages.

Refs #803
