### PR TITLE
fix(js): keep indentation in copied code, harden mermaid and search rendering

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -297,10 +297,7 @@ document.addEventListener('DOMContentLoaded', () => {
           const lineNumbers = codeBlockClone.querySelectorAll('.ln');
           lineNumbers.forEach(ln => ln.remove());
 
-          const codeText = codeBlockClone.textContent
-              .split('\n')
-              .map(line => line.trim())
-              .join('\n');
+          const codeText = codeBlockClone.textContent.replace(/\n$/, '');
 
           navigator.clipboard.writeText(codeText)
               .then(() => {

--- a/static/js/mermaid-render.js
+++ b/static/js/mermaid-render.js
@@ -11,6 +11,10 @@ document.addEventListener('DOMContentLoaded', function() {
     var lightEl = container.querySelector('.theme-light');
     var darkEl = container.querySelector('.theme-dark');
     var id = 'mermaid-' + idx;
+    function advance() {
+      idx++;
+      renderNext();
+    }
     if (lightEl) {
       mermaid.initialize({startOnLoad: false, theme: 'default'});
       mermaid.render(id + '-light', code).then(function(result) {
@@ -19,21 +23,26 @@ document.addEventListener('DOMContentLoaded', function() {
           mermaid.initialize({startOnLoad: false, theme: 'dark'});
           mermaid.render(id + '-dark', code).then(function(result2) {
             darkEl.innerHTML = result2.svg;
-            idx++;
-            renderNext();
-          });
+          }).catch(function(err) {
+            console.error('mermaid render failed', err);
+          }).finally(advance);
         } else {
-          idx++;
-          renderNext();
+          advance();
         }
+      }).catch(function(err) {
+        console.error('mermaid render failed', err);
+        advance();
       });
     } else if (darkEl) {
       mermaid.initialize({startOnLoad: false, theme: 'dark'});
       mermaid.render(id + '-dark', code).then(function(result) {
         darkEl.innerHTML = result.svg;
-        idx++;
-        renderNext();
-      });
+      }).catch(function(err) {
+        console.error('mermaid render failed', err);
+      }).finally(advance);
+    } else {
+      console.error('mermaid-render: container has neither .theme-light nor .theme-dark', container);
+      advance();
     }
   }
   renderNext();

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -11,6 +11,12 @@ function escapeHtml(text) {
   return div.innerHTML;
 }
 
+// Utility: decode HTML entities (e.g. from indexed content) before re-escaping
+function decodeHtml(text) {
+  if (!text) return '';
+  return new DOMParser().parseFromString(text, 'text/html').body.textContent || '';
+}
+
 // Utility: update URL without reloading
 function updateUrl(query, page) {
   const newUrl = new URL(window.location);
@@ -105,9 +111,9 @@ function renderResults(query, page) {
     pageResults.forEach(function(data) {
       html += '<div class="result">';
       html += '<a class="result-title" href="' + escapeHtml(data.url) + '">' +
-      escapeHtml(data.title || (window.searchConfig ? window.searchConfig.untitledText : '')) + '</a>';
+      escapeHtml(decodeHtml(data.title) || (window.searchConfig ? window.searchConfig.untitledText : '')) + '</a>';
     if (data.excerpt) {
-      html += '<div class="result-excerpt">' + escapeHtml(data.excerpt) + '</div>';
+      html += '<div class="result-excerpt">' + escapeHtml(decodeHtml(data.excerpt)) + '</div>';
     }
     html += '</div>';
   });


### PR DESCRIPTION
:robot: _AI text below_ :robot:

This PR fixes three JavaScript issues in the theme. The copy-code button no longer trims each line of code, so indentation-sensitive code (for example Python) keeps its formatting when copied. The Mermaid render chain now catches a failed `mermaid.render()` call, logs the error, and always moves to the next diagram, so a diagram with a syntax error no longer stops later diagrams from rendering. The search page now decodes HTML entities in result titles and excerpts before escaping them, matching the existing behavior in `search-fuse.js`, so entities like `&amp;` display correctly instead of literally.

Refs #803
