### PR TITLE
fix(theme): apply highlight.js dark stylesheet via media query to avoid flash

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -12,19 +12,12 @@
     <script>
       (function() {
         var saved = localStorage.getItem('theme');
-        var dark = false;
         if (saved === 'dark') {
           document.documentElement.setAttribute('data-theme', 'dark');
-          dark = true;
         } else if (saved === 'light') {
           document.documentElement.setAttribute('data-theme', 'light');
         } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
           document.documentElement.setAttribute('data-theme', 'dark');
-          dark = true;
-        }
-        var hljsDark = document.getElementById('hljs-dark');
-        if (hljsDark) {
-          hljsDark.disabled = !dark;
         }
       })();
     </script>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -92,23 +92,38 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,700;1,400;1,700&family=Open+Sans:ital,wght@0,400;0,600;0,700;1,400;1,600;1,700&display=swap" />
   {{- end -}}
 
+  {{- $colorScheme := $.Param "colorScheme" | default "auto" -}}
+  {{- /* In "auto" mode the dark sheet is gated by the media query, so it never applies before JS runs. */ -}}
+  {{- $darkMedia := cond (eq $colorScheme "auto") "(prefers-color-scheme: dark)" "all" -}}
   {{- if $.Param "useHLJS" }}
   {{- if .Site.Params.selfHosted -}}
   <link rel="stylesheet" href="{{ "css/highlight.min.css" | relURL }}" />
-  {{- if ne ($.Param "colorScheme" | default "auto") "light" -}}
-  <link id="hljs-dark" rel="stylesheet" href="{{ "css/highlight-dark.min.css" | relURL }}" />
+  {{- if ne $colorScheme "light" -}}
+  <link id="hljs-dark" rel="stylesheet" href="{{ "css/highlight-dark.min.css" | relURL }}" media="{{ $darkMedia }}" />
   {{- end -}}
   {{- else -}}
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/styles/github.min.css" integrity="sha384-eFTL69TLRZTkNfYZOLM+G04821K1qZao/4QLJbet1pP4tcF+fdXq/9CdqAbWRl/L" crossorigin="anonymous">
-  {{- if ne ($.Param "colorScheme" | default "auto") "light" -}}
-  <link id="hljs-dark" rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/styles/github-dark.min.css" integrity="sha384-wH75j6z1lH97ZOpMOInqhgKzFkAInZPPSPlZpYKYTOqsaizPvhQZmAtLcPKXpLyH" crossorigin="anonymous">
+  {{- if ne $colorScheme "light" -}}
+  <link id="hljs-dark" rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/styles/github-dark.min.css" integrity="sha384-wH75j6z1lH97ZOpMOInqhgKzFkAInZPPSPlZpYKYTOqsaizPvhQZmAtLcPKXpLyH" crossorigin="anonymous" media="{{ $darkMedia }}">
   {{- end -}}
   {{- end -}}
   {{- else -}}
   <link rel="stylesheet" href="{{ "css/syntax.css" | relURL }}" />
-  {{- if ne ($.Param "colorScheme" | default "auto") "light" -}}
-  <link id="hljs-dark" rel="stylesheet" href="{{ "css/syntax-dark.css" | relURL }}" />
+  {{- if ne $colorScheme "light" -}}
+  <link id="hljs-dark" rel="stylesheet" href="{{ "css/syntax-dark.css" | relURL }}" media="{{ $darkMedia }}" />
   {{- end -}}
+  {{- end -}}
+  {{- if eq $colorScheme "auto" }}
+  <script>
+    // The link exists only from here on, so a saved theme must override the media query now.
+    (function() {
+      var saved = localStorage.getItem('theme');
+      var hljsDark = document.getElementById('hljs-dark');
+      if (hljsDark && (saved === 'dark' || saved === 'light')) {
+        hljsDark.media = (saved === 'dark') ? 'all' : 'not all';
+      }
+    })();
+  </script>
   {{- end -}}
   <link rel="stylesheet" href="{{ "css/codeblock.css" | relURL }}" />
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -126,7 +126,7 @@ var main = {
         var hljsDark = document.getElementById('hljs-dark');
         if (hljsDark) {
           var isDark = (state === 'dark') || (state === 'auto' && window.matchMedia('(prefers-color-scheme: dark)').matches);
-          hljsDark.disabled = !isDark;
+          hljsDark.media = isDark ? 'all' : 'not all';
         }
         updateThemeTooltip(state);
       }


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The inline script in the head did `document.getElementById('hljs-dark')`, but `head.html` emits that link later, so the lookup was always null and the code did nothing. With `useHLJS = true`, light-mode users saw the dark highlight.js stylesheet until `main.js` ran, and users without JavaScript saw it permanently.

The dark stylesheet link now has `media="(prefers-color-scheme: dark)"` when `colorScheme` is `auto`, and `media="all"` when `colorScheme` is `dark`. A short script directly after the link applies a saved theme from `localStorage`, and `main.js` now sets `media` instead of the `disabled` property. The dead code in `baseof.html` is removed.

I built the example site with `colorScheme` set to `auto`, `dark` and `light`, with and without `useHLJS`, and checked the generated link element in each case.

Refs #803
