### PR TITLE
chore: use buttons for search pagination, tidy iframe attrs, bump deploy Hugo

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -25,7 +25,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.146.2
+      HUGO_VERSION: 0.163.0
     steps:
       - name: Install Hugo CLI
         run: >

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ hugo serve -s exampleSite --disableFastRender
 
 - **Minimum Hugo version**: `0.146.2` (enforced at runtime in `layouts/_default/baseof.html`).
 - **CI matrix** tests against `0.146.2`, `0.155.2`, and `0.163.0`.
-- The deploy workflow pins `0.146.2`.
+- The deploy workflow pins `0.163.0`.
 - CI uses the **extended** Hugo binary.
 
 ## Architecture

--- a/layouts/partials/github-buttons.html
+++ b/layouts/partials/github-buttons.html
@@ -37,7 +37,7 @@
         {{ if ne $type "follow" }}
           {{ $iframeSrc = printf "https://ghbtns.com/github-btn.html?user=%s&repo=%s&type=%s&size=large%s%s" $user $repoName $type $countParam $extra }}
         {{ end }}
-        <iframe src="{{ $iframeSrc }}" frameborder="0" scrolling="0" width="{{ $width }}" height="{{ $height }}" title="GitHub"></iframe>
+        <iframe src="{{ $iframeSrc }}" style="border:0" loading="lazy" width="{{ $width }}" height="{{ $height }}" title="GitHub"></iframe>
       {{ end }}
     </div>
 {{ end }}

--- a/static/css/dark.css
+++ b/static/css/dark.css
@@ -105,14 +105,17 @@
   background-color: rgba(255, 255, 255, 0.04);
 }
 
-[data-theme="dark"] .post-pager li a {
+[data-theme="dark"] .post-pager li a,
+[data-theme="dark"] .post-pager li button {
   background: var(--dark-surface);
   color: var(--dark-fg);
   border-color: var(--dark-surface-active);
 }
 
 [data-theme="dark"] .post-pager li a:hover,
-[data-theme="dark"] .post-pager li a:focus {
+[data-theme="dark"] .post-pager li a:focus,
+[data-theme="dark"] .post-pager li button:hover,
+[data-theme="dark"] .post-pager li button:focus {
   background: var(--dark-accent);
   border-color: var(--dark-accent);
 }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -818,12 +818,14 @@ img::selection {
 }
 
 .post-pager .pager-prev > a,
-.post-pager .pager-prev > span {
+.post-pager .pager-prev > span,
+.post-pager .pager-prev > button {
   float: left;
 }
 
 .post-pager .pager-next > a,
-.post-pager .pager-next > span {
+.post-pager .pager-next > span,
+.post-pager .pager-next > button {
   float: right;
 }
 
@@ -840,16 +842,19 @@ img::selection {
 }
 
 .post-pager .pager-prev > a,
-.post-pager .pager-prev > span {
+.post-pager .pager-prev > span,
+.post-pager .pager-prev > button {
   float: left;
 }
 
 .post-pager .pager-next > a,
-.post-pager .pager-next > span {
+.post-pager .pager-next > span,
+.post-pager .pager-next > button {
   float: right;
 }
 
-.post-pager li a {
+.post-pager li a,
+.post-pager li button {
   font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   text-transform: uppercase;
   font-size: 14px;
@@ -860,17 +865,21 @@ img::selection {
   border: 1px solid #e0e0e0;
   border-radius: 0;
   color: #404040;
+  cursor: pointer;
 }
 
 .post-pager li a:hover,
-.post-pager li a:focus {
+.post-pager li a:focus,
+.post-pager li button:hover,
+.post-pager li button:focus {
   color: #FFF;
   background: #0085a1;
   border-color: #0085a1;
 }
 
 @media only screen and (min-width: 768px) {
-  .post-pager li a {
+  .post-pager li a,
+  .post-pager li button {
     padding: 15px 25px;
   }
 }

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -17,8 +17,9 @@ function decodeHtml(text) {
   return new DOMParser().parseFromString(text, 'text/html').body.textContent || '';
 }
 
-// Utility: update URL without reloading
-function updateUrl(query, page) {
+// Utility: update URL without reloading. Use push=true only for explicit
+// page changes; typing keeps replaceState so it does not spam history.
+function updateUrl(query, page, push) {
   const newUrl = new URL(window.location);
   if (query) {
     newUrl.searchParams.set('q', query);
@@ -31,7 +32,11 @@ function updateUrl(query, page) {
   } else {
     newUrl.searchParams.delete('page');
   }
-  window.history.pushState({}, '', newUrl);
+  if (push) {
+    window.history.pushState({}, '', newUrl);
+  } else {
+    window.history.replaceState({}, '', newUrl);
+  }
 }
 
 async function initSearch() {
@@ -47,20 +52,20 @@ async function initSearch() {
   }
 }
 
-window.doSearch = function(page) {
+window.doSearch = function(page, push) {
   page = page || 1;
   const input = document.getElementById('searchInput');
   if (!input) return;
   const query = input.value.trim();
 
   if (!query) {
-    updateUrl('', 1);
+    updateUrl('', 1, push);
     const container = document.getElementById('resultsContainer');
     if (container) container.innerHTML = '';
     return;
   }
 
-  updateUrl(query, page);
+  updateUrl(query, page, push);
 
   const container = document.getElementById('resultsContainer');
   if (container) {
@@ -127,14 +132,14 @@ function renderPagination(currentPage, totalResults) {
   if (currentPage > 1) {
     const prevText = window.searchConfig ? window.searchConfig.prevText : '';
     html += '<li class="pager-prev">';
-    html += '<a href="javascript:void(0)" onclick="window.doSearch(' + (currentPage - 1) + ')">&larr; ' + prevText + '</a>';
+    html += '<button type="button" data-page="' + (currentPage - 1) + '">&larr; ' + prevText + '</button>';
     html += '</li>';
   }
 
   if (currentPage < totalPages) {
     const nextText = window.searchConfig ? window.searchConfig.nextText : '';
     html += '<li class="pager-next">';
-    html += '<a href="javascript:void(0)" onclick="window.doSearch(' + (currentPage + 1) + ')">' + nextText + ' &rarr;</a>';
+    html += '<button type="button" data-page="' + (currentPage + 1) + '">' + nextText + ' &rarr;</button>';
     html += '</li>';
   }
 
@@ -170,6 +175,15 @@ document.addEventListener('DOMContentLoaded', () => {
       });
       searchInput.addEventListener('keypress', function(e) {
         if (e.key === 'Enter') window.doSearch();
+      });
+    }
+
+    const paginationContainer = document.getElementById('search-pagination');
+    if (paginationContainer) {
+      paginationContainer.addEventListener('click', function(e) {
+        const button = e.target.closest('[data-page]');
+        if (!button) return;
+        window.doSearch(Number(button.dataset.page), true);
       });
     }
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

- The search pagination controls are now real buttons with a single delegated click handler, instead of anchors with inline `onclick` attributes.
- Typing in the search box updates the URL with `replaceState`. Pagination clicks still use `pushState`, so browser history no longer fills up with one entry per keystroke.
- The GitHub badge iframe drops the obsolete `frameborder` and `scrolling` attributes in favor of `style="border:0"` and `loading="lazy"`.
- The deploy workflow now pins Hugo 0.163.0, the newest version already covered by the CI matrix.

Refs #803
