### PR TITLE
refactor(templates): use GetTerms, share data lookup, drop dead branches

### DIFF
--- a/layouts/_default/archive.html
+++ b/layouts/_default/archive.html
@@ -8,6 +8,7 @@
           </div>
         {{ end }}
 
+{{ $format := partial "func/date-format.html" . }}
 {{ $pages := (partial "func/list-pages.html" site.Home).ByDate.Reverse }}
 {{ $groups := $pages.GroupByDate "2006" }}
         {{ $years := slice }}
@@ -33,7 +34,6 @@
                     <span class="archive-item-subtitle">{{ .Params.subtitle }}</span>
                   {{ end }}
                   <span class="archive-item-date">
-                    {{ $format := default (i18n "dateFormat") site.Params.dateformat }}
                     {{ time.Format $format .Date }}
                   </span>
                 </a>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -14,22 +14,16 @@
         {{ if .Params.categories }}
           <div class="blog-categories">
             <span>{{ i18n "categoriesLabel" }}</span>
-            {{ range .Params.categories }}
-              {{- $catName := . -}}
-              {{- with $.Site.GetPage (printf "/%s/%s" "categories" ($catName | urlize)) -}}
-              <a href="{{ .RelPermalink }}">{{ $catName }}</a>&nbsp;
-              {{- end -}}
+            {{ range .GetTerms "categories" }}
+              <a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>&nbsp;
             {{ end }}
           </div>
         {{ end }}
         {{ if .Params.tags }}
           <div class="blog-tags">
             <span>{{ i18n "tagsLabel" | default "Tags: " }}</span>
-            {{ range .Params.tags }}
-              {{- $tagName := . -}}
-              {{- with $.Site.GetPage (printf "/%s/%s" "tags" ($tagName | urlize)) -}}
-              <a href="{{ .RelPermalink }}">{{ $tagName }}</a>&nbsp;
-              {{- end -}}
+            {{ range .GetTerms "tags" }}
+              <a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>&nbsp;
             {{ end }}
           </div>
         {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -15,7 +15,7 @@
           <div class="blog-categories">
             <span>{{ i18n "categoriesLabel" }}</span>
             {{ range .GetTerms "categories" }}
-              <a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>&nbsp;
+              <a href="{{ .RelPermalink }}">{{ .Data.Term }}</a>&nbsp;
             {{ end }}
           </div>
         {{ end }}
@@ -23,7 +23,7 @@
           <div class="blog-tags">
             <span>{{ i18n "tagsLabel" | default "Tags: " }}</span>
             {{ range .GetTerms "tags" }}
-              <a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>&nbsp;
+              <a href="{{ .RelPermalink }}">{{ .Data.Term }}</a>&nbsp;
             {{ end }}
           </div>
         {{ end }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,6 +1,5 @@
 {{ define "main" }}
 
-{{ $data := .Data }}
 {{ $terms := .Data.Terms }}
 
 <div class="container{{ if .Params.fullWidth }}-fluid{{ end }}" role="main">
@@ -15,7 +14,7 @@
         {{ range $key, $value := $terms.Alphabetical }}
           <div class="terms-item">
             <div class="terms-item-header">
-              <a href="{{ with $.Site.GetPage (printf "/%s/%s" $data.Plural ($value.Name | urlize)) }}{{ .RelPermalink }}{{ end }}">
+              <a href="{{ $value.Page.RelPermalink }}">
                 {{ $value.Name }}
               </a>
               <span class="terms-item-count">{{ $value.Count }}</span>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,9 +1,4 @@
-{{- $data := dict -}}
-{{- if ge hugo.Version "0.156.0" -}}
-  {{- $data = hugo.Data -}}
-{{- else -}}
-  {{- $data = .Site.Data -}}
-{{- end -}}
+{{- $data := partial "func/data.html" . -}}
 {{ if eq .Type "page" }}
   {{ partial "page_meta.html" . }}
 {{ end }}

--- a/layouts/partials/func/data.html
+++ b/layouts/partials/func/data.html
@@ -1,0 +1,17 @@
+{{- /*
+  Resolves the site data map.
+
+  Hugo 0.156.0 moved the data directory to the global `hugo.Data`;
+  `.Site.Data` is deprecated there but is the only option on older
+  versions, which the theme still supports.
+
+  Takes: the page context (.).
+  Returns: the data map.
+*/ -}}
+{{- $data := dict -}}
+{{- if ge hugo.Version "0.156.0" -}}
+  {{- $data = hugo.Data -}}
+{{- else -}}
+  {{- $data = .Site.Data -}}
+{{- end -}}
+{{- return $data -}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -56,13 +56,9 @@
           <div class="{{$contentColClass}}">
             <div class="{{ .Type }}-heading">
               {{ if $bigimg }}
-              <span class="h1">{{ with $title }}{{.}}{{ else }}<br/>{{ end }}</span>
+              <span class="h1">{{ $title }}</span>
               {{ else }}
-              {{ if eq .Type "list" }}
-                <h1>{{ if .Data.Singular }}#{{ end }}{{ .Title }}</h1>
-              {{ else }}
-                <h1>{{ with $title }}{{.}}{{ else }}<br/>{{ end }}</h1>
-              {{ end }}
+              <h1>{{ $title }}</h1>
               {{ end }}
               {{ if not $isMainContent }}
                 <hr class="small">

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -1,10 +1,5 @@
 <span class="post-meta">
-  {{- $data := dict -}}
-  {{- if ge hugo.Version "0.156.0" -}}
-    {{- $data = hugo.Data -}}
-  {{- else -}}
-    {{- $data = .Site.Data -}}
-  {{- end -}}
+  {{- $data := partial "func/data.html" . -}}
   {{ $format := partial "func/date-format.html" . }}
   {{ $datestr := time.Format $format .Date }}
   {{ $lastmodstr := time.Format $format .Lastmod }}

--- a/layouts/partials/post_preview.html
+++ b/layouts/partials/post_preview.html
@@ -43,20 +43,14 @@
     <div class="blog-tags">
         {{ if .Params.categories }}
         <span class="blog-tags-label">{{ i18n "categoriesLabel" }}</span>
-        {{ range .Params.categories }}
-        {{- $catName := . -}}
-        {{- with $.Site.GetPage (printf "/%s/%s" "categories" ($catName | urlize)) -}}
-        <a href="{{ .RelPermalink }}" class="blog-tags-category">{{ $catName }}</a>&nbsp;
-        {{- end -}}
+        {{ range .GetTerms "categories" }}
+        <a href="{{ .RelPermalink }}" class="blog-tags-category">{{ .LinkTitle }}</a>&nbsp;
         {{ end }}
         {{ end }}
         {{ if .Params.tags }}
         <span class="blog-tags-label">{{ i18n "tagsLabel" | default "Tags: " }}</span>
-        {{ range .Params.tags }}
-        {{- $tagName := . -}}
-        {{- with $.Site.GetPage (printf "/%s/%s" "tags" ($tagName | urlize)) -}}
-        <a href="{{ .RelPermalink }}">{{ $tagName }}</a>&nbsp;
-        {{- end -}}
+        {{ range .GetTerms "tags" }}
+        <a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>&nbsp;
         {{ end }}
         {{ end }}
     </div>

--- a/layouts/partials/post_preview.html
+++ b/layouts/partials/post_preview.html
@@ -44,13 +44,13 @@
         {{ if .Params.categories }}
         <span class="blog-tags-label">{{ i18n "categoriesLabel" }}</span>
         {{ range .GetTerms "categories" }}
-        <a href="{{ .RelPermalink }}" class="blog-tags-category">{{ .LinkTitle }}</a>&nbsp;
+        <a href="{{ .RelPermalink }}" class="blog-tags-category">{{ .Data.Term }}</a>&nbsp;
         {{ end }}
         {{ end }}
         {{ if .Params.tags }}
         <span class="blog-tags-label">{{ i18n "tagsLabel" | default "Tags: " }}</span>
         {{ range .GetTerms "tags" }}
-        <a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>&nbsp;
+        <a href="{{ .RelPermalink }}">{{ .Data.Term }}</a>&nbsp;
         {{ end }}
         {{ end }}
     </div>

--- a/layouts/partials/seo/schema.html
+++ b/layouts/partials/seo/schema.html
@@ -11,7 +11,8 @@
 {{- $recipe := dict }}
 {{- $collectionOfPosts := dict }}
 
-{{- if .IsNode -}}
+{{/* Branch kinds only; `.IsBranch` needs Hugo 0.163.0, `.IsNode` is deprecated. */}}
+{{- if in (slice "home" "section" "taxonomy" "term") .Kind -}}
   {{/* Shared partial so head and body paginate the same collection and size */}}
   {{- $paginator = partial "func/paginate.html" . -}}
   {{- $isAbsoluteHome := and .IsHome (or (not $paginator) (eq $paginator.PageNumber 1)) -}}

--- a/layouts/partials/seo/structured/collection-page.html
+++ b/layouts/partials/seo/structured/collection-page.html
@@ -1,5 +1,5 @@
 {{- $schema := dict }}
-{{- if .IsNode }}
+{{- if in (slice "home" "section" "taxonomy" "term") .Kind }}
 
   {{/* Reuse the paginator already initialized in seo/schema.html (cached in
        .Store) so the collection here matches the head canonical link and the

--- a/layouts/partials/seo/structured/organization.html
+++ b/layouts/partials/seo/structured/organization.html
@@ -1,9 +1,4 @@
-{{- $data := dict -}}
-{{- if ge hugo.Version "0.156.0" -}}
-  {{- $data = hugo.Data -}}
-{{- else -}}
-  {{- $data = .Site.Data -}}
-{{- end -}}
+{{- $data := partial "func/data.html" . -}}
 {{- $schema := dict
   "@type" "Organization"
   "name" (.Site.Params.organizationName | default .Site.Params.author.name)

--- a/layouts/partials/staticman-comments.html
+++ b/layouts/partials/staticman-comments.html
@@ -1,10 +1,5 @@
 <section class="js-comments staticman-comments">
-  {{- $data := dict -}}
-  {{- if ge hugo.Version "0.156.0" -}}
-    {{- $data = hugo.Data -}}
-  {{- else -}}
-    {{- $data = .Site.Data -}}
-  {{- end -}}
+  {{- $data := partial "func/data.html" . -}}
 
   {{ $slug := replace .RelPermalink "/" "" }}
 

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -28,16 +28,9 @@ function updateUrl(query, page) {
   window.history.pushState({}, '', newUrl);
 }
 
-// Manage button state (enabled/disabled)
-function setButtonsLoading(loading) {
-  // no-op: search is now triggered via input events
-}
-
 async function initSearch() {
-  setButtonsLoading(true);
   try {
     searchEngine = await window.BeautifulHugoSearch.getEngine();
-    setButtonsLoading(false);
     autoSearchFromUrl();
   } catch (e) {
     console.error('Failed to load search index:', e);
@@ -45,7 +38,6 @@ async function initSearch() {
     if (container) {
       container.innerHTML = '<div class="no-results">' + (window.searchConfig ? window.searchConfig.errorIndexLoad : '') + '</div>';
     }
-    setButtonsLoading(false);
   }
 }
 
@@ -143,18 +135,6 @@ function renderPagination(currentPage, totalResults) {
   html += '</ul>';
   return html;
 }
-
-window.feelingLucky = function() {
-  const input = document.getElementById('searchInput');
-  if (!input || !input.value.trim()) return;
-
-  if (!searchEngine) return;
-
-  const result = searchEngine.lucky(input.value.trim());
-  if (result && result.url) {
-    window.location.href = result.url;
-  }
-};
 
 function autoSearchFromUrl() {
   const params = new URLSearchParams(window.location.search);


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Template and script cleanups. No new features.

- Tag and category links use `.GetTerms` instead of rebuilding the term URL with `Site.GetPage` and `urlize`. The label comes from `.Data.Term`, so it keeps the front-matter spelling. The generated HTML changes only in whitespace.
- The terms list gets the term URL from `$value.Page.RelPermalink`.
- A new `layouts/partials/func/data.html` holds the `hugo.Data` version switch. `footer.html`, `post_meta.html`, `staticman-comments.html` and `seo/structured/organization.html` call it.
- The archive layout uses `func/date-format.html`, so a bad `Params.dateformat` fails the build there too. The format is computed one time.
- The header drops two dead branches: a `.Type "list"` test that can never match, and `with`/`else` fallbacks inside an `if $title` block.
- `static/js/search.js` loses the unused `feelingLucky` function and the empty `setButtonsLoading` function.
- `.IsNode` is deprecated in Hugo 0.163.0 and logs a notice on each page. The two uses now test the page kind. `.IsBranch` is the documented replacement but needs Hugo 0.163.0, and the theme supports 0.146.2, so the templates list the branch kinds instead. The 404 page is not a branch, which the kind list keeps correct.

The example site builds with `--panicOnWarning` and logs no deprecation notice. A file by file comparison of the built site before and after shows differences in whitespace only.

Refs #803
