### PR TITLE
fix(toc): list all posts in the section panel and match previews by URL

### DIFF
--- a/exampleSite/content/page/configuration.md
+++ b/exampleSite/content/page/configuration.md
@@ -177,7 +177,7 @@ When `toc = true` (the default), a list-style button appears in the navbar on pa
 
 **On single pages** (posts, regular pages), the panel shows the page's heading hierarchy extracted from the Table of Contents. An `IntersectionObserver` tracks which heading is currently in view and highlights the corresponding link in the panel.
 
-**On list and home pages**, the panel shows a list of post titles instead of headings. Scrolling through the post previews automatically highlights the currently visible post in the panel.
+**On list and home pages**, the panel shows the titles of all posts in the list, not only those on the current pager page. Scrolling through the post previews automatically highlights the currently visible post in the panel.
 
 The panel can be closed by clicking the close button, clicking the backdrop overlay, or pressing `Escape`.
 

--- a/layouts/partials/func/toc-state.html
+++ b/layouts/partials/func/toc-state.html
@@ -5,12 +5,9 @@
   - `isListPage`: the node is a section or the home page, so the panel
     shows a posts list rather than a table of contents.
   - `hasToc`: the rendered TableOfContents contains at least one item.
-  - `listPages`: on the home page, the mainSections-filtered non-hidden
-    regular pages; on a section, the paginator's pages. Empty otherwise.
+  - `listPages`: every non-hidden page the node lists (all pages, not only
+    the current pager's), from `func/list-pages`. Empty otherwise.
   - `hasListPages`: whether `listPages` is non-empty.
-
-  Note: this touches `.Paginator`, but only relocates logic the callers
-  already ran, so the cached paginator selection is unchanged.
 
   Takes: the page context (.).
   Returns: dict with "isListPage", "hasToc", "hasListPages", "listPages".
@@ -20,11 +17,7 @@
 {{- $hasListPages := false -}}
 {{- $listPages := slice -}}
 {{- if $isListPage -}}
-  {{- if .IsHome -}}
-    {{- $listPages = partial "func/list-pages.html" . -}}
-  {{- else -}}
-    {{- $listPages = .Paginator.Pages -}}
-  {{- end -}}
+  {{- $listPages = partial "func/list-pages.html" . -}}
   {{- $hasListPages = gt (len $listPages) 0 -}}
 {{- end -}}
 {{- return (dict "isListPage" $isListPage "hasToc" $hasToc "hasListPages" $hasListPages "listPages" $listPages) -}}

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -15,9 +15,7 @@
       {{- if $isListPage -}}
       <ul class="toc-post-list">
         {{- range $listPages -}}
-        {{- if ne .Params.hidden true -}}
         <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
-        {{- end -}}
         {{- end -}}
       </ul>
       {{- else -}}

--- a/static/js/toc.js
+++ b/static/js/toc.js
@@ -83,9 +83,17 @@
 
     var activePostLink = null;
 
-    function setActivePost(index) {
+    // The panel lists every post, but the page shows one pager of previews,
+    // so match previews to links by URL rather than by index.
+    var linkByHref = {};
+    postLinks.forEach(function (link) {
+      linkByHref[link.pathname] = link;
+    });
+
+    function setActivePost(preview) {
       if (activePostLink) activePostLink.classList.remove('toc-active');
-      var link = postLinks[index];
+      var anchor = preview.querySelector('a[href]');
+      var link = anchor ? linkByHref[anchor.pathname] : null;
       if (link) {
         link.classList.add('toc-active');
         activePostLink = link;
@@ -96,10 +104,7 @@
     var postObserver = new IntersectionObserver(
       function (entries) {
         entries.forEach(function (entry) {
-          if (entry.isIntersecting) {
-            var idx = Array.prototype.indexOf.call(postPreviews, entry.target);
-            if (idx >= 0) setActivePost(idx);
-          }
+          if (entry.isIntersecting) setActivePost(entry.target);
         });
       },
       {


### PR DESCRIPTION
This matches the current home page.

:robot: _AI text below_ :robot:

The posts panel listed every post on the home page but only the current pager's posts on a section page. Both now use the shared `func/list-pages` partial, so the panel shows the full list on every pager page. The active-post highlight matched previews to panel links by index, which was wrong when the panel held more entries than the page had previews. It now matches by link URL. The configuration docs describe the new behavior.

Refs #803
