### PR TITLE
fix(toc): keep the closed panel out of the tab order

### DIFF
--- a/exampleSite/content/page/configuration.md
+++ b/exampleSite/content/page/configuration.md
@@ -179,7 +179,7 @@ When `toc = true` (the default), a list-style button appears in the navbar on pa
 
 **On list and home pages**, the panel shows the titles of all posts in the list, not only those on the current pager page. Scrolling through the post previews automatically highlights the currently visible post in the panel.
 
-The panel can be closed by clicking the close button, clicking the backdrop overlay, or pressing `Escape`.
+The panel is a Bootstrap offcanvas. It can be closed by clicking the close button, clicking the backdrop overlay, or pressing `Escape`. Focus stays inside the panel while it is open and returns to the navbar button when it closes.
 
 ## Big Image Header
 

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -7,7 +7,7 @@
       {{ if ne ($.Param "toc") false }}
       {{ $tocState := partial "func/toc-state.html" . }}
       {{ if or $tocState.hasToc $tocState.hasListPages }}
-      <button class="theme-toggle" id="toc-toggle" aria-label="{{ i18n "tocLabel" | default "Table of Contents" }}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ i18n "tocLabel" | default "Table of Contents" }}">
+      <button class="theme-toggle" id="toc-toggle" aria-controls="toc-panel" aria-expanded="false" aria-label="{{ i18n "tocLabel" | default "Table of Contents" }}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ i18n "tocLabel" | default "Table of Contents" }}">
         <span class="fas fa-list"></span>
       </button>
       {{ end }}

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -5,25 +5,22 @@
 {{- $hasListPages := $tocState.hasListPages -}}
 {{- $listPages := $tocState.listPages -}}
 {{- if or $hasToc $hasListPages -}}
-<div class="toc-wrapper" id="toc-wrapper" data-toc-mode="{{ if $isListPage }}posts{{ else }}headings{{ end }}">
-  <div class="toc-panel" id="toc-panel" role="dialog" aria-modal="true" inert aria-label="{{ i18n "tocLabel" | default "Table of Contents" }}">
-    <div class="toc-header">
-      <span class="toc-title">{{ if $isListPage }}{{ i18n "tocPostsLabel" | default "Posts" }}{{ else }}{{ i18n "tocLabel" | default "Table of Contents" }}{{ end }}</span>
-      <button class="toc-close" id="toc-close" aria-label="{{ i18n "tocCloseLabel" | default "Close table of contents" }}">&times;</button>
-    </div>
-    <nav class="toc-body">
-      {{- if $isListPage -}}
-      <ul class="toc-post-list">
-        {{- range $listPages -}}
-        <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
-        {{- end -}}
-      </ul>
-      {{- else -}}
-      {{ .TableOfContents }}
-      {{- end -}}
-    </nav>
+<div class="offcanvas offcanvas-start toc-panel" id="toc-panel" tabindex="-1" aria-labelledby="toc-title" data-toc-mode="{{ if $isListPage }}posts{{ else }}headings{{ end }}">
+  <div class="offcanvas-header">
+    <span class="offcanvas-title toc-title" id="toc-title">{{ if $isListPage }}{{ i18n "tocPostsLabel" | default "Posts" }}{{ else }}{{ i18n "tocLabel" | default "Table of Contents" }}{{ end }}</span>
+    <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="{{ i18n "tocCloseLabel" | default "Close table of contents" }}"></button>
   </div>
-  <div class="toc-backdrop" id="toc-backdrop"></div>
+  <nav class="offcanvas-body toc-body">
+    {{- if $isListPage -}}
+    <ul class="toc-post-list">
+      {{- range $listPages -}}
+      <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+      {{- end -}}
+    </ul>
+    {{- else -}}
+    {{ .TableOfContents }}
+    {{- end -}}
+  </nav>
 </div>
 {{- end -}}
 {{- end -}}

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -6,7 +6,7 @@
 {{- $listPages := $tocState.listPages -}}
 {{- if or $hasToc $hasListPages -}}
 <div class="toc-wrapper" id="toc-wrapper" data-toc-mode="{{ if $isListPage }}posts{{ else }}headings{{ end }}">
-  <div class="toc-panel" id="toc-panel" role="dialog" aria-label="{{ i18n "tocLabel" | default "Table of Contents" }}">
+  <div class="toc-panel" id="toc-panel" role="dialog" aria-modal="true" inert aria-label="{{ i18n "tocLabel" | default "Table of Contents" }}">
     <div class="toc-header">
       <span class="toc-title">{{ if $isListPage }}{{ i18n "tocPostsLabel" | default "Posts" }}{{ else }}{{ i18n "tocLabel" | default "Table of Contents" }}{{ end }}</span>
       <button class="toc-close" id="toc-close" aria-label="{{ i18n "tocCloseLabel" | default "Close table of contents" }}">&times;</button>

--- a/static/css/print.css
+++ b/static/css/print.css
@@ -42,9 +42,8 @@
     display: none !important;
   }
 
-  .toc-wrapper,
   .toc-panel,
-  .toc-backdrop {
+  .offcanvas-backdrop {
     display: none !important;
   }
 

--- a/static/css/toc.css
+++ b/static/css/toc.css
@@ -1,44 +1,15 @@
-.toc-wrapper {
-  display: none;
-}
-
-body.toc-visible .toc-wrapper {
-  display: block;
-}
-
 .toc-panel {
-  position: fixed;
-  top: 0;
-  left: 0;
-  z-index: 1040;
-  width: 320px;
+  --bs-offcanvas-width: 320px;
+  --bs-offcanvas-bg: #fff;
+  --bs-offcanvas-border-color: #e0e0e0;
+  --bs-offcanvas-padding-x: 1.25rem;
+  --bs-offcanvas-padding-y: 1rem;
   max-width: 85vw;
-  height: 100vh;
-  background: #fff;
-  border-right: 1px solid #e0e0e0;
-  transform: translateX(-100%);
-  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
 }
 
-.toc-panel.toc-open {
-  transform: translateX(0);
-  box-shadow: 4px 0 20px rgba(0, 0, 0, 0.2);
-}
-
-[data-theme="dark"] .toc-panel.toc-open {
-  box-shadow: 4px 0 20px rgba(0, 0, 0, 0.5);
-}
-
-.toc-header {
-  display: flex;
-  align-items: center;
+.toc-panel .offcanvas-header {
   justify-content: space-between;
-  padding: 1rem 1.25rem;
-  border-bottom: 1px solid #e0e0e0;
-  flex-shrink: 0;
+  border-bottom: 1px solid var(--bs-offcanvas-border-color);
 }
 
 .toc-title {
@@ -48,31 +19,8 @@ body.toc-visible .toc-wrapper {
   color: #404040;
 }
 
-.toc-close {
-  background: none;
-  border: none;
-  font-size: 1.5rem;
-  color: #999;
-  cursor: pointer;
-  padding: 0 0.25rem;
-  line-height: 1;
-  transition: color 0.15s ease;
-}
-
-.toc-close:hover {
-  color: #404040;
-}
-
-.toc-close:focus-visible {
-  outline: 2px solid #0085a1;
-  outline-offset: 2px;
-}
-
 .toc-body {
-  flex: 1;
-  overflow-y: auto;
-  padding: 1rem 1.25rem 2rem;
-  -webkit-overflow-scrolling: touch;
+  padding-bottom: 2rem;
 }
 
 .toc-body #TableOfContents ul {
@@ -153,40 +101,17 @@ body.toc-visible .toc-wrapper {
   background: rgba(0, 133, 161, 0.08);
 }
 
-.toc-backdrop {
-  position: fixed;
-  inset: 0;
-  z-index: 1035;
-  background: rgba(0, 0, 0, 0.25);
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.3s ease;
-}
-
-.toc-backdrop.toc-open {
-  opacity: 1;
-  pointer-events: auto;
-}
-
 [data-theme="dark"] .toc-panel {
-  background: #222;
-  border-right-color: #444;
-}
-
-[data-theme="dark"] .toc-header {
-  border-bottom-color: #444;
+  --bs-offcanvas-bg: #222;
+  --bs-offcanvas-border-color: #444;
 }
 
 [data-theme="dark"] .toc-title {
   color: #eee;
 }
 
-[data-theme="dark"] .toc-close {
-  color: #888;
-}
-
-[data-theme="dark"] .toc-close:hover {
-  color: #eee;
+[data-theme="dark"] .toc-panel .btn-close {
+  filter: invert(1) grayscale(100%) brightness(200%);
 }
 
 [data-theme="dark"] .toc-body #TableOfContents a {

--- a/static/css/toc.css
+++ b/static/css/toc.css
@@ -17,10 +17,7 @@ body.toc-visible .toc-wrapper {
   background: #fff;
   border-right: 1px solid #e0e0e0;
   transform: translateX(-100%);
-  /* `visibility` keeps the closed panel out of the tab order where `inert`
-     is unsupported; it flips back only after the slide-out finishes. */
-  visibility: hidden;
-  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1), visibility 0s linear 0.3s;
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -28,8 +25,6 @@ body.toc-visible .toc-wrapper {
 
 .toc-panel.toc-open {
   transform: translateX(0);
-  visibility: visible;
-  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1), visibility 0s;
   box-shadow: 4px 0 20px rgba(0, 0, 0, 0.2);
 }
 

--- a/static/css/toc.css
+++ b/static/css/toc.css
@@ -17,7 +17,10 @@ body.toc-visible .toc-wrapper {
   background: #fff;
   border-right: 1px solid #e0e0e0;
   transform: translateX(-100%);
-  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  /* `visibility` keeps the closed panel out of the tab order where `inert`
+     is unsupported; it flips back only after the slide-out finishes. */
+  visibility: hidden;
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1), visibility 0s linear 0.3s;
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -25,6 +28,8 @@ body.toc-visible .toc-wrapper {
 
 .toc-panel.toc-open {
   transform: translateX(0);
+  visibility: visible;
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1), visibility 0s;
   box-shadow: 4px 0 20px rgba(0, 0, 0, 0.2);
 }
 

--- a/static/js/toc.js
+++ b/static/js/toc.js
@@ -37,41 +37,78 @@
   var backdrop = document.getElementById('toc-backdrop');
   var isOpen = false;
 
-  function openPanel() {
-    isOpen = true;
-    panel.classList.add('toc-open');
-    backdrop.classList.add('toc-open');
-    toggle.setAttribute('aria-expanded', 'true');
-    document.body.style.overflow = 'hidden';
+  function focusable() {
+    return Array.prototype.filter.call(
+      panel.querySelectorAll('a[href], button:not([disabled])'),
+      function (el) {
+        return el.offsetWidth > 0 || el.offsetHeight > 0;
+      }
+    );
   }
 
-  function closePanel() {
+  function openPanel() {
+    isOpen = true;
+    panel.removeAttribute('inert');
+    panel.classList.add('toc-open');
+    backdrop.classList.add('toc-open');
+    if (toggle) toggle.setAttribute('aria-expanded', 'true');
+    document.body.style.overflow = 'hidden';
+    if (close) close.focus();
+  }
+
+  function closePanel(returnFocus) {
     isOpen = false;
     panel.classList.remove('toc-open');
     backdrop.classList.remove('toc-open');
-    toggle.setAttribute('aria-expanded', 'false');
+    if (toggle) toggle.setAttribute('aria-expanded', 'false');
     document.body.style.overflow = '';
+    // `inert` drops the closed panel out of the tab order and the
+    // accessibility tree, so its links are not read twice on list pages.
+    if (returnFocus && toggle && panel.contains(document.activeElement)) {
+      toggle.focus();
+    }
+    panel.setAttribute('inert', '');
   }
 
   if (toggle) {
     toggle.addEventListener('click', function () {
-      if (isOpen) closePanel();
+      if (isOpen) closePanel(true);
       else openPanel();
     });
   }
 
-  close.addEventListener('click', closePanel);
-  backdrop.addEventListener('click', closePanel);
+  close.addEventListener('click', function () {
+    closePanel(true);
+  });
+  backdrop.addEventListener('click', function () {
+    closePanel(true);
+  });
 
   document.addEventListener('keydown', function (e) {
-    if (e.key === 'Escape' && isOpen) closePanel();
+    if (!isOpen) return;
+    if (e.key === 'Escape') {
+      closePanel(true);
+      return;
+    }
+    if (e.key !== 'Tab') return;
+    var items = focusable();
+    if (items.length === 0) return;
+    var first = items[0];
+    var last = items[items.length - 1];
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
   });
 
   if (mode === 'posts') {
     var postLinks = panel.querySelectorAll('.toc-post-list a');
     postLinks.forEach(function (link) {
       link.addEventListener('click', function () {
-        closePanel();
+        closePanel(false);
       });
     });
 
@@ -120,7 +157,7 @@
     var tocLinks = panel.querySelectorAll('#TableOfContents a');
     tocLinks.forEach(function (link) {
       link.addEventListener('click', function () {
-        closePanel();
+        closePanel(false);
       });
     });
 

--- a/static/js/toc.js
+++ b/static/js/toc.js
@@ -1,121 +1,65 @@
 (function () {
-  var wrapper = document.getElementById('toc-wrapper');
-  if (!wrapper) return;
+  var panel = document.getElementById('toc-panel');
+  if (!panel) return;
 
-  var mode = wrapper.getAttribute('data-toc-mode') || 'headings';
+  var mode = panel.getAttribute('data-toc-mode') || 'headings';
+
+  function removePanel() {
+    panel.remove();
+    var navToggle = document.getElementById('toc-toggle');
+    if (navToggle) navToggle.remove();
+  }
 
   if (mode === 'posts') {
-    var postList = wrapper.querySelector('.toc-post-list');
-    var hasPosts = postList && postList.querySelector('li');
-    if (!hasPosts) {
-      wrapper.remove();
-      var navToggle = document.getElementById('toc-toggle');
-      if (navToggle) navToggle.remove();
+    if (!panel.querySelector('.toc-post-list li')) {
+      removePanel();
       return;
     }
   } else {
-    var tocNav = wrapper.querySelector('#TableOfContents');
-    var hasItems = tocNav && tocNav.querySelector('li');
-    if (!hasItems) {
-      wrapper.remove();
-      var navToggle = document.getElementById('toc-toggle');
-      if (navToggle) navToggle.remove();
-      return;
-    }
-    var allLinks = tocNav.querySelectorAll('a');
-    if (allLinks.length <= 1) {
-      wrapper.remove();
-      var navToggle2 = document.getElementById('toc-toggle');
-      if (navToggle2) navToggle2.remove();
+    if (panel.querySelectorAll('#TableOfContents a').length <= 1) {
+      removePanel();
       return;
     }
   }
 
   var toggle = document.getElementById('toc-toggle');
-  var panel = document.getElementById('toc-panel');
-  var close = document.getElementById('toc-close');
-  var backdrop = document.getElementById('toc-backdrop');
-  var isOpen = false;
-
-  function openPanel() {
-    isOpen = true;
-    panel.removeAttribute('inert');
-    panel.classList.add('toc-open');
-    backdrop.classList.add('toc-open');
-    if (toggle) toggle.setAttribute('aria-expanded', 'true');
-    document.body.style.overflow = 'hidden';
-    if (close) close.focus();
-  }
-
-  function closePanel(returnFocus) {
-    isOpen = false;
-    panel.classList.remove('toc-open');
-    backdrop.classList.remove('toc-open');
-    if (toggle) toggle.setAttribute('aria-expanded', 'false');
-    document.body.style.overflow = '';
-    // `inert` drops the closed panel out of the tab order and the
-    // accessibility tree, so its links are not read twice on list pages.
-    if (returnFocus && toggle && panel.contains(document.activeElement)) {
-      toggle.focus();
-      // Focus would otherwise show the toggle's tooltip until the next blur.
-      if (window.bootstrap && bootstrap.Tooltip) {
-        var tip = bootstrap.Tooltip.getInstance(toggle);
-        if (tip) tip.hide();
-      }
-    }
-    panel.setAttribute('inert', '');
-  }
+  var offcanvas = bootstrap.Offcanvas.getOrCreateInstance(panel);
+  var returnFocus = true;
 
   if (toggle) {
     toggle.addEventListener('click', function () {
-      if (isOpen) closePanel(true);
-      else openPanel();
+      offcanvas.toggle();
     });
   }
 
-  close.addEventListener('click', function () {
-    closePanel(true);
+  panel.addEventListener('show.bs.offcanvas', function () {
+    if (toggle) toggle.setAttribute('aria-expanded', 'true');
   });
-  backdrop.addEventListener('click', function () {
-    closePanel(true);
+  panel.addEventListener('hide.bs.offcanvas', function () {
+    if (toggle) toggle.setAttribute('aria-expanded', 'false');
+    returnFocus = panel.contains(document.activeElement);
+  });
+  panel.addEventListener('hidden.bs.offcanvas', function () {
+    if (!returnFocus || !toggle) return;
+    toggle.focus();
+    // Focus would otherwise show the toggle's tooltip until the next blur.
+    var tip = bootstrap.Tooltip.getInstance(toggle);
+    if (tip) tip.hide();
   });
 
-  document.addEventListener('keydown', function (e) {
-    if (!isOpen) return;
-    if (e.key === 'Escape') {
-      closePanel(true);
-      return;
-    }
-    if (e.key !== 'Tab') return;
-    var items = panel.querySelectorAll('a[href], button:not([disabled])');
-    if (items.length === 0) return;
-    var first = items[0];
-    var last = items[items.length - 1];
-    var active = document.activeElement;
-    // A click on empty panel space leaves focus outside `items`.
-    var outside = !panel.contains(active);
-    if (e.shiftKey && (active === first || outside)) {
-      e.preventDefault();
-      last.focus();
-    } else if (!e.shiftKey && (active === last || outside)) {
-      e.preventDefault();
-      first.focus();
+  // Following a link should leave focus on the destination, not the toggle.
+  panel.addEventListener('click', function (e) {
+    if (e.target.closest('a[href]')) {
+      offcanvas.hide();
+      returnFocus = false;
     }
   });
 
   if (mode === 'posts') {
     var postLinks = panel.querySelectorAll('.toc-post-list a');
-    postLinks.forEach(function (link) {
-      link.addEventListener('click', function () {
-        closePanel(false);
-      });
-    });
 
     var postPreviews = document.querySelectorAll('.post-preview');
-    if (postPreviews.length === 0) {
-      document.body.classList.add('toc-visible');
-      return;
-    }
+    if (postPreviews.length === 0) return;
 
     var activePostLink = null;
 
@@ -153,22 +97,12 @@
       postObserver.observe(el);
     });
   } else {
-    var tocLinks = panel.querySelectorAll('#TableOfContents a');
-    tocLinks.forEach(function (link) {
-      link.addEventListener('click', function () {
-        closePanel(false);
-      });
-    });
-
     var headings = [];
     document.querySelectorAll('.blog-post h2, .blog-post h3, .blog-post h4, .blog-post h5, .blog-post h6').forEach(function (h) {
       if (h.id) headings.push(h);
     });
 
-    if (headings.length === 0) {
-      document.body.classList.add('toc-visible');
-      return;
-    }
+    if (headings.length === 0) return;
 
     var activeLink = null;
 
@@ -200,6 +134,4 @@
       observer.observe(h);
     });
   }
-
-  document.body.classList.add('toc-visible');
 })();

--- a/static/js/toc.js
+++ b/static/js/toc.js
@@ -41,10 +41,13 @@
   });
   panel.addEventListener('hidden.bs.offcanvas', function () {
     if (!returnFocus || !toggle) return;
-    toggle.focus();
     // Focus would otherwise show the toggle's tooltip until the next blur.
+    // Tooltip.show() is queued, so hide() after focus() is too early; disable
+    // the tooltip across the focus call instead.
     var tip = bootstrap.Tooltip.getInstance(toggle);
-    if (tip) tip.hide();
+    if (tip) tip.disable();
+    toggle.focus();
+    if (tip) setTimeout(function () { tip.enable(); }, 0);
   });
 
   // Following a link should leave focus on the destination, not the toggle.

--- a/static/js/toc.js
+++ b/static/js/toc.js
@@ -37,15 +37,6 @@
   var backdrop = document.getElementById('toc-backdrop');
   var isOpen = false;
 
-  function focusable() {
-    return Array.prototype.filter.call(
-      panel.querySelectorAll('a[href], button:not([disabled])'),
-      function (el) {
-        return el.offsetWidth > 0 || el.offsetHeight > 0;
-      }
-    );
-  }
-
   function openPanel() {
     isOpen = true;
     panel.removeAttribute('inert');
@@ -66,6 +57,11 @@
     // accessibility tree, so its links are not read twice on list pages.
     if (returnFocus && toggle && panel.contains(document.activeElement)) {
       toggle.focus();
+      // Focus would otherwise show the toggle's tooltip until the next blur.
+      if (window.bootstrap && bootstrap.Tooltip) {
+        var tip = bootstrap.Tooltip.getInstance(toggle);
+        if (tip) tip.hide();
+      }
     }
     panel.setAttribute('inert', '');
   }
@@ -91,14 +87,17 @@
       return;
     }
     if (e.key !== 'Tab') return;
-    var items = focusable();
+    var items = panel.querySelectorAll('a[href], button:not([disabled])');
     if (items.length === 0) return;
     var first = items[0];
     var last = items[items.length - 1];
-    if (e.shiftKey && document.activeElement === first) {
+    var active = document.activeElement;
+    // A click on empty panel space leaves focus outside `items`.
+    var outside = !panel.contains(active);
+    if (e.shiftKey && (active === first || outside)) {
       e.preventDefault();
       last.focus();
-    } else if (!e.shiftKey && document.activeElement === last) {
+    } else if (!e.shiftKey && (active === last || outside)) {
       e.preventDefault();
       first.focus();
     }


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Closes #812.

The TOC panel was only moved off-screen when closed, so its links stayed focusable and in the accessibility tree. On the home page and section pages this made Tab go through the post previews and then the same posts again in the panel.

The panel is now a Bootstrap Offcanvas, which was already loaded on every page. Bootstrap handles the slide-in, backdrop, scroll lock, focus trap, Escape, and hides the closed panel. This removes the hand-written versions of all of these from `toc.js` and `toc.css`.

- The toggle button keeps its tooltip and opens the panel from JS. It carries `aria-controls` and `aria-expanded`.
- Focus stays inside the panel while it is open and returns to the toggle on close (Escape, backdrop, close button, or toggle). The tooltip is hidden after focus returns. Link clicks navigate away, so they do not move focus.
- The close button is a Bootstrap `btn-close`, inverted in dark mode.
- Docs updated in `configuration.md`.

Verified in headless Chrome on the home page and the configuration page: open and close state, backdrop, scroll lock, Shift+Tab wrapping, focus return without a tooltip, link clicks, dark theme, and no console errors.
