### PR TITLE
chore: ignore the example site resources cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ Temporary Items
 exampleSite/public/
 /public/
 
+# Hugo Pipes cache for the example site
+exampleSite/resources/
+
 # Claude requires a symlink to AGENTS.md, all other harnesses support the std
 CLAUDE.md
 .claude/


### PR DESCRIPTION
Might not be strictly needed yet, but let's prepare in case.

:robot: _AI text below_ :robot:

Hugo writes `exampleSite/resources/_gen` when it builds the example site. Add it to `.gitignore` so it stays out of commits and release archives.