### PR TITLE
feat: add a theme-level hugo.toml

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ hugo serve -s exampleSite --disableFastRender
 - Hugo only writes a **warning** if `[module.hugoVersion]` is not satisfied, for modules and for classic `themes/` use. `layouts/_default/baseof.html` keeps an `errorf` to stop the build.
 - **CI matrix** tests against `0.146.2`, `0.155.2`, and `0.163.0`. `--panicOnWarning` makes the module warning a CI failure.
 - The deploy workflow pins `0.163.0`.
-- CI uses the **extended** Hugo binary; the theme declares `extended = true` because it encodes WebP images.
+- The theme declares `extended = false`: it has no SCSS and no WebP encoding, so the **standard** Hugo edition is sufficient. CI still uses the extended binary.
 
 ## Theme Configuration (`hugo.toml`)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,10 +18,15 @@ hugo serve -s exampleSite --disableFastRender
 
 ## Hugo Version
 
-- **Minimum Hugo version**: `0.146.2` (enforced at runtime in `layouts/_default/baseof.html`).
-- **CI matrix** tests against `0.146.2`, `0.155.2`, and `0.163.0`.
+- **Minimum Hugo version**: `0.146.2`, declared in `hugo.toml` (`[module.hugoVersion]`) and in `theme.toml` (`min_version`, for the themes gallery).
+- Hugo only writes a **warning** if `[module.hugoVersion]` is not satisfied, for modules and for classic `themes/` use. `layouts/_default/baseof.html` keeps an `errorf` to stop the build.
+- **CI matrix** tests against `0.146.2`, `0.155.2`, and `0.163.0`. `--panicOnWarning` makes the module warning a CI failure.
 - The deploy workflow pins `0.163.0`.
-- CI uses the **extended** Hugo binary.
+- CI uses the **extended** Hugo binary; the theme declares `extended = true` because it encodes WebP images.
+
+## Theme Configuration (`hugo.toml`)
+
+Hugo merges only some sections of a theme configuration into the site configuration. `params` merge deeply and site values win. Sections such as `[markup]` are **not** merged, so Chroma and goldmark settings must stay in the site configuration (`exampleSite/hugo.toml`).
 
 ## Architecture
 

--- a/exampleSite/content/page/configuration.md
+++ b/exampleSite/content/page/configuration.md
@@ -14,10 +14,10 @@ The theme ships its own `hugo.toml` with a version constraint:
 [module]
   [module.hugoVersion]
     min = "0.146.2"
-    extended = true
+    extended = false
 ```
 
-Use the **extended** Hugo edition, version 0.146.2 or later. The extended edition is necessary because the theme encodes images to WebP. If your Hugo edition or version is not sufficient, Hugo writes a warning and the theme stops the build with an error message.
+Use Hugo 0.146.2 or later. The **standard** edition is sufficient; the theme has no SCSS and does not encode WebP images. If your Hugo version is too old, Hugo writes a warning and the theme stops the build with an error message.
 
 The same file supplies the theme defaults `colorScheme = "auto"` and `mathEngine = "katex"`. Your site configuration overrides them.
 
@@ -30,7 +30,7 @@ Hugo does not merge all sections of a theme configuration into your site configu
 | `homeTitle` | string | site title | Brand name shown in the navbar, home page header, and footer link. Falls back to the site title when unset |
 | `subtitle` | string | `""` | Site subtitle shown under the home page title |
 | `mainSections` | list | `["post", "posts"]` | Content sections treated as "posts" on the home page and archive page |
-| `logo` | string | — | Path to a square avatar/logo image. When the file is found via Hugo's asset pipeline (`resources.Get`), it is automatically processed into WebP format (300×300, quality 100) for optimal loading. If the file is not found as a resource, the raw path is used as-is. |
+| `logo` | string | — | Path to a square avatar/logo image. When the file is found via Hugo's asset pipeline (`resources.Get`), it is automatically resized (300×300, quality 100) and keeps its source format. If the file is not found as a resource, the raw path is used as-is. |
 | `favicon` | string | — | Path to favicon |
 | `dateFormat` | string | i18n default | Date format string. Accepts Hugo locale tokens (e.g. `":date_long"`, `":date_medium"`, `":date_short"`) for automatic localization, or a Go time layout string based on the reference time `Mon Jan 2 15:04:05 MST 2006` (e.g. `"January 2, 2006"` or `"2006-01-02"`). **Do not use an example date** like `"2023-10-15"` — the year must be `2006`, month `01`, and day `02`. Locale tokens are recommended for multilingual sites. The theme validates `dateFormat` at build time and will emit a build error if it detects an invalid format (e.g. a date that doesn't use Go's reference time). |
 | `since` | int | — | Start year for copyright range (e.g. `2015 - 2026`) |

--- a/exampleSite/content/page/configuration.md
+++ b/exampleSite/content/page/configuration.md
@@ -6,6 +6,23 @@ comments: false
 
 This page is a complete reference for every configuration option in Beautiful Hugo. All settings go in your site's `hugo.toml` (or `config.toml`/`config.yaml`).
 
+## Requirements
+
+The theme ships its own `hugo.toml` with a version constraint:
+
+```toml
+[module]
+  [module.hugoVersion]
+    min = "0.146.2"
+    extended = true
+```
+
+Use the **extended** Hugo edition, version 0.146.2 or later. The extended edition is necessary because the theme encodes images to WebP. If your Hugo edition or version is not sufficient, Hugo writes a warning and the theme stops the build with an error message.
+
+The same file supplies the theme defaults `colorScheme = "auto"` and `mathEngine = "katex"`. Your site configuration overrides them.
+
+Hugo does not merge all sections of a theme configuration into your site configuration. Markup settings (`[markup.highlight]`, `[markup.goldmark]`) must be in your own site configuration — see [Syntax Highlighting](#syntax-highlighting) and [Markdown Extensions](../markdown-extensions/).
+
 ## Core Settings
 
 | Param | Type | Default | Description |

--- a/hugo.toml
+++ b/hugo.toml
@@ -6,7 +6,7 @@
 [module]
   [module.hugoVersion]
     min = "0.146.2"
-    extended = true # WebP encoding in the image partials
+    extended = false # No SCSS or WebP encoding; the standard edition is sufficient
 
 [params]
   colorScheme = "auto"

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,0 +1,13 @@
+# Theme configuration. Hugo merges only some sections of a theme configuration
+# into the site configuration (params deeply, with site values winning).
+# Sections such as [markup] are not merged, so they stay in the site
+# configuration. See exampleSite/hugo.toml.
+
+[module]
+  [module.hugoVersion]
+    min = "0.146.2"
+    extended = true # WebP encoding in the image partials
+
+[params]
+  colorScheme = "auto"
+  mathEngine = "katex"

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,3 +1,4 @@
+{{/* hugo.toml [module.hugoVersion] only warns; this stops the build. */}}
 {{ if lt hugo.Version "0.146.2" }}
 	{{ errorf "Please use Hugo version 0.146.2 or higher!" }}
 {{ end }}

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -100,7 +100,7 @@
             <a title="{{ $page.Site.Title }}" href="{{ "" | relLangURL }}">
             {{- $image := resources.Get . -}}
             {{ if $image }}
-              <img class="avatar-img" src="{{ ($image.Fit "300x300 webp q100").RelPermalink }}" alt="{{ $page.Site.Title }}" />
+              <img class="avatar-img" src="{{ ($image.Fit "300x300 q100").RelPermalink }}" alt="{{ $page.Site.Title }}" />
             {{else}}
               <img class="avatar-img" src="{{ strings.TrimPrefix "/" . | relURL }}" alt="{{ $page.Site.Title }}" />
              {{end}}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #798.

Adds `hugo.toml` at the theme root:

```toml
[module]
  [module.hugoVersion]
    min = "0.146.2"
    extended = false # No SCSS or WebP encoding; the standard edition is sufficient

[params]
  colorScheme = "auto"
  mathEngine = "katex"
```

**The theme no longer needs the extended edition.** The only extended-only feature was the avatar in `nav.html`, which encoded WebP (`.Fit "300x300 webp q100"`). With the standard edition at the minimum supported version the build failed:

```
error calling Fit: this feature is not available in your current Hugo version
```

The avatar now keeps its source format (`.Fit "300x300 q100"`), and the example site builds with the standard edition of both Hugo 0.146.2 and 0.163.0. CI stays on the extended binary.

**The runtime check in `baseof.html` stays.** Hugo only writes a warning when `[module.hugoVersion]` is not satisfied, both for module use and for classic `themes/` use:

```
WARN  Module "github.com/halogenica/beautifulhugo/v5" is not compatible with this Hugo version: Min 99.0.0; ...
```

The build then completes. Only CI fails, because of `--panicOnWarning`. The `errorf` in `baseof.html` is what actually stops a user build, so it is kept with a short comment.

**No `[markup]` in the theme configuration.** Hugo does not merge that section from a theme. A test that moved `[markup.highlight] noClasses = false` and the goldmark settings into the theme configuration broke Chroma classes and block attributes in the rendered output. Those settings stay in the site configuration and are still documented.

`theme.toml` is unchanged. Docs updated in `exampleSite/content/page/configuration.md` (new Requirements section) and `AGENTS.md`.